### PR TITLE
chore: sync release state into develop

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ permissions:
 
 env:
   GHCR_IMAGE: ghcr.io/${{ github.repository }}
-  DOCKERHUB_IMAGE: docker.io/pullboxapp/pullbox
+  DOCKERHUB_IMAGE: docker.io/pullbox/pullbox
   PYTHON_DEFAULT: "3.14"
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}"
-            echo "docker pull docker.io/pullboxapp/pullbox:${{ steps.version.outputs.version }}"
+            echo "docker pull docker.io/pullbox/pullbox:${{ steps.version.outputs.version }}"
             echo '```'
             echo ""
             echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ steps.release.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.2] - 2026-06-10
+
+Patch release to validate dual-registry Docker publishing after the public repository relaunch.
+
+### CI / Build
+
+- Docker release publishing now publishes signed release images to both GHCR and Docker Hub.
+- Untagged `main` Docker workflow runs now build, scan, and smoke-test without publishing registry images.
+- Generated GitHub release notes now include both GHCR and Docker Hub pull commands.
+
+### Documentation
+
+- Registry and release-process documentation now reflects the dual-registry publishing contract.
+
 ## [0.9.1] - 2026-06-10
 
 First clean public release from the relaunched `pullboxapp/pullbox` repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Patch release to validate dual-registry Docker publishing after the public repos
 
 ### CI / Build
 
-- Docker release publishing now publishes signed release images to both GHCR and Docker Hub.
+- Docker release publishing now publishes versioned release images to both GHCR and Docker Hub.
 - Untagged `main` Docker workflow runs now build, scan, and smoke-test without publishing registry images.
 - Generated GitHub release notes now include both GHCR and Docker Hub pull commands.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.3] - 2026-06-10
+
+Corrective release for Docker Hub publication.
+
+### CI / Build
+
+- Docker Hub release publishing now targets the `docker.io/pullbox/pullbox` namespace.
+- Generated GitHub release notes now show the corrected Docker Hub pull command.
+
 ## [0.9.2] - 2026-06-10
 
 Patch release to validate dual-registry Docker publishing after the public repository relaunch.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- sync v0.9.2 and v0.9.3 release state back into develop
- keep Docker Hub namespace correction aligned on the development branch

## Validation
- v0.9.3 Docker workflow completed successfully
- GHCR and Docker Hub 0.9.3/latest images verified as multi-arch manifests
