### PR TITLE
ci: publish release images to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,15 @@
 ---
 # Pullbox Docker Build & Push Pipeline
-# Builds multi-arch images, scans with Grype, runs smoke tests, then pushes to GHCR.
+# Builds images, scans with Grype, runs smoke tests, and publishes registry
+# images only for release tags or explicit manual dispatches.
 #
-# Registry: GHCR only (private, inherits visibility from repo).
-# Docker Hub will be added at v1.0 launch when the repo goes public.
-# To add Docker Hub: add login step, add DOCKERHUB_IMAGE env, add to metadata images.
+# Registries: GHCR and Docker Hub.
 #
 # Security: All actions pinned to full SHA. Container scanned before push.
 # See: docs/development/INFRASTRUCTURE.md
 #
 # Trigger rules:
-#   workflow_run → runs after CI passes on main for untagged SHAs
+#   workflow_run → validates Docker after CI passes on main for untagged SHAs
 #   push tags    → builds semver release images for tagged commits
 #   dispatch     → manual builds from any branch (tagged as "edge")
 # Trusted Docker publish stays on the self-hosted runner. This workflow is not
@@ -19,6 +18,7 @@
 # Tag strategy:
 #   v* tag       → 1.2.3, 1.2, 1, latest, sha-xxxxx
 #   manual       → edge (or custom), sha-xxxxx
+#   untagged main workflow_run → build/scan/smoke only; no registry publish
 #
 # Versioning:
 #   Version is read from pullbox/__init__.py (__version__).
@@ -51,6 +51,7 @@ permissions:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
+  DOCKERHUB_IMAGE: docker.io/pullboxapp/pullbox
   PYTHON_DEFAULT: "3.14"
 
 concurrency:
@@ -135,6 +136,7 @@ jobs:
       image-labels: ${{ steps.meta.outputs.labels }}
       image-version: ${{ steps.version.outputs.version }}
       build-sha: ${{ needs.gate.outputs.build-sha }}
+      is-release: ${{ steps.resolve-tag.outputs.is_release }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -188,6 +190,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.resolve-tag.outputs.tag }},enable=${{ steps.resolve-tag.outputs.is_release }}
             type=raw,value=latest,enable=${{ steps.resolve-tag.outputs.is_release }}
@@ -383,12 +386,13 @@ jobs:
         run: docker rm -f pullbox-smoke || true
 
   # ──────────────────────────────────────────────
-  # Job 4: Push to GHCR (after scan + smoke)
+  # Job 4: Push to registries (after scan + smoke)
   # ──────────────────────────────────────────────
   push:
-    name: Push to GHCR
+    name: Push to Registries
     runs-on: self-hosted
     needs: [build, scan, smoke-test]
+    if: needs.build.outputs.is-release == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 60
     permissions:
       contents: read
@@ -445,12 +449,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: Add Docker Hub login at v1.0 launch when repo goes public
-      # - name: Log in to Docker Hub
-      #   uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Validate Docker Hub authentication
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "::error::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets are required to publish release images to Docker Hub."
+            exit 1
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker metadata
         id: meta
@@ -458,6 +471,7 @@ jobs:
         with:
           images: |
             ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.resolve-tag.outputs.tag }},enable=${{ steps.resolve-tag.outputs.is_release }}
             type=raw,value=latest,enable=${{ steps.resolve-tag.outputs.is_release }}
@@ -501,7 +515,7 @@ jobs:
       - name: Summary
         run: |
           {
-            echo "## Docker Image Published 🐳"
+            echo "## Docker Images Published 🐳"
             echo ""
             echo "**Tags:**"
             echo '```'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}"
+            echo "docker pull docker.io/pullboxapp/pullbox:${{ steps.version.outputs.version }}"
             echo '```'
             echo ""
             echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ steps.release.outputs.tag }}"

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -453,7 +453,7 @@ Pullbox has two release-note artifacts:
 | Artifact | Source | When Updated | Purpose |
 |---|---|---|---|
 | `CHANGELOG.md` | Curated by maintainers | During release prep PR | Human-readable project history in the repo |
