### PR TITLE
fix: resolve bandit security findings

### DIFF
--- a/src/pullbox/core/https_runtime.py
+++ b/src/pullbox/core/https_runtime.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 HTTPS_CONFIG_KEYS = ("https_enabled", "https_cert_path", "https_key_path")
+_HTTPS_CONFIG_QUERY = "SELECT key, value FROM system_config WHERE key IN (?, ?, ?)"
 HTTPS_ENV_KEYS = {
     "https_enabled": "PULLBOX_HTTPS_ENABLED",
     "https_cert_path": "PULLBOX_HTTPS_CERT_PATH",
@@ -89,16 +90,14 @@ def load_https_db_values(settings: PullboxSettings | object | None = None) -> di
     if db_path is None or not db_path.exists():
         return {}
 
-    placeholders = ",".join("?" for _ in HTTPS_CONFIG_KEYS)
     try:
-        query = "SELECT key, value FROM system_config WHERE key IN (" + placeholders + ")"
         with sqlite3.connect(
             f"file:{db_path.as_posix()}?mode=ro",
             uri=True,
             timeout=1.0,
         ) as conn:
             rows = conn.execute(
-                query,
+                _HTTPS_CONFIG_QUERY,
                 HTTPS_CONFIG_KEYS,
             ).fetchall()
     except sqlite3.Error:

--- a/src/pullbox/docker_healthcheck.py
+++ b/src/pullbox/docker_healthcheck.py
@@ -28,7 +28,8 @@ def main() -> None:
             "127.0.0.1",
             _healthcheck_port(),
             timeout=5,
-            context=ssl._create_unverified_context(),
+            # Local healthcheck may use self-signed HTTPS on loopback.
+            context=ssl._create_unverified_context(),  # nosec B323
         )
     else:
         connection = HTTPConnection("127.0.0.1", _healthcheck_port(), timeout=5)

--- a/src/pullbox/performance/baseline.py
+++ b/src/pullbox/performance/baseline.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections import Counter
 from dataclasses import dataclass
@@ -187,6 +188,15 @@ def resolve_endpoint_url(base_url: str, target: str) -> str:
     return f"{base_url.rstrip('/')}/{target.lstrip('/')}"
 
 
