### PR TITLE
chore: prepare 0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Use this section for curated, human-readable release notes. During release prep,
-move completed entries into a versioned section like `## [1.0.0] - 2026-06-09`
-and create a fresh empty `## [Unreleased]` section above it.
-
 ### Added
 
 ### Changed
@@ -26,3 +22,23 @@ and create a fresh empty `## [Unreleased]` section above it.
 ### CI / Build
 
 ### Internal
+
+## [0.9.1] - 2026-06-10
+
+First clean public release from the relaunched `pullboxapp/pullbox` repository.
+
+### Added
+
+- Public-ready repository configuration, rulesets, security checks, and release automation.
+- CodeQL, secret scanning, push protection, Dependabot security posture, and aggregate required checks for the public repo.
+
+### Fixed
+
+- Runtime environment validation now tolerates expected deployment-provided values.
+- Bandit findings were resolved or narrowed with explicit, documented exceptions.
+- Library preview E2E assertions now wait for rendered modal rows before checking counts.
+
+### CI / Build
+
+- Trusted PR Docker validation now runs successfully against the clean public repository.
+- Trusted CI routing is restored to the local self-hosted runners for same-repository PRs.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.0-dev"
+__version__ = "0.9.1"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- set Pullbox runtime version to 0.9.1
- add the first clean public 0.9.1 changelog section

## Verification
- .venv/bin/python import/version check
- .venv/bin/pytest tests/unit/test_whats_new_data_client.py tests/unit/test_usage_stats_telemetry.py tests/unit/test_update_check.py -q
- .venv/bin/ruff check src/pullbox/__init__.py
- .venv/bin/ruff format --check src/pullbox/__init__.py
- pre-commit hooks via repo .venv PATH with TZ unset