-| GitHub Release notes | Generated from commit subjects by `.github/workflows/release.yml` | After a signed version tag and successful Docker workflow | Detailed release event log and Docker pull command |
+| GitHub Release notes | Generated from commit subjects by `.github/workflows/release.yml` | After a signed version tag and successful Docker workflow | Detailed release event log and Docker pull commands |
 
 `CHANGELOG.md` is not generated automatically. Keep it concise and user-facing:
 summarize the release, do not paste every commit. During release prep, move

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -1,8 +1,8 @@
 # Pullbox Git Workflow
 
-**Author:** Adam Hernandez  
-**Version:** 1.0  
-**Last Modified:** 2026-05-15  
+**Author:** Adam Hernandez
+**Version:** 1.0
+**Last Modified:** 2026-05-15
 
 ## Purpose
 
@@ -388,7 +388,9 @@ Example PR body:
 - Release tags are signed.
 - Tag pushes trigger:
   - GitHub Release creation
-  - Docker build, Grype scan, smoke test, and GHCR publish
+  - Docker build, Grype scan, smoke test, and GHCR/Docker Hub publish
+- Ordinary untagged `main` merges may run Docker validation, but they must not
+  publish registry images.
 - Pre-release tags are supported.
 
 ### 8.2 Required standard
@@ -483,8 +485,9 @@ Recommended mapping:
   correctly.
 - If `git tag -s` fails, stop and configure a verified GPG or SSH signing key
   before pushing the tag.
