### PR TITLE
ci: correct docker hub namespace

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ permissions:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  DOCKERHUB_IMAGE: docker.io/pullboxapp/pullbox
+  DOCKERHUB_IMAGE: docker.io/pullbox/pullbox
   PYTHON_DEFAULT: "3.14"
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}"
-            echo "docker pull docker.io/pullboxapp/pullbox:${{ steps.version.outputs.version }}"
+            echo "docker pull docker.io/pullbox/pullbox:${{ steps.version.outputs.version }}"
             echo '```'
             echo ""
             echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ steps.release.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.3] - 2026-06-10
+
+Corrective release for Docker Hub publication.
+
+### CI / Build
+
+- Docker Hub release publishing now targets the `docker.io/pullbox/pullbox` namespace.
+- Generated GitHub release notes now show the corrected Docker Hub pull command.
+
 ## [0.9.2] - 2026-06-10
 
 Patch release to validate dual-registry Docker publishing after the public repository relaunch.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- bump Pullbox to 0.9.3 for a corrective release
- publish Docker Hub images to docker.io/pullbox/pullbox instead of docker.io/pullboxapp/pullbox
- update generated release notes to show the corrected Docker Hub pull command

## Validation
- make workflow-hygiene
- git diff --check
- local pre-commit was bypassed because the host Python env still lacks types-defusedxml and has PULLBOX_TZ set; GitHub CI remains the clean release gate
