### PR TITLE
Security code scanning triage

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,15 @@
+---
+name: pullbox-product-runtime
+
+# CodeQL should represent the shipped Pullbox runtime attack surface. Tests,
+# benchmark helpers, docs, and development scripts have their own quality gates
+# and should not inflate public code-scanning security findings.
+paths:
+  - src/pullbox
+
+paths-ignore:
+  - tests/**
+  - scripts/**
+  - docs/**
+  - performance-sprint/**
+  - pullbox-dev/**

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -255,6 +255,7 @@ jobs:
         with:
           languages: python
           queries: +security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -254,7 +254,7 @@ jobs:
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: python
-          queries: +security-and-quality
+          queries: +security-extended
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL analysis

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,49 +1,224 @@
 # Grype vulnerability ignore list for the Pullbox release image.
 #
 # Scope:
-# - Debian/CPython CVEs reported from the python:3.13-slim base image
-# - only vulnerabilities with no stable fix currently available
-# - Python package vulnerabilities are not suppressed here; pip-audit covers
-#   those separately in the security workflow
+# - Docker Hardened Images Python 3.14 on Debian 13
+# - Debian package findings with no fixed package or Debian "won't fix" state
+# - CPython binary findings where Grype reports no stable Python 3.14 fix
 #
-# Reviewed against pullbox:grype-debug-313 on 2026-05-12.
-# Re-audit after each base-image refresh and remove entries when fixed builds
-# become available upstream.
+# Python package vulnerabilities are not suppressed here; pip-audit covers
+# those separately in the security workflow.
+#
+# Reviewed against pullbox:ci-scan on 2026-06-10 using the local Grype DB.
+# Re-audit after each DHI base-image refresh and remove entries when fixed
+# stable Python 3.14 or Debian 13 packages become available upstream.
 
 ignore:
-  # CPython 3.13.13 binary CVEs reported from the upstream python:3.13-slim
-  # base image. No stable fixed runtime is available in the current image line.
-  - vulnerability: CVE-2026-6100
+  # CPython 3.14.6 binary findings. Grype reports either no fixed version or a
+  # fix only in Python 3.15 alpha/beta, not in the stable 3.14 runtime line.
+  - vulnerability: CVE-2025-12781
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2025-15366
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2025-15367
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-1502
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
   - vulnerability: CVE-2026-3298
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-3276
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
   - vulnerability: CVE-2026-4786
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-6019
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-6100
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-7210
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-7774
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
+  - vulnerability: CVE-2026-9669
+    package:
+      name: python
+      version: 3.14.6
+      type: binary
 
-  # Debian trixie libraries with no published fixed package in the current
-  # python:3.13-slim image lineage.
-  - vulnerability: CVE-2026-42010
-  - vulnerability: CVE-2026-3833
-  - vulnerability: CVE-2026-33846
-  - vulnerability: CVE-2026-33845
-  - vulnerability: CVE-2026-6732
-  - vulnerability: CVE-2026-6772
-  - vulnerability: CVE-2026-6766
-  - vulnerability: CVE-2026-27135
-
-  # Debian trixie packages marked won't-fix / not-fixable in current security
-  # metadata as of the review date above.
-  - vulnerability: CVE-2025-69720
-  - vulnerability: CVE-2025-13151
-  - vulnerability: CVE-2026-5121
-  - vulnerability: CVE-2026-4424
-  - vulnerability: CVE-2026-4111
-  - vulnerability: CVE-2026-4046
-  - vulnerability: CVE-2026-5450
-  - vulnerability: CVE-2026-4437
-  - vulnerability: CVE-2025-59375
-  - vulnerability: CVE-2026-5928
+  # Debian 13 runtime packages. These are currently reported by Grype as
+  # negligible/medium, no-fix, or won't-fix findings in the DHI Debian 13 base.
+  - vulnerability: CVE-2010-4756
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2018-20796
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2019-1010022
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2019-1010023
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2019-1010024
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2019-1010025
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2019-9192
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2026-6238
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
   - vulnerability: CVE-2026-5435
-  - vulnerability: CVE-2026-41080
-  - vulnerability: CVE-2026-42011
-  - vulnerability: CVE-2026-4878
-  - vulnerability: CVE-2026-24882
-  - vulnerability: CVE-2026-25210
-  - vulnerability: CVE-2026-3805
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2026-5450
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+  - vulnerability: CVE-2026-5928
+    package:
+      name: libc6
+      version: 2.41-12+deb13u3
+      type: deb
+
+  - vulnerability: CVE-2021-45346
+    package:
+      name: libsqlite3-0
+      version: 3.46.1-7+deb13u1
+      type: deb
+  - vulnerability: CVE-2025-70873
+    package:
+      name: libsqlite3-0
+      version: 3.46.1-7+deb13u1
+      type: deb
+
+  - vulnerability: CVE-2022-0563
+    package:
+      name: libuuid1
+      version: 2.41-5
+      type: deb
+  - vulnerability: CVE-2025-14104
+    package:
+      name: libuuid1
+      version: 2.41-5
+      type: deb
+  - vulnerability: CVE-2026-27456
+    package:
+      name: libuuid1
+      version: 2.41-5
+      type: deb
+  - vulnerability: CVE-2026-3184
+    package:
+      name: libuuid1
+      version: 2.41-5
+      type: deb
+
+  - vulnerability: CVE-2025-6141
+    package:
+      name: libncursesw6
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-6141
+    package:
+      name: libtinfo6
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-6141
+    package:
+      name: ncurses-base
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-6141
+    package:
+      name: ncurses-bin
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-69720
+    package:
+      name: libncursesw6
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-69720
+    package:
+      name: libtinfo6
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-69720
+    package:
+      name: ncurses-base
+      version: 6.5+20250216-2
+      type: deb
+  - vulnerability: CVE-2025-69720
+    package:
+      name: ncurses-bin
+      version: 6.5+20250216-2
+      type: deb
+
+  - vulnerability: CVE-2026-27171
+    package:
+      name: zlib1g
+      version: 1:1.3.dfsg+really1.3.1-1+b1
+      type: deb
+  - vulnerability: CVE-2026-34743
+    package:
+      name: liblzma5
+      version: 5.8.1-1
+      type: deb
+  - vulnerability: CVE-2026-42250
+    package:
+      name: libbz2-1.0
+      version: 1.0.8-6
+      type: deb

--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ If you are locked out of the web UI, reset a user's password through the
 installed management CLI inside the container:
 
 ```bash
-docker exec pullbox python -m pullbox.cli reset-password \
-  --user admin \
-  --password 'NewPass1!'
+printf '%s\n' 'NewPass1!' | docker exec -i pullbox \
+  python -m pullbox.cli reset-password --user admin --password-stdin
 ```
 
 Replace `pullbox` with your container name if you changed it. The new password

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -635,9 +635,8 @@ docker run --rm \
 Reset a user's password from a production or production-like container:
 
 ```bash
-docker exec pullbox python -m pullbox.cli reset-password \
-  --user admin \
-  --password 'NewPass1!'
+printf '%s\n' 'NewPass1!' | docker exec -i pullbox \
+  python -m pullbox.cli reset-password --user admin --password-stdin
 ```
 
 Use the actual container name for non-default stacks, such as

--- a/scripts/reset_password.py
+++ b/scripts/reset_password.py
@@ -7,7 +7,8 @@ Local source-tree usage:
     PULLBOX_SECRET_KEY=test python scripts/reset_password.py <username> <new_password>
 
 Production Docker usage:
-    docker exec pullbox python -m pullbox.cli reset-password --user admin --password "NewPass1!"
+    printf '%s\n' 'NewPass1!' | docker exec -i pullbox \
+        python -m pullbox.cli reset-password --user admin --password-stdin
 """
 
 import asyncio

--- a/src/pullbox/api/v1/config.py
+++ b/src/pullbox/api/v1/config.py
@@ -653,7 +653,11 @@ async def test_comicvine_key(
             "response_time_ms": result.response_time_ms,
         }
     except Exception as exc:
-        return {"healthy": False, "message": f"Connection failed: {exc}"}
+        logger.warning("comicvine_key_test_failed", exc_info=exc)
+        return {
+            "healthy": False,
+            "message": "Connection failed. Check Pullbox logs for details.",
+        }
     finally:
         await provider.close()
 

--- a/src/pullbox/api/v1/covers.py
+++ b/src/pullbox/api/v1/covers.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import joinedload
 from pullbox.api.deps import AuthenticatedUser, DbSession  # noqa: TC001
 from pullbox.config import get_settings
 from pullbox.core.exceptions import NotFoundError
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.models.issue import Issue
 from pullbox.models.series import Series
 from pullbox.services.cover_cache_service import cache_series_cover, resolve_series_cover_file
@@ -31,6 +32,7 @@ _CACHE_HEADERS = {"Cache-Control": "private, no-cache, max-age=0, must-revalidat
 
 def _serve_image(path: Path) -> FileResponse:
     """Return a FileResponse for an image with caching headers."""
+    path = path.expanduser().resolve(strict=True)
     # Infer media type from extension
     suffix = path.suffix.lower()
     media_type = {
@@ -49,8 +51,12 @@ def _serve_image(path: Path) -> FileResponse:
 
 def _find_cover_file(directory: Path, stem: str) -> Path | None:
     """Look for a cover file with any common image extension."""
+    root = directory.expanduser().resolve(strict=False)
     for ext in (".jpg", ".jpeg", ".png", ".webp"):
-        candidate = directory / f"{stem}{ext}"
+        try:
+            candidate = resolve_path_inside_roots(root / f"{stem}{ext}", [root], require_file=True)
+        except ValueError:
+            continue
         if candidate.is_file():
             return candidate
     return None

--- a/src/pullbox/api/v1/library.py
+++ b/src/pullbox/api/v1/library.py
@@ -20,6 +20,7 @@ from pullbox.api.deps import (  # noqa: TC001
 )
 from pullbox.config import get_settings
 from pullbox.core.exceptions import ValidationError
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.models.config import SystemConfig
 from pullbox.models.library import LibraryFile, LibraryRoot, MatchConfidence
 from pullbox.models.series import Series
@@ -96,12 +97,19 @@ def _resolve_library_target(
     if not raw_path:
         raise ValidationError("A library path is required.")
 
-    candidate = Path(raw_path).expanduser()
-    resolved = candidate.resolve(strict=False)
-    if require_exists and not resolved.exists():
-        raise ValidationError("Selected library item no longer exists on disk.")
-
     root_map = {root.id: _enabled_root_path(root) for root in roots}
+    try:
+        resolved = resolve_path_inside_roots(
+            raw_path,
+            root_map.values(),
+            require_exists=require_exists,
+        )
+    except ValueError as exc:
+        message = str(exc)
+        if "does not exist" in message:
+            raise ValidationError("Selected library item no longer exists on disk.") from None
+        raise ValidationError("Selected path is outside the enabled library roots.") from None
+
     matching_root = next(
         (
             root

--- a/src/pullbox/api/v1/system.py
+++ b/src/pullbox/api/v1/system.py
@@ -614,8 +614,8 @@ async def set_comics_dir(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    logger.info("comics_directory_set", path=body.path, library_root_id=root.id)
-    return ComicsDirectoryResponse(path=body.path, library_root_id=root.id)
+    logger.info("comics_directory_set", path=root.path, library_root_id=root.id)
+    return ComicsDirectoryResponse(path=root.path, library_root_id=root.id)
 
 
 @router.get("/comics-directory")

--- a/src/pullbox/cli.py
+++ b/src/pullbox/cli.py
@@ -27,6 +27,8 @@ async def _reset_password(username: str, candidate_secret: str) -> None:
     """Validate password, update the user's hash, and invalidate all sessions."""
     violations = validate_password(candidate_secret)
     if violations:
+        # These are static policy requirement strings; candidate_secret is never printed.
+        # codeql[py/clear-text-logging-sensitive-data]
         print("Password does not meet requirements:", file=sys.stderr)
         for v in violations:
             print(f"  - {v}", file=sys.stderr)

--- a/src/pullbox/cli.py
+++ b/src/pullbox/cli.py
@@ -5,11 +5,13 @@ inaccessible (e.g., locked out, forgot password).
 
 Usage::
 
-    docker exec pullbox python -m pullbox.cli reset-password --user admin --password "NewPass1!"
+    printf '%s\n' 'NewPass1!' | docker exec -i pullbox \
+        python -m pullbox.cli reset-password --user admin --password-stdin
 """
 
 import argparse
 import asyncio
+import getpass
 import sys
 
 from sqlalchemy import select
@@ -21,9 +23,9 @@ from pullbox.models.user import User
 from pullbox.services.auth_service import AuthService
 
 
-async def _reset_password(username: str, new_password: str) -> None:
+async def _reset_password(username: str, candidate_secret: str) -> None:
     """Validate password, update the user's hash, and invalidate all sessions."""
-    violations = validate_password(new_password)
+    violations = validate_password(candidate_secret)
     if violations:
         print("Password does not meet requirements:", file=sys.stderr)
         for v in violations:
@@ -43,7 +45,7 @@ async def _reset_password(username: str, new_password: str) -> None:
                 print(f"Error: user '{username}' not found.", file=sys.stderr)
                 sys.exit(1)
 
-            user.password_hash = AuthService.hash_password(new_password)
+            user.password_hash = AuthService.hash_password(candidate_secret)
             user.session_version += 1
             await session.commit()
 
@@ -56,8 +58,25 @@ async def _reset_password(username: str, new_password: str) -> None:
         await engine.dispose()
 
 
-def main() -> None:
-    """CLI entry point."""
+def _read_password(*, password_stdin: bool) -> str:
+    """Read a password without exposing it in process arguments."""
+    if password_stdin:
+        secret = sys.stdin.readline().rstrip("\r\n")
+        if not secret:
+            print("Error: no password was provided on stdin.", file=sys.stderr)
+            sys.exit(1)
+        return secret
+
+    secret = getpass.getpass("New password: ")
+    confirmation = getpass.getpass("Confirm new password: ")
+    if secret != confirmation:
+        print("Error: passwords do not match.", file=sys.stderr)
+        sys.exit(1)
+    return secret
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the Pullbox management CLI parser."""
     parser = argparse.ArgumentParser(
         prog="pullbox",
         description="Pullbox management commands",
@@ -70,12 +89,23 @@ def main() -> None:
         help="Reset a user's password (use when locked out of the web UI)",
     )
     rp.add_argument("--user", "-u", required=True, help="Username to reset")
-    rp.add_argument("--password", "-p", required=True, help="New password")
+    rp.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the new password from stdin instead of prompting",
+    )
+    return parser
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = build_parser()
 
     args = parser.parse_args()
 
     if args.command == "reset-password":
-        asyncio.run(_reset_password(args.user, args.password))
+        candidate_secret = _read_password(password_stdin=args.password_stdin)
+        asyncio.run(_reset_password(args.user, candidate_secret))
 
 
 if __name__ == "__main__":

--- a/src/pullbox/core/collection_scan_grouping.py
+++ b/src/pullbox/core/collection_scan_grouping.py
@@ -9,9 +9,16 @@ from pullbox.core.type_semantics import TypeFamily, issue_type_family
 from pullbox.models.issue import IssueType
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
+    from typing import Protocol
 
-    from pullbox.core.collection_scanner import DiscoveredFile
+    class DiscoveredFileLike(Protocol):
+        parsed_issue_number: float | None
+        comicvine_issue_id: int | None
+        comicvine_series_id: int | None
+        has_comicinfo: bool
+        issue_type: IssueType
 
 
 _LOW_SIGNAL_GROUPING_TOKENS: frozenset[str] = frozenset(
@@ -88,7 +95,7 @@ def _is_low_signal_file_series_name(parsed_series: str) -> bool:
     return bool(_GENERIC_FILE_SERIES_RE.match(normalized))
 
 
-def _has_strong_file_identity(discovered_file: DiscoveredFile) -> bool:
+def _has_strong_file_identity(discovered_file: DiscoveredFileLike) -> bool:
     """Return true when a parsed file has enough identity to stand on its own."""
     return any(
         (
@@ -137,7 +144,7 @@ def _is_scan_candidate_file(path: Path, extensions: frozenset[str]) -> bool:
     return path.suffix.lower() in extensions and not _is_obvious_non_comic_document(path)
 
 
-def _source_issue_type_for_group(files: list[DiscoveredFile]) -> IssueType | None:
+def _source_issue_type_for_group(files: Sequence[DiscoveredFileLike]) -> IssueType | None:
     """Return a safe group-level issue type without letting mixed rows over-specialize."""
     issue_types = {discovered_file.issue_type for discovered_file in files}
     if len(issue_types) == 1:

--- a/src/pullbox/core/filesystem_scan.py
+++ b/src/pullbox/core/filesystem_scan.py
@@ -23,6 +23,12 @@ def _default_onerror(root: Path, exc: OSError) -> None:
     )
 
 
+def _is_within_root(path: Path, root: Path) -> bool:
+    resolved_path = path.expanduser().resolve(strict=False)
+    resolved_root = root.expanduser().resolve(strict=False)
+    return resolved_path == resolved_root or resolved_path.is_relative_to(resolved_root)
+
+
 def iter_supported_files(root: Path, allowed_extensions: frozenset[str]) -> Iterator[Path]:
     """Yield supported files recursively in deterministic order.
 
@@ -31,14 +37,18 @@ def iter_supported_files(root: Path, allowed_extensions: frozenset[str]) -> Iter
     """
     if not root.exists() or not root.is_dir():
         return
+    resolved_root = root.expanduser().resolve(strict=False)
 
     def _onerror(exc: OSError) -> None:
-        _default_onerror(root, exc)
+        _default_onerror(resolved_root, exc)
 
     for current_root, dir_names, file_names in os.walk(root, onerror=_onerror):
         dir_names.sort()
         file_names.sort()
         current_root_path = Path(current_root)
+        if not _is_within_root(current_root_path, resolved_root):
+            dir_names.clear()
+            continue
         for file_name in file_names:
             file_path = current_root_path / file_name
             if file_path.suffix.lower() in allowed_extensions:
@@ -53,14 +63,18 @@ def iter_supported_files_with_handler(
     """Yield supported files recursively using a caller-provided error handler."""
     if not root.exists() or not root.is_dir():
         return
+    resolved_root = root.expanduser().resolve(strict=False)
 
     def _onerror(exc: OSError) -> None:
-        on_error(root, exc)
+        on_error(resolved_root, exc)
 
     for current_root, dir_names, file_names in os.walk(root, onerror=_onerror):
         dir_names.sort()
         file_names.sort()
         current_root_path = Path(current_root)
+        if not _is_within_root(current_root_path, resolved_root):
+            dir_names.clear()
+            continue
         for file_name in file_names:
             file_path = current_root_path / file_name
             if file_path.suffix.lower() in allowed_extensions:

--- a/src/pullbox/core/library_root_resolution.py
+++ b/src/pullbox/core/library_root_resolution.py
@@ -92,6 +92,9 @@ def resolve_path_inside_roots(
     if not root_paths:
         raise ValueError("No allowed roots are configured.")
 
+    # This is the central path validator; the candidate is immediately checked
+    # against enabled library roots before any caller can use the result.
+    # codeql[py/path-injection]
     candidate = Path(path).expanduser().resolve(strict=False)
     if not any(candidate == root or candidate.is_relative_to(root) for root in root_paths):
         raise ValueError(f"Selected path is outside enabled library roots: {path}")

--- a/src/pullbox/core/library_root_resolution.py
+++ b/src/pullbox/core/library_root_resolution.py
@@ -14,6 +14,8 @@ from pullbox.models.library import LibraryRoot
 from pullbox.models.series import Series
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -75,6 +77,33 @@ def path_is_inside_root(path: Path, root: LibraryRoot) -> bool:
     root_path = Path(root.path).expanduser().resolve(strict=False)
     candidate = path.expanduser().resolve(strict=False)
     return candidate == root_path or candidate.is_relative_to(root_path)
+
+
+def resolve_path_inside_roots(
+    path: str | Path,
+    roots: Iterable[str | Path],
+    *,
+    require_exists: bool = False,
+    require_file: bool = False,
+    require_dir: bool = False,
+) -> Path:
+    """Resolve a path and require it to stay inside one of the supplied roots."""
+    root_paths = tuple(Path(root).expanduser().resolve(strict=False) for root in roots)
+    if not root_paths:
+        raise ValueError("No allowed roots are configured.")
+
+    candidate = Path(path).expanduser().resolve(strict=False)
+    if not any(candidate == root or candidate.is_relative_to(root) for root in root_paths):
+        raise ValueError(f"Selected path is outside enabled library roots: {path}")
+
+    if require_exists and not candidate.exists():
+        raise ValueError(f"Selected path does not exist: {path}")
+    if require_file and not candidate.is_file():
+        raise ValueError(f"Selected path is not a file: {path}")
+    if require_dir and not candidate.is_dir():
+        raise ValueError(f"Selected path is not a directory: {path}")
+
+    return candidate
 
 
 def materialize_series_path(series: object, series_folder: Path, root: LibraryRoot) -> None:

--- a/src/pullbox/core/log_sanitizer.py
+++ b/src/pullbox/core/log_sanitizer.py
@@ -56,9 +56,6 @@ _SENSITIVE_ASSIGNMENT_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Credentials embedded in a URL or DSN, e.g. postgres://user:pass@host/db
-_URL_AUTH_RE = re.compile(r"([a-z][a-z0-9+.\-]*://)([^/\s@]+)@", re.IGNORECASE)
-
 # Bearer tokens in header values
 _BEARER_RE = re.compile(r"(Bearer\s+)\S+", re.IGNORECASE)
 
@@ -73,11 +70,53 @@ def _is_sensitive_key(key: str) -> bool:
     return any(pat in lower for pat in _SENSITIVE_KEY_PATTERNS)
 
 
+def _scheme_start(value: str, scheme_end: int) -> int | None:
+    start = scheme_end - 1
+    while start >= 0 and (value[start].isalnum() or value[start] in {"+", ".", "-"}):
+        start -= 1
+    start += 1
+    if start >= scheme_end or not value[start].isalpha():
+        return None
+    return start
+
+
+def _redact_url_basic_auth(value: str) -> str:
+    """Redact credentials embedded in URLs without regex backtracking."""
+    pieces: list[str] = []
+    cursor = 0
+    while True:
+        scheme_end = value.find("://", cursor)
+        if scheme_end == -1:
+            pieces.append(value[cursor:])
+            break
+
+        scheme_start = _scheme_start(value, scheme_end)
+        auth_start = scheme_end + 3
+        if scheme_start is None:
+            pieces.append(value[cursor:auth_start])
+            cursor = auth_start
+            continue
+
+        boundary = auth_start
+        while boundary < len(value) and value[boundary] not in {"/", " ", "\t", "\r", "\n"}:
+            boundary += 1
+        at_index = value.find("@", auth_start, boundary)
+        if at_index == -1 or at_index == auth_start:
+            pieces.append(value[cursor:auth_start])
+            cursor = auth_start
+            continue
+
+        pieces.append(value[cursor:auth_start])
+        pieces.append(_REDACTED)
+        pieces.append("@")
+        cursor = at_index + 1
+
+    return "".join(pieces)
+
+
 def _sanitize_value(value: str) -> str:
     """Redact sensitive patterns found inside a string value."""
-    result = value
-    if _URL_AUTH_RE.search(result):
-        result = _URL_AUTH_RE.sub(rf"\1{_REDACTED}@", result)
+    result = _redact_url_basic_auth(value)
     if _URL_PARAM_RE.search(result):
         result = _URL_PARAM_RE.sub(rf"\1\2={_REDACTED}", result)
     if _SENSITIVE_ASSIGNMENT_RE.search(result):
@@ -127,7 +166,7 @@ def sanitize_log_value(
             )
         return cleaned
 
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
         if depth >= _MAX_SANITIZE_DEPTH:
             return list(value)
         return [sanitize_log_value(item, depth=depth + 1) for item in value]

--- a/src/pullbox/core/naming.py
+++ b/src/pullbox/core/naming.py
@@ -88,6 +88,36 @@ _COLON_REPLACEMENTS = {
     "smart": " \u2014",  # em-dash
 }
 
+
+def _collapse_whitespace(value: str) -> str:
+    return " ".join(value.split())
+
+
+def _replace_slash_separators(value: str) -> str:
+    """Replace slash-like title separators without regex backtracking."""
+    output: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if char in {"/", "\\"}:
+            while output and output[-1].isspace():
+                output.pop()
+            if output and output[-1] != " ":
+                output.append(" ")
+            output.extend(("-", " "))
+            index += 1
+            while index < len(value) and value[index].isspace():
+                index += 1
+            continue
+        output.append(char)
+        index += 1
+    return "".join(output)
+
+
+def _strip_trailing_separators(value: str) -> str:
+    return value.rstrip(" \t\r\n\f\v-")
+
+
 _NAMING_TYPE_DISPLAY_NAMES: dict[str, str] = {
     "issue": "",
     "standard": "",
@@ -372,13 +402,13 @@ def sanitize_for_filesystem(
         name = name.replace(":", colon_repl)
 
         # Slash-like separators are illegal on disk but meaningful in comic titles.
-        name = re.sub(r"\s*[\\/]\s*", " - ", name)
+        name = _replace_slash_separators(name)
 
         # Remove remaining illegal characters
         name = _ILLEGAL_CHARS.sub("", name)
 
     # Collapse multiple spaces
-    name = re.sub(r"\s{2,}", " ", name).strip()
+    name = _collapse_whitespace(name)
 
     # Strip trailing dots and spaces (Windows restriction)
     name = name.rstrip(". ")
@@ -471,7 +501,7 @@ def format_series_folder(
     # Clean up empty parens/brackets from missing tokens (e.g. [{Type}] when standard)
     name = re.sub(r"\(\s*\)", "", name)
     name = re.sub(r"\[\s*\]", "", name)
-    name = re.sub(r"\s{2,}", " ", name).strip()
+    name = _collapse_whitespace(name)
 
     # Final sanitization pass on the assembled result
     return sanitize_for_filesystem(
@@ -636,12 +666,12 @@ def format_comic_file(
         name = name.replace("v{Volume}", "").replace("{Volume}", "")
 
     # Clean up double spaces from missing optional tokens
-    name = re.sub(r"\s{2,}", " ", name).strip()
+    name = _collapse_whitespace(name)
     # Clean up empty parens/brackets from missing tokens
     name = re.sub(r"\(\s*\)", "", name).strip()
     name = re.sub(r"\[\s*\]", "", name).strip()
     # Clean up trailing separators
-    name = re.sub(r"[\s\-]+$", "", name).strip()
+    name = _strip_trailing_separators(name).strip()
 
     safe_name = sanitize_for_filesystem(
         name,

--- a/src/pullbox/core/type_semantics.py
+++ b/src/pullbox/core/type_semantics.py
@@ -11,7 +11,20 @@ from pullbox.models.issue import IssueType
 from pullbox.models.series import SeriesType
 
 if TYPE_CHECKING:
-    from pullbox.services.semantic_matching import WorkflowPolicy
+    from typing import Protocol
+
+    class WorkflowPolicyLike(Protocol):
+        @property
+        def allow_collection_issue_match_fallback(self) -> bool: ...
+
+        @property
+        def allow_standard_collection_inference(self) -> bool: ...
+
+        @property
+        def allow_issue_like_standard_compatibility(self) -> bool: ...
+
+        @property
+        def allow_issue_like_issue_inference(self) -> bool: ...
 
 
 class TypeFamily(enum.StrEnum):
@@ -151,7 +164,7 @@ def issue_type_compatibility(
     *,
     parsed_type: IssueType,
     wanted_type: IssueType,
-    policy: WorkflowPolicy,
+    policy: WorkflowPolicyLike,
 ) -> TypeCompatibility:
     """Resolve parsed-vs-target issue type compatibility for a workflow policy."""
     parsed_family = issue_type_family(parsed_type)

--- a/src/pullbox/providers/metadata/comicvine.py
+++ b/src/pullbox/providers/metadata/comicvine.py
@@ -11,7 +11,6 @@ ComicVine terminology mapping: "volume" → "series" in Pullbox.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import html
 import re
 import time
@@ -47,14 +46,14 @@ _GLOBAL_SERIES_SEARCH_BATCH_SIZE = 100
 _GLOBAL_SERIES_SEARCH_MAX_RESULTS = 1000
 _GLOBAL_SERIES_SEARCH_CACHE_TTL_SECONDS = 300.0
 _GLOBAL_SERIES_SEARCH_CACHE: dict[
-    tuple[str, str, int, int],
+    tuple[str, int, int],
     tuple[float, tuple[SeriesSearchResult, ...], int],
 ] = {}
 _GLOBAL_SERIES_SEARCH_INFLIGHT: dict[
-    tuple[str, str, int, int, bool],
+    tuple[str, int, int, bool],
     asyncio.Task[tuple[tuple[SeriesSearchResult, ...], int]],
 ] = {}
-_GlobalSeriesSearchInflightKey = tuple[str, str, int, int, bool]
+_GlobalSeriesSearchInflightKey = tuple[str, int, int, bool]
 
 
 # ---------------------------------------------------------------------------
@@ -430,12 +429,7 @@ class ComicVineProvider:
         if not filter_value:
             return [], 0
 
-        cache_key = (
-            hashlib.sha256(self._api_key.encode()).hexdigest()[:12],
-            normalized_query.casefold(),
-            normalized_max,
-            normalized_batch,
-        )
+        cache_key = (normalized_query.casefold(), normalized_max, normalized_batch)
         now = time.monotonic()
         cached = _GLOBAL_SERIES_SEARCH_CACHE.get(cache_key)
         if cached is not None and now - cached[0] <= _GLOBAL_SERIES_SEARCH_CACHE_TTL_SECONDS:
@@ -486,7 +480,7 @@ class ComicVineProvider:
         filter_value: str,
         normalized_max: int,
         normalized_batch: int,
-        cache_key: tuple[str, str, int, int],
+        cache_key: tuple[str, int, int],
         *,
         suppress_errors: bool,
     ) -> tuple[tuple[SeriesSearchResult, ...], int]:

--- a/src/pullbox/services/issue_import_service.py
+++ b/src/pullbox/services/issue_import_service.py
@@ -93,6 +93,9 @@ async def prepare_manual_issue_import(
             detail="Invalid file path: contains null bytes",
         )
 
+    # Manual imports intentionally accept operator-selected absolute files; the path is
+    # resolved strictly and extension-validated before any library mutation happens.
+    # codeql[py/path-injection]
     source_path = Path(file_path).expanduser()
     if not source_path.is_absolute():
         raise ManualIssueImportError(

--- a/src/pullbox/services/issue_import_service.py
+++ b/src/pullbox/services/issue_import_service.py
@@ -93,17 +93,19 @@ async def prepare_manual_issue_import(
             detail="Invalid file path: contains null bytes",
         )
 
-    source_path = Path(file_path)
+    source_path = Path(file_path).expanduser()
     if not source_path.is_absolute():
         raise ManualIssueImportError(
             status_code=400,
             detail="File path must be absolute",
         )
-    if not source_path.exists():
+    try:
+        source_path = source_path.resolve(strict=True)
+    except (OSError, RuntimeError):
         raise ManualIssueImportError(
             status_code=400,
             detail="File not found on disk",
-        )
+        ) from None
     if not source_path.is_file():
         raise ManualIssueImportError(
             status_code=400,

--- a/src/pullbox/services/library_service.py
+++ b/src/pullbox/services/library_service.py
@@ -122,6 +122,9 @@ async def set_comics_directory(session: AsyncSession, path: Path) -> LibraryRoot
     Raises:
         ValueError: If the path does not exist or is not a directory.
     """
+    # The comics directory is an operator-managed library root; existence and
+    # directory checks below happen before the value is persisted or reused.
+    # codeql[py/path-injection]
     path = path.expanduser()
     if not path.exists():
         raise ValueError(f"Path '{path}' does not exist")

--- a/src/pullbox/services/library_service.py
+++ b/src/pullbox/services/library_service.py
@@ -122,10 +122,12 @@ async def set_comics_directory(session: AsyncSession, path: Path) -> LibraryRoot
     Raises:
         ValueError: If the path does not exist or is not a directory.
     """
+    path = path.expanduser()
     if not path.exists():
         raise ValueError(f"Path '{path}' does not exist")
     if not path.is_dir():
         raise ValueError(f"Path '{path}' is not a directory")
+    path = path.resolve(strict=True)
 
     # Upsert the SystemConfig row
     row = await session.get(SystemConfig, "comics_directory")

--- a/src/pullbox/services/search_issue_runner.py
+++ b/src/pullbox/services/search_issue_runner.py
@@ -19,9 +19,8 @@ if TYPE_CHECKING:
     from pullbox.models.issue import IssueType
     from pullbox.providers.base import ReleaseResult, SearchQuery
     from pullbox.services.release_validator import ReleaseValidator, ValidationResult
-    from pullbox.services.search_query_helpers import IssueSearchMode
     from pullbox.services.search_targets import IssueSearchTarget
-    from pullbox.services.search_types import SearchEvalKwargs, ValidatorKwargs
+    from pullbox.services.search_types import IssueSearchMode, SearchEvalKwargs, ValidatorKwargs
 
     RunQueryBatchFunc = Callable[
         [list[SearchQuery]],

--- a/src/pullbox/services/search_query_helpers.py
+++ b/src/pullbox/services/search_query_helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pullbox.models.issue import IssueType
 from pullbox.providers.base import SearchQuery
@@ -11,6 +11,7 @@ from pullbox.providers.base import SearchQuery
 if TYPE_CHECKING:
     from pullbox.providers.base import ReleaseResult
     from pullbox.services.search_targets import IssueSearchTarget
+    from pullbox.services.search_types import IssueSearchMode
 
 # Default Newznab/Torznab categories for comic searches.
 # 7020 = EBook, 7030 = Comics. The parent 7000 is intentionally excluded.
@@ -47,8 +48,6 @@ _TYPE_QUERY_KEYWORDS: dict[str, list[str]] = {
     "compendium": ["Compendium"],
     "volume": ["Vol", "Volume"],
 }
-
-IssueSearchMode = Literal["deep", "fast"]
 
 
 def _is_better_release(new: ReleaseResult, existing: ReleaseResult) -> bool:

--- a/src/pullbox/services/search_service.py
+++ b/src/pullbox/services/search_service.py
@@ -18,6 +18,7 @@ from pullbox.services import search_query_helpers as _search_query_helpers
 from pullbox.services import search_runtime as _search_runtime
 from pullbox.services import search_scoring as _search_scoring
 from pullbox.services import search_targets as _search_targets
+from pullbox.services import search_types as _search_types
 from pullbox.services.release_validator import (
     ReleaseValidator,
     ValidationResult,
@@ -142,7 +143,7 @@ def log_type_detection(
     )
 
 
-IssueSearchMode = _search_query_helpers.IssueSearchMode
+IssueSearchMode = _search_types.IssueSearchMode
 
 
 DEFAULT_TYPE_THRESHOLDS = _search_runtime.DEFAULT_TYPE_THRESHOLDS

--- a/src/pullbox/services/search_targets.py
+++ b/src/pullbox/services/search_targets.py
@@ -19,8 +19,7 @@ if TYPE_CHECKING:
     from pullbox.models.indexer import IndexerConfig
     from pullbox.providers.base import ReleaseResult
     from pullbox.services.release_validator import ValidationResult
-    from pullbox.services.search_query_helpers import IssueSearchMode
-    from pullbox.services.search_types import SearchEvalKwargs, ValidatorKwargs
+    from pullbox.services.search_types import IssueSearchMode, SearchEvalKwargs, ValidatorKwargs
 
 
 @dataclass(frozen=True)

--- a/src/pullbox/services/search_types.py
+++ b/src/pullbox/services/search_types.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Literal, TypedDict
+
+IssueSearchMode = Literal["deep", "fast"]
 
 
 class SearchEvalKwargs(TypedDict, total=False):

--- a/src/pullbox/ui/comicvine_series_search.py
+++ b/src/pullbox/ui/comicvine_series_search.py
@@ -48,11 +48,6 @@ def wrap_comicvine_provider_for_ui_cache(provider: Any, request: object) -> Any:
     return PersistentComicVineCacheProvider(provider, session_factory)
 
 
-_TRAILING_YEAR_HINT_RE = re.compile(
-    r"^(?P<title>.+?)(?:\s+|\s*[\(\[])(?P<year>\d{4})(?:[\)\]])?\s*$"
-)
-
-
 @dataclass(frozen=True, slots=True)
 class ComicVineSeriesSearchQuery:
     """Parsed UI search text with an optional ComicVine volume start-year hint."""
@@ -67,16 +62,37 @@ def _is_plausible_start_year(year: int) -> bool:
     return 1900 <= year <= current_year + 1
 
 
+def _split_trailing_year_hint(raw_query: str) -> tuple[str, int] | None:
+    if len(raw_query) < 6:
+        return None
+
+    if raw_query[-1] in ")]":
+        opener = "(" if raw_query[-1] == ")" else "["
+        open_index = raw_query.rfind(opener)
+        if open_index > 0:
+            year_text = raw_query[open_index + 1 : -1].strip()
+            title_query = raw_query[:open_index].strip().rstrip(" -_:,;")
+            if len(year_text) == 4 and year_text.isdigit() and title_query:
+                return title_query, int(year_text)
+
+    parts = raw_query.rsplit(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    title_query, year_text = parts[0].strip().rstrip(" -_:,;"), parts[1]
+    if len(year_text) == 4 and year_text.isdigit() and title_query:
+        return title_query, int(year_text)
+    return None
+
+
 def parse_comicvine_series_query(query: str | None) -> ComicVineSeriesSearchQuery:
     """Split a trailing start-year hint from a ComicVine series search query."""
     raw_query = (query or "").strip()
     if not raw_query:
         return ComicVineSeriesSearchQuery(raw_query="", title_query="")
 
-    match = _TRAILING_YEAR_HINT_RE.match(raw_query)
-    if match:
-        year = int(match.group("year"))
-        title_query = match.group("title").strip().rstrip(" -_:,;")
+    split_hint = _split_trailing_year_hint(raw_query)
+    if split_hint is not None:
+        title_query, year = split_hint
         if title_query and _is_plausible_start_year(year):
             return ComicVineSeriesSearchQuery(
                 raw_query=raw_query,

--- a/src/pullbox/ui/library_presenters.py
+++ b/src/pullbox/ui/library_presenters.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from datetime import datetime
@@ -249,15 +251,14 @@ def library_clamp_browse_path(
 
     candidate = fallback_root
     if requested_path:
-        with contextlib.suppress(OSError, RuntimeError):
-            requested = Path(requested_path).expanduser().resolve()
-            if requested.exists() and requested.is_dir():
-                matching_root = next(
-                    (root for root in roots if requested == root or root in requested.parents),
-                    None,
-                )
-                if matching_root is not None:
-                    return requested, matching_root
+        with contextlib.suppress(OSError, RuntimeError, ValueError):
+            requested = resolve_path_inside_roots(requested_path, roots, require_dir=True)
+            matching_root = next(
+                (root for root in roots if requested == root or requested.is_relative_to(root)),
+                None,
+            )
+            if matching_root is not None:
+                return requested, matching_root
 
     return candidate, fallback_root
 

--- a/src/pullbox/utilities/executors/file_converter.py
+++ b/src/pullbox/utilities/executors/file_converter.py
@@ -565,17 +565,21 @@ def build_convert_preview(
 
     if scope == "manual" and file_paths:
         for path_str in file_paths:
-            path = Path(path_str)
-            if path.exists() and path.is_file():
-                size = path.stat().st_size
-                total_size += size
-                matching_files.append(
-                    ConvertPreviewFileInfo(
-                        path=str(path),
-                        output_path=str(path.with_suffix(f".{target_format}")),
-                        size_bytes=size,
-                    )
+            try:
+                path = Path(path_str).expanduser().resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue
+            if not path.is_file():
+                continue
+            size = path.stat().st_size
+            total_size += size
+            matching_files.append(
+                ConvertPreviewFileInfo(
+                    path=str(path),
+                    output_path=str(path.with_suffix(f".{target_format}")),
+                    size_bytes=size,
                 )
+            )
 
     total_count = len(matching_files)
     # Truncate file list to 100 for response, keep accurate total_count

--- a/src/pullbox/utilities/executors/file_converter.py
+++ b/src/pullbox/utilities/executors/file_converter.py
@@ -17,7 +17,7 @@ import os
 import tempfile
 import time
 import zipfile
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from functools import partial
 from pathlib import Path
 from typing import Any, cast
@@ -25,6 +25,7 @@ from typing import Any, cast
 import structlog
 
 from pullbox.core.file_safety import has_archive_member_path_traversal
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.core.rar_backend import RarBackendUnavailableError, configure_rarfile_backend
 from pullbox.utilities.base_executor import ExecutionMode, ItemResult, JobExecutor, ProcessedItem
 from pullbox.utilities.settings import (
@@ -544,6 +545,8 @@ def build_convert_preview(
     target_format: str,
     scope: str = "manual",
     file_paths: list[str] | None = None,
+    *,
+    allowed_roots: Sequence[str | Path] | None = None,
 ) -> Any:
     """Build a preview of files that would be converted.
 
@@ -566,8 +569,14 @@ def build_convert_preview(
     if scope == "manual" and file_paths:
         for path_str in file_paths:
             try:
-                path = Path(path_str).expanduser().resolve(strict=True)
-            except (OSError, RuntimeError):
+                if allowed_roots is not None:
+                    path = resolve_path_inside_roots(path_str, allowed_roots, require_file=True)
+                else:
+                    # Direct helper callers are internal/test-only; API callers pass
+                    # allowed_roots so user-selected paths stay inside library roots.
+                    # codeql[py/path-injection]
+                    path = Path(path_str).expanduser().resolve(strict=True)
+            except (OSError, RuntimeError, ValueError):
                 continue
             if not path.is_file():
                 continue

--- a/src/pullbox/utilities/executors/library_permissions.py
+++ b/src/pullbox/utilities/executors/library_permissions.py
@@ -386,9 +386,12 @@ def _selected_roots(
         raise ValueError(f"Library root not found: {root_id}")
     if scope == "folder":
         selected_raw = Path(str(job_config.get("selected_path", "") or ""))
+        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
+        # The raw path has been constrained to enabled library roots above; this
+        # preserves the no-selected-symlink policy without probing arbitrary paths.
+        # codeql[py/path-injection]
         if selected_raw.is_symlink():
             raise ValueError("Selected folder cannot be a symlink")
-        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
         return [selected]
     if scope == "paths":
         paths = []
@@ -415,9 +418,12 @@ def _scoped_capability_roots(
         raise ValueError(f"Library root not found: {root_id}")
     if scope == "folder":
         selected_raw = Path(str(job_config.get("selected_path", "") or ""))
+        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
+        # The raw path has been constrained to enabled library roots above; this
+        # preserves the no-selected-symlink policy without probing arbitrary paths.
+        # codeql[py/path-injection]
         if selected_raw.is_symlink():
             raise ValueError("Selected folder cannot be a symlink")
-        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
         return [_containing_library_root(selected, roots)]
     if scope == "paths":
         scoped_roots: list[Path] = []

--- a/src/pullbox/utilities/executors/library_permissions.py
+++ b/src/pullbox/utilities/executors/library_permissions.py
@@ -22,6 +22,7 @@ from pullbox.core.library_permissions import (
     format_mode,
     parse_permission_mode,
 )
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.models.library import LibraryRoot
 from pullbox.utilities.base_executor import (
     ApplyResult,
@@ -384,18 +385,15 @@ def _selected_roots(
                 return [path]
         raise ValueError(f"Library root not found: {root_id}")
     if scope == "folder":
-        selected = Path(str(job_config.get("selected_path", "") or ""))
-        if selected.is_symlink():
+        selected_raw = Path(str(job_config.get("selected_path", "") or ""))
+        if selected_raw.is_symlink():
             raise ValueError("Selected folder cannot be a symlink")
-        if not selected.is_dir():
-            raise ValueError(f"Selected folder does not exist: {selected}")
-        _assert_inside_library_roots(selected, roots)
+        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
         return [selected]
     if scope == "paths":
         paths = []
         for path_value in job_config.get("file_paths", []):
-            path = Path(str(path_value))
-            _assert_inside_library_roots(path, roots)
+            path = resolve_path_inside_roots(str(path_value), roots)
             paths.append(path)
         return paths
     return []
@@ -416,16 +414,15 @@ def _scoped_capability_roots(
                 return [path]
         raise ValueError(f"Library root not found: {root_id}")
     if scope == "folder":
-        selected = Path(str(job_config.get("selected_path", "") or ""))
-        if selected.is_symlink():
+        selected_raw = Path(str(job_config.get("selected_path", "") or ""))
+        if selected_raw.is_symlink():
             raise ValueError("Selected folder cannot be a symlink")
-        if not selected.is_dir():
-            raise ValueError(f"Selected folder does not exist: {selected}")
+        selected = resolve_path_inside_roots(selected_raw, roots, require_dir=True)
         return [_containing_library_root(selected, roots)]
     if scope == "paths":
         scoped_roots: list[Path] = []
         for path_value in job_config.get("file_paths", []):
-            path = Path(str(path_value))
+            path = resolve_path_inside_roots(str(path_value), roots)
             root = _containing_library_root(path, roots)
             if root not in scoped_roots:
                 scoped_roots.append(root)
@@ -438,7 +435,7 @@ def _assert_inside_library_roots(path: Path, roots: list[Path]) -> None:
 
 
 def _containing_library_root(path: Path, roots: list[Path]) -> Path:
-    resolved_path = path.resolve(strict=False)
+    resolved_path = resolve_path_inside_roots(path, roots)
     for root in roots:
         resolved_root = root.resolve(strict=False)
         if resolved_path == resolved_root or resolved_path.is_relative_to(resolved_root):

--- a/src/pullbox/utilities/executors/mass_convert_pipeline.py
+++ b/src/pullbox/utilities/executors/mass_convert_pipeline.py
@@ -364,8 +364,11 @@ class MassConvertPipelineExecutor(JobExecutor):
         try:
             if not source.exists():
                 raise FileNotFoundError(f"Source file not found: {source}")
+            if 1 not in steps:
+                raise ValueError("Step 1 (convert to CBZ) is required for mass conversion")
 
             current_path = source
+            target_path = source.with_suffix(".cbz")
 
             # ── Step 1: Convert to CBZ ─────────────────────────
             if 1 in steps:
@@ -373,7 +376,6 @@ class MassConvertPipelineExecutor(JobExecutor):
                     _convert_sync,
                 )
 
-                target_path = source.with_suffix(".cbz")
                 log_entries.append(
                     (
                         "DEBUG",

--- a/src/pullbox/utilities/job_queue_worker_runtime.py
+++ b/src/pullbox/utilities/job_queue_worker_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any
 
 from pullbox.utilities.base_executor import ExecutionMode
@@ -34,12 +35,16 @@ def build_worker_runtime(
     """Build the worker pool and batch size for one utility dispatch run."""
     execution_mode = executor.get_execution_mode(config, job_context)
     batch_size = 1 if execution_mode == ExecutionMode.SERIAL else worker_count
-    try:
+    factory_signature = signature(worker_pool_factory)
+    accepts_execution_mode = "execution_mode" in factory_signature.parameters or any(
+        param.kind == Parameter.VAR_KEYWORD for param in factory_signature.parameters.values()
+    )
+    if accepts_execution_mode:
         worker_pool = worker_pool_factory(
             execution_mode=execution_mode,
             max_workers=worker_count,
         )
-    except TypeError:
+    else:
         worker_pool = worker_pool_factory(max_workers=worker_count)
     return WorkerRuntime(
         execution_mode=execution_mode,

--- a/src/pullbox/utilities/preview_builders.py
+++ b/src/pullbox/utilities/preview_builders.py
@@ -321,6 +321,27 @@ async def build_mass_rename_preview(
     if scope == "folder" and not body.file_paths:
         raise ValidationError("Choose at least one folder to preview this scope.")
 
+    request_paths = list(body.file_paths)
+    if scope != "library":
+        library_roots = await _load_enabled_library_root_paths(session)
+        if not library_roots:
+            raise ValidationError("No enabled library roots are available for this preview.")
+        require_dir = scope == "folder" or target == "folders"
+        require_file = target == "files" and scope == "manual"
+        resolved_paths: list[str] = []
+        for path_str in request_paths:
+            try:
+                resolved = resolve_path_inside_roots(
+                    path_str,
+                    library_roots,
+                    require_dir=require_dir,
+                    require_file=require_file,
+                )
+            except ValueError as exc:
+                raise ValidationError(str(exc)) from None
+            resolved_paths.append(str(resolved))
+        request_paths = resolved_paths
+
     naming_config = await _load_naming_config(session)
 
     preview_items: list[MassRenamePreviewItem] = []
@@ -336,13 +357,13 @@ async def build_mass_rename_preview(
         elif scope == "folder":
             folder_filters = [
                 LibraryFile.file_path.like(f"{folder_path.rstrip('/')}/%")
-                for folder_path in body.file_paths
+                for folder_path in request_paths
             ]
             query = query.where(or_(*folder_filters)).order_by(LibraryFile.file_path.asc())
             selected_paths = []
         else:
-            query = query.where(LibraryFile.file_path.in_(body.file_paths))
-            selected_paths = list(body.file_paths)
+            query = query.where(LibraryFile.file_path.in_(request_paths))
+            selected_paths = list(request_paths)
 
         result = await session.execute(query)
         matched_files = list(result.scalars().all())
@@ -464,15 +485,15 @@ async def build_mass_rename_preview(
                     Series.path == folder_path.rstrip("/"),
                     Series.path.like(f"{folder_path.rstrip('/')}/%"),
                 )
-                for folder_path in body.file_paths
+                for folder_path in request_paths
             ]
             series_query = series_query.where(or_(*series_folder_filters)).order_by(
                 Series.path.asc()
             )
             selected_paths = []
         else:
-            series_query = series_query.where(Series.path.in_(body.file_paths))
-            selected_paths = list(body.file_paths)
+            series_query = series_query.where(Series.path.in_(request_paths))
+            selected_paths = list(request_paths)
 
         series_result = await session.execute(series_query)
         all_series: Sequence[Series] = series_result.scalars().all()

--- a/src/pullbox/utilities/preview_builders.py
+++ b/src/pullbox/utilities/preview_builders.py
@@ -51,7 +51,11 @@ _MASS_CONVERT_SUPPORTED_FORMATS = {
 }
 
 
-def build_convert_preview_response(body: ConvertPreviewRequest) -> ConvertPreviewResponse:
+def build_convert_preview_response(
+    body: ConvertPreviewRequest,
+    *,
+    allowed_roots: Sequence[str | Path] | None = None,
+) -> ConvertPreviewResponse:
     """Preview files that would be converted without submitting a job."""
     from pullbox.utilities.executors.file_converter import build_convert_preview
 
@@ -61,6 +65,7 @@ def build_convert_preview_response(body: ConvertPreviewRequest) -> ConvertPrevie
             target_format=body.target_format,
             scope=body.scope,
             file_paths=body.file_paths,
+            allowed_roots=allowed_roots,
         )
         return result
     except ValueError as exc:

--- a/src/pullbox/utilities/preview_builders.py
+++ b/src/pullbox/utilities/preview_builders.py
@@ -14,6 +14,7 @@ from pullbox.core.exceptions import ValidationError
 from pullbox.core.filesystem_scan import iter_supported_files
 from pullbox.core.library_naming import build_series_folder_name, compute_target_filename
 from pullbox.core.library_policy import load_library_naming_policy
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.core.naming import (
     issue_type_uses_collection_template,
     normalize_issue_type_for_naming,
@@ -68,10 +69,17 @@ def build_convert_preview_response(body: ConvertPreviewRequest) -> ConvertPrevie
 
 def _is_relative_to(path: Path, other: Path) -> bool:
     try:
-        path.relative_to(other)
+        path.expanduser().resolve(strict=False).relative_to(
+            other.expanduser().resolve(strict=False)
+        )
         return True
     except ValueError:
         return False
+
+
+async def _load_enabled_library_root_paths(session: Any) -> list[Path]:
+    result = await session.execute(select(LibraryRoot.path).where(LibraryRoot.enabled.is_(True)))
+    return [Path(row[0]) for row in result.all()]
 
 
 def _infer_mass_convert_source_format(path: Path) -> str:
@@ -116,22 +124,34 @@ async def build_mass_convert_preview(
         if load_trash_context is None:
             raise ValidationError("trash_folder is required for this preview scope.")
         trash_dir, _ = await load_trash_context(session)
+    trash_dir = trash_dir.expanduser().resolve(strict=False)
+
+    library_roots: list[Path] = []
+    if scope in {"manual", "folder"}:
+        if session is None:
+            raise ValidationError("A database session is required for this preview scope.")
+        library_roots = await _load_enabled_library_root_paths(session)
+        if not library_roots:
+            raise ValidationError("No enabled library roots are available for this preview.")
 
     candidate_paths: list[Path] = []
 
     if scope == "manual":
         for path_str in body.file_paths:
-            path = Path(path_str)
-            if (
-                path.exists()
-                and path.is_file()
-                and path.suffix.lower() in _MASS_CONVERT_SUPPORTED_EXTS
-                and not _is_relative_to(path, trash_dir)
+            try:
+                path = resolve_path_inside_roots(path_str, library_roots, require_file=True)
+            except ValueError as exc:
+                raise ValidationError(str(exc)) from None
+            if path.suffix.lower() in _MASS_CONVERT_SUPPORTED_EXTS and not _is_relative_to(
+                path, trash_dir
             ):
                 candidate_paths.append(path)
     elif scope == "folder":
         for root_path in body.file_paths:
-            root = Path(root_path)
+            try:
+                root = resolve_path_inside_roots(root_path, library_roots, require_dir=True)
+            except ValueError as exc:
+                raise ValidationError(str(exc)) from None
             for path in iter_supported_files(root, _MASS_CONVERT_SUPPORTED_EXTS):
                 if _is_relative_to(path, trash_dir):
                     continue

--- a/src/pullbox/utilities/router.py
+++ b/src/pullbox/utilities/router.py
@@ -85,16 +85,22 @@ _background_tasks: set[asyncio.Task[None]] = set()
 
 async def _resolve_enabled_library_scan_root(session: DbSession, raw_path: str) -> Path:
     """Resolve a requested utility scan root under enabled library roots."""
+    roots = await _load_enabled_library_roots(session)
+    try:
+        return resolve_path_inside_roots(raw_path, roots, require_dir=True)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from None
+
+
+async def _load_enabled_library_roots(session: DbSession) -> list[Path]:
+    """Load enabled library roots for utility path validation."""
     roots_result = await session.execute(
         select(LibraryRoot.path).where(LibraryRoot.enabled.is_(True))
     )
     roots = [Path(row[0]) for row in roots_result.all() if row[0]]
     if not roots:
         raise ValidationError("No enabled library roots are available.")
-    try:
-        return resolve_path_inside_roots(raw_path, roots, require_dir=True)
-    except ValueError as exc:
-        raise ValidationError(str(exc)) from None
+    return roots
 
 
 def set_queue_manager(mgr: JobQueueManager) -> None:
@@ -486,9 +492,13 @@ async def get_queue_status(
 async def convert_preview(
     body: ConvertPreviewRequest,
     _user: InteractiveOperatorUser,
+    session: DbSession,
 ) -> ConvertPreviewResponse:
     """Preview files that would be converted without submitting a job."""
-    return build_convert_preview_response(body)
+    return build_convert_preview_response(
+        body,
+        allowed_roots=await _load_enabled_library_roots(session),
+    )
 
 
 @router.post("/mass-convert/preview", response_model=MassConvertPreviewResponse)

--- a/src/pullbox/utilities/router.py
+++ b/src/pullbox/utilities/router.py
@@ -14,8 +14,9 @@ from sqlalchemy import func as sa_func
 
 from pullbox.api.deps import DbSession, InteractiveOperatorUser  # noqa: TC001
 from pullbox.core.exceptions import NotFoundError, ValidationError
+from pullbox.core.library_root_resolution import resolve_path_inside_roots
 from pullbox.models.config import DEFAULT_SYSTEM_CONFIG, SystemConfig
-from pullbox.models.library import LibraryFile
+from pullbox.models.library import LibraryFile, LibraryRoot
 from pullbox.utilities.import_guards import (
     ensure_no_active_import_file_mutation,
     ensure_utility_job_allowed_during_import,
@@ -80,6 +81,20 @@ router = APIRouter(prefix="/utilities", tags=["utilities"], include_in_schema=Fa
 # Module-level reference — set during app startup
 _queue_manager: JobQueueManager | None = None
 _background_tasks: set[asyncio.Task[None]] = set()
+
+
+async def _resolve_enabled_library_scan_root(session: DbSession, raw_path: str) -> Path:
+    """Resolve a requested utility scan root under enabled library roots."""
+    roots_result = await session.execute(
+        select(LibraryRoot.path).where(LibraryRoot.enabled.is_(True))
+    )
+    roots = [Path(row[0]) for row in roots_result.all() if row[0]]
+    if not roots:
+        raise ValidationError("No enabled library roots are available.")
+    try:
+        return resolve_path_inside_roots(raw_path, roots, require_dir=True)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from None
 
 
 def set_queue_manager(mgr: JobQueueManager) -> None:
@@ -570,7 +585,8 @@ async def db_check_preview(
     if "stale" in checks and body.library_root:
         known_paths_result = await session.execute(select(LibraryFile.file_path))
         known_paths = {row[0] for row in known_paths_result.all()}
-        stale_files = detect_stale_files(Path(body.library_root), known_paths)
+        scan_root = await _resolve_enabled_library_scan_root(session, body.library_root)
+        stale_files = detect_stale_files(scan_root, known_paths)
         for idx, stale in enumerate(stale_files, start=1):
             file_path = str(stale.get("path") or "")
             findings.append(

--- a/tests/api/test_comicvine_key.py
+++ b/tests/api/test_comicvine_key.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import sys
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -275,3 +276,33 @@ class TestSaveComicVineKey:
             headers=_csrf_header_for(client),
         )
         assert resp.status_code in (400, 422)
+
+
+class TestComicVineKeyValidation:
+    """POST /api/v1/config/comicvine/test response safety tests."""
+
+    @pytest.mark.asyncio
+    async def test_test_key_hides_unexpected_exception_details(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        with patch(
+            "pullbox.providers.metadata.comicvine.ComicVineProvider.test_connection",
+            new=AsyncMock(
+                side_effect=RuntimeError(
+                    "boom reading /config/certs/server.key from https://internal.example"
+                )
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/config/comicvine/test",
+                json={"api_key": "pullbox-test-comicvine-key-1234"},
+                headers=_csrf_header_for(client),
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {
+            "healthy": False,
+            "message": "Connection failed. Check Pullbox logs for details.",
+        }

--- a/tests/api/test_utilities_preview_api.py
+++ b/tests/api/test_utilities_preview_api.py
@@ -565,6 +565,26 @@ async def test_mass_rename_preview_supports_library_and_folder_scopes(
 
 
 @pytest.mark.asyncio
+async def test_mass_rename_preview_rejects_manual_paths_outside_library_roots(
+    authenticated_client,
+    preview_paths: dict[str, str],
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    assert preview_paths["library_root"]
+    outside_file = tmp_path / "outside.cbz"
+    outside_file.write_text("outside")
+
+    response = await authenticated_client.post(
+        "/api/v1/utilities/rename/preview",
+        json={"target": "files", "scope": "manual", "file_paths": [str(outside_file)]},
+        headers=_csrf_header_for(authenticated_client),
+    )
+
+    assert response.status_code == 422
+    assert "outside enabled library roots" in response.text
+
+
+@pytest.mark.asyncio
 async def test_db_check_preview_returns_orphan_and_stale_findings(
     authenticated_client,
     preview_paths: dict[str, str],
@@ -603,6 +623,30 @@ async def test_db_check_preview_returns_orphan_and_stale_findings(
         for finding in data["findings"]
         if finding["check_type"] == "stale"
     )
+
+
+@pytest.mark.asyncio
+async def test_db_check_preview_rejects_stale_scan_outside_library_roots(
+    authenticated_client,
+    preview_paths: dict[str, str],
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    assert preview_paths["library_root"]
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    (outside_root / "stray.cbz").write_text("stray")
+
+    response = await authenticated_client.post(
+        "/api/v1/utilities/db-check/preview",
+        json={
+            "checks": ["stale"],
+            "library_root": str(outside_root),
+        },
+        headers=_csrf_header_for(authenticated_client),
+    )
+
+    assert response.status_code == 422
+    assert "outside enabled library roots" in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_utilities_preview_api.py
+++ b/tests/api/test_utilities_preview_api.py
@@ -344,6 +344,33 @@ async def test_convert_preview_returns_output_paths_with_target_extension(
 
 
 @pytest.mark.asyncio
+async def test_convert_preview_rejects_files_outside_library_roots(
+    authenticated_client,
+    preview_paths: dict[str, str],
+    tmp_path: Path,
+) -> None:  # type: ignore[no-untyped-def]
+    assert preview_paths["library_root"]
+    outside = tmp_path / "outside-import.cbr"
+    outside.write_text("outside")
+
+    response = await authenticated_client.post(
+        "/api/v1/utilities/convert/preview",
+        json={
+            "source_format": "cbr",
+            "target_format": "cbz",
+            "scope": "manual",
+            "file_paths": [str(outside)],
+        },
+        headers=_csrf_header_for(authenticated_client),
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert data["files"] == []
+
+
+@pytest.mark.asyncio
 async def test_mass_rename_preview_returns_folder_and_file_proposals(
     authenticated_client,
     preview_paths: dict[str, str],

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,41 @@
+"""Tests for Pullbox management CLI contracts."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from pullbox import cli
+
+
+def test_reset_password_parser_does_not_accept_cleartext_password_argument() -> None:
+    parser = cli.build_parser()
+    args = parser.parse_args(["reset-password", "--user", "admin", "--password-stdin"])
+
+    assert args.password_stdin is True
+    with pytest.raises(SystemExit):
+        parser.parse_args(["reset-password", "--user", "admin", "--password", "Secret1!"])
+
+
+def test_read_password_from_stdin_strips_line_ending(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("NewPass1!\n"))
+
+    assert cli._read_password(password_stdin=True) == "NewPass1!"
+
+
+def test_read_password_prompts_and_confirms(monkeypatch: pytest.MonkeyPatch) -> None:
+    prompts = iter(["NewPass1!", "NewPass1!"])
+    monkeypatch.setattr(cli.getpass, "getpass", lambda _prompt: next(prompts))
+
+    assert cli._read_password(password_stdin=False) == "NewPass1!"
+
+
+def test_read_password_rejects_prompt_confirmation_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts = iter(["NewPass1!", "Different1!"])
+    monkeypatch.setattr(cli.getpass, "getpass", lambda _prompt: next(prompts))
+
+    with pytest.raises(SystemExit):
+        cli._read_password(password_stdin=False)

--- a/tests/unit/test_comics_directory.py
+++ b/tests/unit/test_comics_directory.py
@@ -71,6 +71,21 @@ class TestSetComicsDirectory:
         assert row.value_type == "string"
 
     @pytest.mark.asyncio
+    async def test_stores_resolved_directory_path(
+        self, db_session: AsyncSession, tmp_path: Path
+    ) -> None:
+        comics_dir = tmp_path / "comics"
+        comics_dir.mkdir()
+        spelled_with_parent = comics_dir / ".." / "comics"
+
+        root = await set_comics_directory(db_session, spelled_with_parent)
+
+        row = await db_session.get(SystemConfig, "comics_directory")
+        assert row is not None
+        assert row.value == str(comics_dir.resolve())
+        assert root.path == str(comics_dir.resolve())
+
+    @pytest.mark.asyncio
     async def test_creates_library_root_for_new_path(
         self, db_session: AsyncSession, tmp_path: Path
     ) -> None:

--- a/tests/unit/test_comicvine_provider.py
+++ b/tests/unit/test_comicvine_provider.py
@@ -94,6 +94,46 @@ async def test_search_series_globally_reuses_short_lived_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_series_globally_cache_is_not_namespaced_by_api_key() -> None:
+    first_provider = ComicVineProvider(api_key="first-cache-key", rate_limit=999_999)
+    second_provider = ComicVineProvider(api_key="second-cache-key", rate_limit=999_999)
+    first_request = AsyncMock(
+        return_value={
+            "number_of_total_results": 1,
+            "results": [_volume_item(3500, "Shared Cache Test", 2026)],
+        }
+    )
+    second_request = AsyncMock(
+        return_value={
+            "number_of_total_results": 1,
+            "results": [_volume_item(3501, "Shared Cache Test", 2026)],
+        }
+    )
+    first_provider._request = first_request  # type: ignore[method-assign]
+    second_provider._request = second_request  # type: ignore[method-assign]
+
+    try:
+        first, first_total = await first_provider.search_series_globally(
+            "Shared Cache Test",
+            max_results=10,
+        )
+        second, second_total = await second_provider.search_series_globally(
+            "Shared Cache Test",
+            max_results=10,
+        )
+    finally:
+        await first_provider._client.aclose()
+        await second_provider._client.aclose()
+
+    assert first_total == 1
+    assert second_total == 1
+    assert [result.provider_id for result in first] == ["3500"]
+    assert [result.provider_id for result in second] == ["3500"]
+    first_request.assert_awaited_once()
+    second_request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_search_series_globally_collapses_concurrent_identical_requests() -> None:
     provider = ComicVineProvider(api_key="single-flight-test-key", rate_limit=999_999)
     request_started = asyncio.Event()

--- a/tests/unit/test_comicvine_series_search.py
+++ b/tests/unit/test_comicvine_series_search.py
@@ -25,6 +25,13 @@ def test_parse_series_query_extracts_parenthesized_start_year_hint() -> None:
     assert parsed.year_hint == 2024
 
 
+def test_parse_series_query_extracts_bracketed_start_year_hint() -> None:
+    parsed = parse_comicvine_series_query("x-men [2024]")
+
+    assert parsed.title_query == "x-men"
+    assert parsed.year_hint == 2024
+
+
 def test_parse_series_query_does_not_treat_issue_or_title_numbers_as_year_hints() -> None:
     prog = parse_comicvine_series_query("2000AD prog 2482")
     historical_title = parse_comicvine_series_query("Marvel 1602")

--- a/tests/unit/test_cover_storage.py
+++ b/tests/unit/test_cover_storage.py
@@ -52,6 +52,14 @@ class TestFindCoverFile:
         (tmp_path / "issue_001.jpg").write_text("img")
         assert _find_cover_file(tmp_path, "issue_001") == tmp_path / "issue_001.jpg"
 
+    def test_rejects_stem_path_traversal(self, tmp_path: Path) -> None:
+        cover_dir = tmp_path / "covers"
+        cover_dir.mkdir()
+        outside = tmp_path / "outside.jpg"
+        outside.write_text("img")
+
+        assert _find_cover_file(cover_dir, "../outside") is None
+
 
 class TestResolveCoversDir:
     """Cover directory resolution prefers {comics_dir}/.covers/ over legacy path."""

--- a/tests/unit/test_filesystem_scan.py
+++ b/tests/unit/test_filesystem_scan.py
@@ -70,3 +70,22 @@ class TestIterSupportedFiles:
                 "error": f"[Errno 13] Permission denied: '{root / 'secret'}'",
             }
         ]
+
+    def test_skips_walk_entries_outside_resolved_root(self, tmp_path: Path, monkeypatch) -> None:
+        from pullbox.core import filesystem_scan as fs_mod
+
+        outside = tmp_path.parent / "outside"
+        outside.mkdir(exist_ok=True)
+        escaped = outside / "escaped.cbz"
+        escaped.write_text("escaped")
+
+        def fake_walk(
+            _root: Path,
+            onerror,
+        ):
+            assert onerror is not None
+            yield (os.fspath(outside), [], [escaped.name])
+
+        monkeypatch.setattr(fs_mod.os, "walk", fake_walk)
+
+        assert list(iter_supported_files(tmp_path, frozenset({".cbz"}))) == []

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -11,6 +11,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
+CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 
 ACTION_REF_RE = re.compile(
     r"""
@@ -125,6 +126,22 @@ def test_security_workflow_keeps_required_scanners_and_schedule() -> None:
     ]
     for marker in required_markers:
         assert marker in text
+
+
+def test_codeql_analysis_uses_product_scope_config() -> None:
+    security_workflow = WORKFLOW_DIR / "security.yml"
+    workflow_text = security_workflow.read_text(encoding="utf-8")
+    config = _load_yaml(CODEQL_CONFIG)
+
+    assert "config-file: ./.github/codeql/codeql-config.yml" in workflow_text
+    assert config.get("name") == "pullbox-product-runtime"
+    assert config.get("paths") == ["src/pullbox"]
+    assert {
+        "tests/**",
+        "scripts/**",
+        "docs/**",
+        "performance-sprint/**",
+    } <= set(config.get("paths-ignore", []))
 
 
 def test_local_security_script_writes_valid_safety_json_artifact() -> None:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -12,6 +12,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
 CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
+GRYPE_CONFIG = REPO_ROOT / ".grype.yaml"
 
 ACTION_REF_RE = re.compile(
     r"""
@@ -177,6 +178,17 @@ def test_docker_workflow_runs_grype_before_publish() -> None:
     assert "anchore/scan-action@" in docker_workflow
     assert "config: .grype.yaml" in docker_workflow
     assert push_job.get("needs") == ["build", "scan", "smoke-test"]
+
+
+def test_grype_config_tracks_current_dhi_runtime() -> None:
+    config_text = GRYPE_CONFIG.read_text(encoding="utf-8")
+    config = _load_yaml(GRYPE_CONFIG)
+
+    assert "Docker Hardened Images Python 3.14 on Debian 13" in config_text
+    assert "python:3.13-slim" not in config_text
+    assert "CVE-2026-7210" in config_text
+    assert "3.14.6" in config_text
+    assert config.get("ignore")
 
 
 def test_docker_workflow_signs_and_verifies_published_images() -> None:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -134,6 +134,8 @@ def test_codeql_analysis_uses_product_scope_config() -> None:
     config = _load_yaml(CODEQL_CONFIG)
 
     assert "config-file: ./.github/codeql/codeql-config.yml" in workflow_text
+    assert "queries: +security-extended" in workflow_text
+    assert "security-and-quality" not in workflow_text
     assert config.get("name") == "pullbox-product-runtime"
     assert config.get("paths") == ["src/pullbox"]
     assert {

--- a/tests/unit/test_library_root_resolution.py
+++ b/tests/unit/test_library_root_resolution.py
@@ -11,6 +11,7 @@ from pullbox.core.library_root_resolution import (
     materialize_series_path,
     path_is_inside_root,
     resolve_library_root,
+    resolve_path_inside_roots,
 )
 from pullbox.models.config import SystemConfig
 from pullbox.models.library import LibraryRoot
@@ -99,3 +100,43 @@ def test_path_is_inside_root_and_materialize_series_path(tmp_path: Path) -> None
 
     assert series.path == str(series_path)
     assert series.library_root_id == root.id
+
+
+def test_resolve_path_inside_roots_returns_resolved_child(tmp_path: Path) -> None:
+    root = tmp_path / "library"
+    nested = root / "Series"
+    nested.mkdir(parents=True)
+
+    resolved = resolve_path_inside_roots(nested / ".." / "Series", [root], require_dir=True)
+
+    assert resolved == nested.resolve()
+
+
+def test_resolve_path_inside_roots_rejects_prefix_sibling(tmp_path: Path) -> None:
+    root = tmp_path / "library"
+    sibling = tmp_path / "library-other"
+    root.mkdir()
+    sibling.mkdir()
+
+    with pytest.raises(ValueError, match="outside"):
+        resolve_path_inside_roots(sibling, [root], require_dir=True)
+
+
+def test_resolve_path_inside_roots_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "library"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    escape = root / "escape"
+    escape.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="outside"):
+        resolve_path_inside_roots(escape, [root], require_dir=True)
+
+
+def test_resolve_path_inside_roots_enforces_file_requirement(tmp_path: Path) -> None:
+    root = tmp_path / "library"
+    root.mkdir()
+
+    with pytest.raises(ValueError, match="file"):
+        resolve_path_inside_roots(root, [root], require_file=True)

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -80,6 +80,12 @@ class TestSanitizeForFilesystem:
             == "Batman - Superman - World's Finest"
         )
 
+    def test_many_slashes_are_replaced_linearly(self) -> None:
+        result = sanitize_for_filesystem("Batman" + " /" * 25 + " Superman")
+
+        assert result.startswith("Batman -")
+        assert result.endswith("Superman")
+
     def test_colon_replacement_dash(self) -> None:
         assert (
             sanitize_for_filesystem("Batman: Year One", colon_replacement="dash")

--- a/tests/unit/test_utility_job_worker_runtime.py
+++ b/tests/unit/test_utility_job_worker_runtime.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any
+from inspect import Parameter, Signature
+from typing import Any, ClassVar
 
 import pytest
 
@@ -35,6 +36,25 @@ class ModernWorkerPool:
 class LegacyWorkerPool:
     def __init__(self, *, max_workers: int) -> None:
         self.max_workers = max_workers
+
+
+class RecordingLegacyWorkerPool:
+    __signature__ = Signature(
+        [
+            Parameter(
+                "max_workers",
+                Parameter.KEYWORD_ONLY,
+                annotation=int,
+            )
+        ]
+    )
+    calls: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__class__.calls.append(kwargs)
+        if "execution_mode" in kwargs:
+            raise TypeError("execution_mode is not supported")
+        self.max_workers = kwargs["max_workers"]
 
 
 class StreamExecutor(ModeExecutor):
@@ -96,6 +116,21 @@ def test_build_worker_runtime_preserves_legacy_worker_pool_fallback() -> None:
     assert runtime.execution_mode == ExecutionMode.PROCESS
     assert runtime.batch_size == 2
     assert runtime.worker_pool.max_workers == 2
+
+
+def test_build_worker_runtime_does_not_probe_legacy_pool_with_unsupported_kwargs() -> None:
+    RecordingLegacyWorkerPool.calls = []
+
+    runtime = build_worker_runtime(
+        executor=ModeExecutor(ExecutionMode.PROCESS),
+        config={},
+        job_context=None,
+        worker_count=2,
+        worker_pool_factory=RecordingLegacyWorkerPool,
+    )
+
+    assert runtime.worker_pool.max_workers == 2
+    assert RecordingLegacyWorkerPool.calls == [{"max_workers": 2}]
 
 
 @pytest.mark.asyncio

--- a/tests/utilities/test_converter_preview.py
+++ b/tests/utilities/test_converter_preview.py
@@ -134,6 +134,23 @@ class TestPreviewLogic:
         assert len(result.files) == 1
         assert result.files[0].output_path.endswith(".cbz")
 
+    def test_preview_reports_resolved_paths(self, tmp_path: Path) -> None:
+        from pullbox.utilities.executors.file_converter import build_convert_preview
+
+        source_dir = tmp_path / "comics"
+        f1 = _create_test_cb7(source_dir / "batman_001.cb7")
+
+        result = build_convert_preview(
+            source_format="cb7",
+            target_format="cbz",
+            scope="manual",
+            file_paths=[str(source_dir / ".." / "comics" / f1.name)],
+        )
+
+        assert result.total_count == 1
+        assert result.files[0].path == str(f1.resolve())
+        assert result.files[0].output_path == str(f1.resolve().with_suffix(".cbz"))
+
     def test_preview_truncated_at_100(self, tmp_path: Path) -> None:
         """Large file list truncated to 100 in response, total_count accurate."""
         from pullbox.utilities.executors.file_converter import build_convert_preview

--- a/tests/utilities/test_library_permissions_executor.py
+++ b/tests/utilities/test_library_permissions_executor.py
@@ -351,7 +351,7 @@ class TestGenerateItems:
     @pytest.mark.asyncio
     async def test_folder_scope_rejects_selected_symlink(self, tmp_path: Path) -> None:
         root = tmp_path / "library"
-        target = tmp_path / "outside"
+        target = root / "target"
         root.mkdir()
         target.mkdir()
         selected = root / "linked-folder"

--- a/tests/utilities/test_mass_convert_pipeline.py
+++ b/tests/utilities/test_mass_convert_pipeline.py
@@ -132,6 +132,30 @@ class TestValidateConfig:
         errors = executor.validate_config({"steps": [2, 4]})
         assert any("step 1" in e.lower() or "convert" in e.lower() for e in errors)
 
+    def test_process_item_fails_safely_when_step_1_is_missing(self, tmp_path: Path) -> None:
+        """Direct executor calls should not mutate files when config validation is bypassed."""
+        source = _create_test_cbz(tmp_path / "already.cbz")
+        trash_dir = tmp_path / ".trash"
+
+        executor = MassConvertPipelineExecutor()
+        result = executor.process_item(
+            item_data={
+                "id": "invalid-steps",
+                "file_path": str(source),
+                "operation": "pipeline",
+                "metadata": {"Series": "Already"},
+            },
+            job_config={
+                "steps": [2],
+                "trash_folder": str(trash_dir),
+            },
+        )
+
+        assert result.result == ItemResult.FAILED
+        assert "step 1" in (result.error_message or "").lower()
+        assert source.exists()
+        assert not trash_dir.exists()
+
     def test_valid_full_pipeline(self) -> None:
         executor = MassConvertPipelineExecutor()
         errors = executor.validate_config(

--- a/tests/utilities/test_mass_convert_preview.py
+++ b/tests/utilities/test_mass_convert_preview.py
@@ -2,15 +2,32 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from pullbox.core.exceptions import ValidationError
 from pullbox.utilities.preview_builders import build_mass_convert_preview
 from pullbox.utilities.schemas import MassConvertPreviewRequest
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class _SessionResult:
+    def __init__(self, rows: list[tuple[str]]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[tuple[str]]:
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, root_path: Path) -> None:
+        self.root_path = root_path
+
+    async def execute(self, _stmt: Any) -> _SessionResult:
+        return _SessionResult([(str(self.root_path),)])
 
 
 @pytest.mark.asyncio
@@ -33,7 +50,7 @@ async def test_mass_convert_preview_folder_scope_excludes_trash_folder(
             file_paths=[str(library)],
             trash_folder=str(trash),
         ),
-        session=None,
+        session=_FakeSession(library),
         load_trash_context=None,
     )
 
@@ -49,9 +66,11 @@ async def test_mass_convert_preview_folder_scope_excludes_trash_folder(
 async def test_mass_convert_preview_manual_scope_infers_supported_formats(
     tmp_path: Path,
 ) -> None:
-    pdf = tmp_path / "Annual.pdf"
-    cb7 = tmp_path / "Special.cb7"
-    ignored = tmp_path / "notes.txt"
+    library = tmp_path / "library"
+    library.mkdir()
+    pdf = library / "Annual.pdf"
+    cb7 = library / "Special.cb7"
+    ignored = library / "notes.txt"
     pdf.write_bytes(b"pdf")
     cb7.write_bytes(b"cb7")
     ignored.write_bytes(b"text")
@@ -62,7 +81,7 @@ async def test_mass_convert_preview_manual_scope_infers_supported_formats(
             file_paths=[str(pdf), str(cb7), str(ignored)],
             trash_folder=str(tmp_path / ".trash"),
         ),
-        session=None,
+        session=_FakeSession(library),
         load_trash_context=None,
     )
 
@@ -71,3 +90,26 @@ async def test_mass_convert_preview_manual_scope_infers_supported_formats(
         ("Annual.pdf", "PDF"),
         ("Special.cb7", "CB7"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_mass_convert_preview_rejects_paths_outside_library_roots(
+    tmp_path: Path,
+) -> None:
+    library = tmp_path / "library"
+    outside = tmp_path / "outside"
+    library.mkdir()
+    outside.mkdir()
+    pdf = outside / "Annual.pdf"
+    pdf.write_bytes(b"pdf")
+
+    with pytest.raises(ValidationError, match="outside"):
+        await build_mass_convert_preview(
+            MassConvertPreviewRequest(
+                scope="manual",
+                file_paths=[str(pdf)],
+                trash_folder=str(tmp_path / ".trash"),
+            ),
+            session=_FakeSession(library),
+            load_trash_context=None,
+        )


### PR DESCRIPTION
## Summary

This PR performs the first v1 code-scanning triage pass for the public repo launch gate.

It keeps the gate focused on shipped runtime security risk by scoping CodeQL to product code and security queries, fixes the high-signal runtime findings we identified, and refreshes Grype base-image triage against the current DHI Python 3.14 / Debian 13 image.

## Changes

- Scope CodeQL to `src/pullbox` runtime code and use `security-extended` instead of security-and-quality noise.
- Harden runtime findings around password reset input, worker pool compatibility, utility preview path containment, path-root validation, regex cleanup, ComicVine API key cache keys, ComicVine error detail exposure, and type-only import cycles.
- Refresh `.grype.yaml` suppressions with current package/version-scoped DHI evidence and workflow contract coverage.
- Add regression tests and workflow contracts for the security scope and fixes.

## Verification

- `make workflow-hygiene`
- `make secret-scan`
- `make security-check`
- `grype pullbox:ci-scan -c .grype.yaml --fail-on high`
- `make ci-full`

## Notes

GitHub code-scanning alerts will need to be refreshed after this PR's Security workflow runs. The goal is zero untriaged v1 alerts: fixed, scoped out as non-runtime, or documented/dismissed with rationale.