-- Docker metadata rules may publish semver-derived aliases. Review GHCR tags
-  after release and delete unwanted aliases deliberately.
+- Docker metadata rules may publish semver-derived aliases during release-tag
+  builds. Review GHCR and Docker Hub tags after release and delete unwanted
+  aliases deliberately.
 - A pre-release tag can be used to test the release pipeline:
 
 ```bash
@@ -501,7 +504,7 @@ git push origin vX.Y.Z-rc1
 - [ ] Release PR targets `main`.
 - [ ] Release tag is signed and verified locally.
 - [ ] Release workflows complete successfully.
-- [ ] GHCR tags are reviewed after publish.
+- [ ] GHCR and Docker Hub tags are reviewed after publish.
 
 ## 9. Post-Release Sync
 

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -26,7 +26,7 @@ requirements.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
 - The runtime image is non-root and intentionally minimal.
-- GHCR is the current container registry.
+- GHCR and Docker Hub are the current container registries.
 - Release tags trigger Docker publication and GitHub Release generation.
 - Security workflows include gitleaks, `pip-audit`, Safety, Bandit, workflow
   hygiene checks, and Grype container scanning.
@@ -174,7 +174,7 @@ GitHub Actions workflows live in `.github/workflows/`.
 |---|---|---|
 | `ci.yml` | Push to `main`, PR to `main` or `develop`, merge queue | Lint, format, typecheck, tests, migration check, accessibility, E2E, `CI Required` aggregate |
 | `docker-pr.yml` | Docker-relevant PR changes | Production Docker build validation before merge |
-| `docker.yml` | CI success on `main`, tag push, manual dispatch | Multi-arch Docker build, Grype scan, smoke test, GHCR publish |
+| `docker.yml` | CI success on `main`, tag push, manual dispatch | Docker build validation, Grype scan, smoke test, and registry publish only for release tags or manual dispatch |
 | `security.yml` | Push to `main`, PR to `main` or `develop`, merge queue, schedule, manual dispatch | gitleaks, `pip-audit`, Safety, Bandit, public-gated CodeQL, `Security Required` aggregate |
 | `workflow-hygiene.yml` | Push to `main`, PR to `main` or `develop`, merge queue, manual dispatch | actionlint, workflow expression validation, `Workflow Hygiene Required` aggregate |
 | `clean-room.yml` | Schedule, manual dispatch | Fresh install validation outside runner-local cache |
@@ -194,6 +194,9 @@ GitHub Actions workflows live in `.github/workflows/`.
 
 ### 3.3 Current repo nuances
 
+- Docker validation runs after successful `main` CI for untagged commits, but
+  registry publication happens only for release tags or explicit manual
+  dispatches.
 - Docker publication depends on trusted refs and release tags.
 - DHI credentials are required for Docker builds that pull `dhi.io` base images.
 - Forked or Dependabot PRs may not have repository secrets. PR workflows should
@@ -542,13 +545,15 @@ Development dependency categories:
 ### 8.1 Current Pullbox implementation
 
 - Version tags trigger release and Docker automation.
-- `docker.yml` builds, scans, smoke-tests, and publishes container images.
+- `docker.yml` builds, scans, and smoke-tests container images after successful
+  `main` CI. It publishes to GHCR and Docker Hub only for release tags or
+  explicit manual dispatches.
 - `release.yml` creates or updates GitHub Releases for tagged commits after the
   Docker workflow succeeds.
 - GitHub Release notes are generated from conventional commit prefixes.
 - The root `CHANGELOG.md` is curated manually during release prep.
 - Release tags are expected to be signed.
-- GHCR is the current image registry.
+- GHCR and Docker Hub are the current image registries.
 
 ### 8.2 Required standard
 
@@ -556,15 +561,16 @@ Development dependency categories:
 - Release tags should be signed and verified locally before push.
 - Curated `CHANGELOG.md` entries should be moved from Unreleased into the
   release section before the release PR.
-- Docker publication should happen only from trusted refs.
+- Docker publication should happen only from trusted refs and should not publish
+  ordinary untagged `main` merges.
 - Release images should pass Grype and smoke tests before publication.
-- GHCR tags should be reviewed after release.
+- GHCR and Docker Hub tags should be reviewed after release.
 - Unwanted tag aliases should be deleted deliberately, not ignored.
 
 ### 8.3 Current repo nuances
 
 - Docker metadata rules may publish semver aliases in addition to exact version
-  and SHA tags.
+  and SHA tags during release-tag builds.
 - Pre-release tags can exercise the full pipeline before a stable release.
 - If Docker publish succeeds but registry tags look wrong, treat that as release
   hygiene work before moving on.
@@ -574,8 +580,8 @@ Development dependency categories:
 - [ ] Release tag is signed.
 - [ ] Docker workflow succeeds.
 - [ ] GitHub Release points at the expected tag.
-- [ ] GHCR exact version and SHA tags exist.
-- [ ] Unwanted GHCR aliases are reviewed and cleaned up.
+- [ ] GHCR and Docker Hub exact version and SHA tags exist.
+- [ ] Unwanted GHCR and Docker Hub aliases are reviewed and cleaned up.
 
 ## 9. Operational Support
 
@@ -669,6 +675,6 @@ dependencies:
 - [ ] Grype scans run before image publish.
 - [ ] Docker smoke tests verify startup and `/ping`.
 - [ ] Release tags are signed.
-- [ ] GHCR tags are reviewed after publish.
+- [ ] GHCR and Docker Hub tags are reviewed after publish.
 - [ ] New dependencies are justified and validated.
 - [ ] Operator deployment docs match the actual runtime contract.

--- a/docs/development/SECURITY_STANDARDS.md
+++ b/docs/development/SECURITY_STANDARDS.md
@@ -794,14 +794,17 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 - Release guidance lives in `docs/development/GIT_WORKFLOW.md`.
 - Infrastructure and registry guidance lives in
   `docs/development/INFRASTRUCTURE.md`.
-- Container publication uses GHCR.
+- Container publication uses GHCR and Docker Hub.
 - Docker metadata rules may publish semver-derived aliases depending on the
   release event.
+- Untagged `main` merges may run Docker validation, but they do not publish
+  registry images.
 
 **Required standard**
 
 - Release tags should be signed with the documented release process.
-- GHCR package tags should be reviewed after each release.
+- GHCR and Docker Hub package tags should be reviewed after each release.
+- Ordinary untagged `main` merges should not publish registry images.
 - Unwanted registry aliases should be deleted deliberately rather than changing
   metadata behavior without a release-process decision.
 - Release automation must not publish images from untrusted code.
@@ -814,7 +817,7 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 **Audit checks**
 
 - [ ] Release tag signing process is documented and followed.
-- [ ] GHCR tags are reviewed after publication.
+- [ ] GHCR and Docker Hub tags are reviewed after publication.
 - [ ] Unwanted aliases are removed deliberately.
 - [ ] Release workflows build from trusted refs.
 


### PR DESCRIPTION
## Summary
- publish release/manual Docker images to both GHCR and Docker Hub
- keep untagged main workflow_run Docker builds as build/scan/smoke only with no registry publish
- document the two-registry release contract

## Validation
- [x] make workflow-hygiene
- [x] git diff --check
