### PR TITLE
Add CodeQL branch probe

### DIFF
--- a/.github/scripts/codeql-alert-summary.py
+++ b/.github/scripts/codeql-alert-summary.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Summarize CodeQL alerts for the ref analyzed by a branch probe workflow."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import Counter
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+API_VERSION = "2026-03-10"
+DEFAULT_POLL_ATTEMPTS = 12
+DEFAULT_POLL_SECONDS = 10
+
+
+@dataclass(frozen=True)
+class GitHubContext:
+    api_url: str
+    repository: str
+    token: str
+    ref: str
+    sha: str
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _context() -> GitHubContext:
+    token = _env("GITHUB_TOKEN") or _env("GH_TOKEN")
+    repository = _env("GITHUB_REPOSITORY")
+    ref = _env("PULLBOX_CODEQL_PROBE_REF") or _env("GITHUB_REF")
+    sha = _env("PULLBOX_CODEQL_PROBE_SHA") or _env("GITHUB_SHA")
+    missing = [
+        name
+        for name, value in {
+            "GITHUB_TOKEN": token,
+            "GITHUB_REPOSITORY": repository,
+            "GITHUB_REF": ref,
+            "GITHUB_SHA": sha,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(f"Missing required environment values: {', '.join(missing)}")
+    return GitHubContext(
+        api_url=_env("GITHUB_API_URL", "https://api.github.com").rstrip("/"),
+        repository=repository,
+        token=token,
+        ref=ref,
+        sha=sha,
+    )
+
+
+def _api_get(context: GitHubContext, path: str, params: dict[str, str]) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(params)
+    url = f"{context.api_url}{path}?{query}"
+    items: list[dict[str, Any]] = []
+    while url:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {context.token}",
+                "X-GitHub-Api-Version": API_VERSION,
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                if isinstance(payload, list):
+                    items.extend(item for item in payload if isinstance(item, dict))
+                else:
+                    raise RuntimeError(f"Expected list response from GitHub API: {path}")
+                url = _next_link(response.headers.get("Link", ""))
+        except urllib.error.HTTPError as exc:
+            body = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"GitHub API request failed: {exc.code} {body}") from exc
+    return items
+
+
+def _next_link(link_header: str) -> str:
+    for part in link_header.split(","):
+        url_part, _, rel_part = part.partition(";")
+        if 'rel="next"' not in rel_part:
+            continue
+        return url_part.strip().removeprefix("<").removesuffix(">")
+    return ""
+
+
+def _latest_analysis(context: GitHubContext) -> dict[str, Any] | None:
+    owner, repo = context.repository.split("/", maxsplit=1)
+    path = f"/repos/{owner}/{repo}/code-scanning/analyses"
+    analyses = _api_get(context, path, {"per_page": "100", "tool_name": "CodeQL"})
+    matches = [
+        analysis
+        for analysis in analyses
+        if analysis.get("ref") == context.ref and analysis.get("commit_sha") == context.sha
+    ]
+    if not matches:
+        return None
+    return sorted(matches, key=lambda item: item.get("created_at", ""), reverse=True)[0]
+
+
+def _alerts_for_state(context: GitHubContext, state: str) -> list[dict[str, Any]]:
+    owner, repo = context.repository.split("/", maxsplit=1)
+    path = f"/repos/{owner}/{repo}/code-scanning/alerts"
+    return _api_get(
+        context,
+        path,
+        {
+            "state": state,
+            "per_page": "100",
+            "tool_name": "CodeQL",
+            "ref": context.ref,
+        },
+    )
+
+
+def _poll_latest_analysis(context: GitHubContext) -> dict[str, Any] | None:
+    attempts = int(_env("PULLBOX_CODEQL_SUMMARY_POLL_ATTEMPTS", str(DEFAULT_POLL_ATTEMPTS)))
+    wait_seconds = int(_env("PULLBOX_CODEQL_SUMMARY_POLL_SECONDS", str(DEFAULT_POLL_SECONDS)))
+    for attempt in range(1, attempts + 1):
+        analysis = _latest_analysis(context)
+        if analysis is not None:
+            return analysis
+        if attempt < attempts:
+            print(
+                f"CodeQL analysis for {context.ref}@{context.sha[:12]} is not indexed yet; "
+                f"waiting {wait_seconds}s..."
+            )
+            time.sleep(wait_seconds)
+    return None
+
+
+def _rule_rows(alerts: Iterable[dict[str, Any]]) -> list[tuple[str, str, int]]:
+    counts: Counter[tuple[str, str]] = Counter()
+    for alert in alerts:
+        rule = alert.get("rule") if isinstance(alert.get("rule"), dict) else {}
+        rule_id = str(rule.get("id") or "unknown")
+        name = str(rule.get("name") or rule_id)
+        counts[(rule_id, name)] += 1
+    return [(rule_id, name, count) for (rule_id, name), count in counts.most_common()]
+
+
+def _markdown_table(rows: list[tuple[str, str, int]]) -> str:
+    if not rows:
+        return "_None._"
+    lines = ["| Rule | Name | Count |", "| --- | --- | ---: |"]
+    for rule_id, name, count in rows:
+        lines.append(f"| `{rule_id}` | {name} | {count} |")
+    return "\n".join(lines)
+
+
+def _append_step_summary(markdown: str) -> None:
+    summary_path = _env("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as summary:
+        summary.write(markdown)
+        summary.write("\n")
+
+
+def main() -> int:
+    context = _context()
+    analysis = _poll_latest_analysis(context)
+    open_alerts = _alerts_for_state(context, "open")
+    dismissed_alerts = _alerts_for_state(context, "dismissed")
+    fixed_alerts = _alerts_for_state(context, "fixed")
+
+    lines = [
+        "## CodeQL Branch Probe",
+        "",
+        f"- Ref: `{context.ref}`",
+        f"- Commit: `{context.sha}`",
+    ]
+    if analysis:
+        lines.extend(
+            [
+                f"- Analysis ID: `{analysis.get('id')}`",
+                f"- Rules evaluated: `{analysis.get('rules_count', 'unknown')}`",
+                f"- Raw results: `{analysis.get('results_count', 'unknown')}`",
+            ]
+        )
+    else:
+        lines.append("- Analysis: not visible through the API before polling ended")
+
+    lines.extend(
+        [
+            f"- Open alerts: `{len(open_alerts)}`",
+            f"- Dismissed/triaged alerts: `{len(dismissed_alerts)}`",
+            f"- Fixed alerts on this ref: `{len(fixed_alerts)}`",
+            "",
+            "### Open Alerts By Rule",
+            _markdown_table(_rule_rows(open_alerts)),
+            "",
+            "### Dismissed/Triaged Alerts By Rule",
+            _markdown_table(_rule_rows(dismissed_alerts)),
+        ]
+    )
+    output = "\n".join(lines)
+    print(output)
+    _append_step_summary(output)
+
+    fail_on_open = _env("PULLBOX_CODEQL_BRANCH_PROBE_FAIL_ON_OPEN").lower() == "true"
+    if fail_on_open and open_alerts:
+        print(
+            f"::error::CodeQL branch probe found {len(open_alerts)} open alert(s) "
+            f"for {context.ref}."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"::warning::Unable to summarize CodeQL branch alerts: {exc}", file=sys.stderr)
+        raise

--- a/.github/workflows/codeql-branch-probe.yml
+++ b/.github/workflows/codeql-branch-probe.yml
@@ -1,0 +1,59 @@
+---
+# Pullbox CodeQL Branch Probe
+# Fast feedback for trusted security-cleanup branches without waiting for a
+# default-branch merge to refresh the Security and quality dashboard.
+#
+# Security: All actions pinned to full SHA. No pull_request_target.
+# This workflow intentionally does not run on pull_request.
+
+name: CodeQL Branch Probe
+
+on:
+  push:
+    branches:
+      - develop
+      - feature/code-scanning-*
+      - feature/codeql-*
+      - feature/security-*
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-branch-probe-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codeql-branch-probe:
+    name: CodeQL Branch Probe
+    if: github.repository_visibility == 'public' || vars.PULLBOX_ENABLE_CODEQL == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      actions: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          languages: python
+          queries: +security-extended
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        with:
+          category: "/language:python"
+
+      - name: Summarize CodeQL alerts for refs/heads/<branch>
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PULLBOX_CODEQL_PROBE_REF: ${{ github.ref }}
+          PULLBOX_CODEQL_PROBE_SHA: ${{ github.sha }}
+          PULLBOX_CODEQL_BRANCH_PROBE_FAIL_ON_OPEN: ${{ vars.PULLBOX_CODEQL_BRANCH_PROBE_FAIL_ON_OPEN }}
+        run: python .github/scripts/codeql-alert-summary.py

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -147,6 +147,43 @@ def test_codeql_analysis_uses_product_scope_config() -> None:
     } <= set(config.get("paths-ignore", []))
 
 
+def test_codeql_branch_probe_scans_trusted_push_refs_with_summary() -> None:
+    workflow_path = WORKFLOW_DIR / "codeql-branch-probe.yml"
+    data = _load_yaml(workflow_path)
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+
+    # PyYAML follows YAML 1.1 and parses the key "on" as True.
+    triggers = data.get(True, data.get("on"))
+    assert isinstance(triggers, dict)
+    assert "pull_request" not in triggers
+
+    push = triggers.get("push")
+    assert isinstance(push, dict)
+    assert push.get("branches") == [
+        "develop",
+        "feature/code-scanning-*",
+        "feature/codeql-*",
+        "feature/security-*",
+    ]
+
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict)
+    codeql_job = jobs.get("codeql-branch-probe")
+    assert isinstance(codeql_job, dict)
+    assert codeql_job.get("runs-on") == "ubuntu-latest"
+
+    permissions = codeql_job.get("permissions")
+    assert isinstance(permissions, dict)
+    assert permissions.get("contents") == "read"
+    assert permissions.get("actions") == "read"
+    assert permissions.get("security-events") == "write"
+
+    assert "config-file: ./.github/codeql/codeql-config.yml" in workflow_text
+    assert "queries: +security-extended" in workflow_text
+    assert "python .github/scripts/codeql-alert-summary.py" in workflow_text
+    assert "refs/heads/<branch>" in workflow_text
+
+
 def test_local_security_script_writes_valid_safety_json_artifact() -> None:
     script = (REPO_ROOT / "scripts" / "security_check.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary\n- add a trusted-branch CodeQL-only probe workflow for faster alert feedback\n- add a ref-aware code-scanning alert summary helper\n- add workflow contract coverage for the probe behavior\n\n## Verification\n- pytest tests/unit/test_github_actions_security_contracts.py -q\n- ruff check .github/scripts/codeql-alert-summary.py tests/unit/test_github_actions_security_contracts.py\n- make workflow-hygiene