+def _validate_http_url(url: str) -> None:
+    """Allow the baseline harness to fetch only HTTP(S) URLs."""
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        msg = f"baseline fetch URLs must use http or https: {url!r}"
+        raise ValueError(msg)
+
+
 def _fetch_url(
     url: str,
     timeout: float,
@@ -196,13 +206,15 @@ def _fetch_url(
 ) -> FetchResult:
     """Fetch one URL using the standard library so the harness stays lightweight."""
 
+    _validate_http_url(url)
     request_headers = {"User-Agent": f"PullboxPerformanceBaseline/{MEASUREMENT_VERSION}"}
     if headers:
         request_headers.update(headers)
     request = urllib.request.Request(url, headers=request_headers)
     started_at = time.perf_counter()
     try:
-        with urllib.request.urlopen(request, timeout=timeout, context=ssl_context) as response:
+        # `_validate_http_url` rejects file/custom schemes before this call.
+        with urllib.request.urlopen(request, timeout=timeout, context=ssl_context) as response:  # nosec B310
             body = response.read()
             status_code = response.status
     except urllib.error.HTTPError as exc:
@@ -229,7 +241,8 @@ def create_fetcher(
 ) -> Fetcher:
     """Create a fetcher, optionally allowing local self-signed HTTPS certificates."""
 
-    ssl_context = None if verify_tls else ssl._create_unverified_context()
+    # `verify_tls=False` is an explicit local benchmark option for self-signed HTTPS.
+    ssl_context = None if verify_tls else ssl._create_unverified_context()  # nosec B323
 
     def fetcher(url: str, timeout: float) -> FetchResult:
         return _fetch_url(url, timeout, ssl_context=ssl_context, headers=headers)
@@ -244,6 +257,7 @@ def _fetch_with_opener(
     *,
     headers: dict[str, str] | None = None,
 ) -> FetchResult:
+    _validate_http_url(url)
     request_headers = {"User-Agent": f"PullboxPerformanceBaseline/{MEASUREMENT_VERSION}"}
     if headers:
         request_headers.update(headers)
@@ -276,7 +290,8 @@ def login_and_create_fetcher(
 ) -> Fetcher:
     """Create a session-cookie fetcher by logging into the local Pullbox app."""
 
-    ssl_context = None if verify_tls else ssl._create_unverified_context()
+    # `verify_tls=False` is an explicit local benchmark option for self-signed HTTPS.
+    ssl_context = None if verify_tls else ssl._create_unverified_context()  # nosec B323
     cookie_jar = http.cookiejar.CookieJar()
     handlers: list[urllib.request.BaseHandler] = [urllib.request.HTTPCookieProcessor(cookie_jar)]
     if ssl_context is not None:
@@ -284,6 +299,7 @@ def login_and_create_fetcher(
     opener = urllib.request.build_opener(*handlers)
 
     login_target = resolve_endpoint_url(base_url, login_url)
+    _validate_http_url(login_target)
     payload = json.dumps(
         {"username": username, "password": password},
         separators=(",", ":"),

--- a/tests/e2e/test_library_page.py
+++ b/tests/e2e/test_library_page.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from playwright.sync_api import expect
 
 from tests.e2e.pages.library import LibraryPage
 
@@ -548,12 +549,11 @@ class TestLibraryPage:
         assert library.auto_rename_modal.get_by_test_id(
             "library-auto-rename-preview-grid"
         ).is_visible()
-        assert (
+        expect(
             library.auto_rename_modal.locator(
                 "[data-testid='library-auto-rename-preview-grid'] tbody tr"
-            ).count()
-            == 4
-        )
+            )
+        ).to_have_count(4)
         assert library.auto_rename_modal.get_by_text("Queue Rename", exact=True).count() == 0
 
         with authed_page.expect_response(
@@ -628,12 +628,11 @@ class TestLibraryPage:
             .strip()
             == "Preview"
         )
-        assert (
+        expect(
             library.auto_rename_modal.locator(
                 "[data-testid='library-auto-rename-preview-grid'] tbody tr"
-            ).count()
-            == 4
-        )
+            )
+        ).to_have_count(4)
 
     def test_library_delete_action_opens_series_delete_modal_for_tracked_series_folder(
         self,
@@ -841,12 +840,11 @@ class TestLibraryPage:
             assert library.convert_modal.get_by_test_id(
                 "library-convert-preview-header"
             ).is_visible()
-            assert (
+            expect(
                 library.convert_modal.locator(
                     "[data-testid='library-convert-preview-grid'] tbody tr"
-                ).count()
-                == 3
-            )
+                )
+            ).to_have_count(3)
         finally:
             sample_file.unlink(missing_ok=True)
 

--- a/tests/unit/test_https_runtime_settings.py
+++ b/tests/unit/test_https_runtime_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -106,6 +107,30 @@ class TestHttpsRuntimeResolver:
         assert resolved.enabled is True
         assert resolved.cert_path == "/config/certs/env.crt"
         assert resolved.key_path == "/config/certs/env.key"
+
+    def test_load_https_db_values_reads_only_known_https_keys(self, tmp_path: Path) -> None:
+        from pullbox.core.https_runtime import load_https_db_values
+
+        db_path = tmp_path / "pullbox.db"
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("CREATE TABLE system_config (key TEXT PRIMARY KEY, value TEXT)")
+            conn.executemany(
+                "INSERT INTO system_config (key, value) VALUES (?, ?)",
+                [
+                    ("https_enabled", "true"),
+                    ("https_cert_path", "/config/certs/server.crt"),
+                    ("https_key_path", "/config/certs/server.key"),
+                    ("unrelated", "ignored"),
+                ],
+            )
+
+        settings = SimpleNamespace(db_url=f"sqlite+aiosqlite:///{db_path}")
+
+        assert load_https_db_values(settings) == {
+            "https_enabled": "true",
+            "https_cert_path": "/config/certs/server.crt",
+            "https_key_path": "/config/certs/server.key",
+        }
 
 
 class TestHttpsValidation:

--- a/tests/unit/test_performance_baseline.py
+++ b/tests/unit/test_performance_baseline.py
@@ -198,6 +198,17 @@ def test_create_fetcher_applies_default_headers(monkeypatch) -> None:
     assert captured_headers[0]["Hx-request"] == "true"
 
 
+def test_create_fetcher_rejects_non_http_urls() -> None:
+    fetcher = create_fetcher()
+
+    try:
+        fetcher("file:///etc/passwd", 1.0)
+    except ValueError as exc:
+        assert "http or https" in str(exc)
+    else:  # pragma: no cover - assertion clarity
+        raise AssertionError("expected fetcher to reject non-http URL")
+
+
 def test_login_and_create_fetcher_posts_login_and_reuses_cookie_opener(monkeypatch) -> None:
     opened_requests: list[tuple[str, bytes | None]] = []
 


### PR DESCRIPTION
## Summary
- Replace dynamic HTTPS config SQL construction with a fixed parameterized query for the known config keys
- Restrict the performance baseline fetcher to HTTP(S) URLs before calling `urlopen`
- Add narrow Bandit suppressions only for intentional local/self-signed HTTPS behavior
- Add regression coverage for HTTPS DB config loading and non-HTTP URL rejection

## Validation
- `.venv/bin/pytest tests/unit/test_https_runtime_settings.py tests/unit/test_performance_baseline.py tests/unit/test_docker_healthcheck_https.py -q`
- `.venv/bin/ruff check` on touched files
- `.venv/bin/ruff format --check` on touched files
- `.venv/bin/bandit -r src/pullbox/ -ll -f json -o /tmp/pullbox-bandit-after.json` -> 0 findings
- `make security-check`

## Notes
- Bandit is no longer reporting findings locally. The remaining nosec comments are intentionally narrow and documented at the call sites.