### PR TITLE
fix: tolerate runtime env entries

### DIFF
--- a/src/pullbox/config.py
+++ b/src/pullbox/config.py
@@ -32,6 +32,7 @@ class PullboxSettings(BaseSettings):
         env_prefix="PULLBOX_",
         env_file=".env",
         env_file_encoding="utf-8",
+        extra="ignore",
         frozen=True,
     )
 

--- a/tests/unit/test_runtime_settings_env.py
+++ b/tests/unit/test_runtime_settings_env.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pullbox.config import PullboxSettings
+
+
+def test_settings_ignore_unprefixed_dotenv_entries(tmp_path, monkeypatch) -> None:
+    """Deployment/runtime .env files may include non-Pullbox keys like TZ."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("PULLBOX_PORT", raising=False)
+    monkeypatch.delenv("PULLBOX_SECRET_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "TZ=America/Los_Angeles\nPULLBOX_PORT=9999\nPULLBOX_SECRET_KEY=from-dotenv\n",
+        encoding="utf-8",
+    )
+
+    settings = PullboxSettings()
+
+    assert settings.port == 9999
+    assert settings.secret_key == "from-dotenv"


### PR DESCRIPTION
## Summary
- Allow Pullbox runtime settings to ignore non-PULLBOX keys in `.env` files
- Add regression coverage for `.env` files that include runtime-only keys like `TZ` alongside Pullbox settings

## Validation
- `.venv/bin/pytest tests/unit/test_runtime_settings_env.py tests/unit/test_https_runtime_settings.py tests/unit/test_docker_healthcheck_https.py -q`
- App boot check from `make ci-full`
- `make ci-full` locally, including Chromium/Firefox E2E and Docker smoke

## Notes
- GitHub Docker workflow is currently blocked by DHI authentication: DHI rejects the configured Actions credentials at `docker/login-action` for `dhi.io`. Local Docker smoke authenticates and passes with local credentials, so this appears to be a repository secret/account access issue rather than a Dockerfile/build issue.