### PR TITLE
chore: sync main into develop

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,7 +10,7 @@
 #   safety    → Safety DB (secondary, different vulnerability coverage)
 #   gitleaks  → blocking secret scan
 #   bandit    → advisory static analysis during initial rollout
-#   CodeQL    → public-repo static analysis, gated while private
+#   CodeQL    → public-repo static analysis, informational until promoted
 
 name: Security
 
@@ -279,7 +279,7 @@ jobs:
       - name: Verify required security jobs
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
-          CODEQL_REQUIRED: ${{ github.repository_visibility == 'public' || vars.PULLBOX_ENABLE_CODEQL == 'true' }}
+          CODEQL_BLOCKING: ${{ vars.PULLBOX_REQUIRE_CODEQL == 'true' }}
         run: |
           python - <<'PY'
           import json
@@ -287,11 +287,13 @@ jobs:
           import sys
 
           needs = json.loads(os.environ["NEEDS_CONTEXT"])
-          codeql_required = os.environ["CODEQL_REQUIRED"].lower() == "true"
+          codeql_blocking = os.environ["CODEQL_BLOCKING"].lower() == "true"
           failed = {}
           for name, info in needs.items():
               result = info.get("result")
-              if name == "codeql" and not codeql_required and result == "skipped":
+              if name == "codeql" and not codeql_blocking:
+                  if result != "success":
+                      print(f"CodeQL is informational for now; observed result: {result}")
                   continue
               if result != "success":
                   failed[name] = result

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,10 +14,14 @@ Contributor-facing implementation standards live in
 Please report security vulnerabilities privately.
 
 1. Do not open a public GitHub issue for a security vulnerability.
-2. Email `security@pullbox.app` with a short description, reproduction steps,
-   affected version or commit when known, and any relevant logs or screenshots.
-3. Reports are acknowledged within 48 hours.
-4. The issue will be reviewed, fixed, and disclosed publicly only after a safe
+2. Use GitHub private vulnerability reporting from the repository Security tab
+   when possible. This keeps triage in GitHub's advisory workflow.
+3. If you cannot use GitHub private reporting, or if you need to coordinate
+   outside GitHub, email `security@pullbox.app` with a short description,
+   reproduction steps, affected version or commit when known, and any relevant
+   logs or screenshots.
+4. Reports are acknowledged within 48 hours.
+5. The issue will be reviewed, fixed, and disclosed publicly only after a safe
    remediation path is available.
 
 Helpful reports usually include:

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -30,7 +30,8 @@ requirements.
 - Release tags trigger Docker publication and GitHub Release generation.
 - Security workflows include gitleaks, `pip-audit`, Safety, Bandit, workflow
   hygiene checks, and Grype container scanning.
-- CodeQL is configured for public repositories and remains gated while private.
+- CodeQL is configured for public repositories and can be opt-in while private;
+  it is informational in the required aggregate gate until explicitly promoted.
 
 ## Table of Contents
 
@@ -237,7 +238,8 @@ GitHub Actions workflows live in `.github/workflows/`.
 - Safety runs as an advisory scanner with artifact output.
 - Bandit runs Python static security checks.
 - CodeQL runs on public repositories, or while private when
-  `PULLBOX_ENABLE_CODEQL=true`.
+  `PULLBOX_ENABLE_CODEQL=true`; `Security Required` treats CodeQL as
+  informational unless `PULLBOX_REQUIRE_CODEQL=true`.
 - Grype scans container images.
 - Dependabot covers `pip`, GitHub Actions, Docker, and npm/Tailwind tooling.
 
@@ -249,6 +251,8 @@ GitHub Actions workflows live in `.github/workflows/`.
 - Dependency and secret scanning remain active.
 - Container scanning remains active before publish.
 - Security checks should not silently move from blocking to advisory.
+- CodeQL should only become merge-blocking after an explicit policy change and
+  backlog triage.
 - CodeQL should stay on GitHub-hosted runners and must not expose self-hosted
   runners to untrusted code.
 - New secrets must be documented and scoped narrowly.

--- a/docs/development/SECURITY_STANDARDS.md
+++ b/docs/development/SECURITY_STANDARDS.md
@@ -34,7 +34,8 @@ that lock down important behavior.
 - CSP is documented exactly as implemented. It still allows inline script/style
   and app-side `'unsafe-eval'`, so CSP tightening remains a good future
   hardening target.
-- CodeQL is configured for public repositories and remains gated while private.
+- CodeQL is configured for public repositories and can be opt-in while private;
+  it is informational in the required aggregate gate until explicitly promoted.
 
 ## Table of Contents
 
@@ -736,6 +737,8 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 
 - `.github/workflows/security.yml` runs gitleaks, `pip-audit`, Safety, and
   Bandit, plus CodeQL when the repo is public or `PULLBOX_ENABLE_CODEQL=true`.
+  `Security Required` treats CodeQL as informational unless
+  `PULLBOX_REQUIRE_CODEQL=true`.
 - `.github/workflows/docker.yml` runs Grype container scanning before publish.
 - GitHub Actions are SHA-pinned with version comments.
 - Workflows define explicit default permissions and per-job permissions.
@@ -755,14 +758,16 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 - Dependency scanning remains active in CI.
 - Container scanning remains active for Docker artifacts.
 - CodeQL must run on GitHub-hosted runners only.
+- CodeQL should only become merge-blocking after an explicit policy change and
+  backlog triage.
 - Security checks should not silently degrade from blocking to advisory.
 - Safety remains advisory unless a deliberate policy change says otherwise.
 
 **Current repo nuances**
 
 - CodeQL is skipped while the repository is private unless
-  `PULLBOX_ENABLE_CODEQL=true`; it should run automatically after the
-  repository becomes public.
+  `PULLBOX_ENABLE_CODEQL=true`; it runs automatically after the repository
+  becomes public, but remains informational unless `PULLBOX_REQUIRE_CODEQL=true`.
 - Safety's legacy command still needs valid JSON artifact generation while it
   remains advisory.
 - Before public visibility, scan the current tree, full Git history, release


### PR DESCRIPTION
## Summary
- sync post-public hardening updates from main back into develop
- keep development branch aligned before the next feature branch

## Notes
- No application behavior changes beyond the already-merged main hardening work.
- GHCR untagged publish gate remains stashed for the next feature branch.