### PR TITLE
Fix permissions preview for symlinked roots

### DIFF
--- a/src/pullbox/utilities/preview_builders.py
+++ b/src/pullbox/utilities/preview_builders.py
@@ -122,13 +122,22 @@ def _lexical_absolute_path(path: str | Path) -> Path:
     return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
 
 
+def _generated_preview_root_paths(root: str | Path) -> tuple[Path, ...]:
+    """Return acceptable root prefixes for executor-generated preview paths."""
+    lexical_root = _lexical_absolute_path(root)
+    resolved_root = Path(root).expanduser().resolve(strict=False)
+    if resolved_root == lexical_root:
+        return (lexical_root,)
+    return (lexical_root, resolved_root)
+
+
 def _resolve_generated_preview_path(path: str | Path, roots: Sequence[Path]) -> Path:
     """Constrain an executor-generated preview path without following symlinks."""
     candidate = _lexical_absolute_path(path)
     for root in roots:
-        root_path = _lexical_absolute_path(root)
-        if candidate == root_path or candidate.is_relative_to(root_path):
-            return candidate
+        for root_path in _generated_preview_root_paths(root):
+            if candidate == root_path or candidate.is_relative_to(root_path):
+                return candidate
     msg = f"Selected path is outside enabled library roots: {path}"
     raise ValidationError(msg)
 

--- a/tests/utilities/test_library_permissions_preview.py
+++ b/tests/utilities/test_library_permissions_preview.py
@@ -118,3 +118,33 @@ async def test_library_permissions_preview_preserves_external_symlink_item(
     assert any(
         item.name == "External Archive" and item.item_type == "symlink" for item in preview.items
     )
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlink support unavailable")
+@pytest.mark.asyncio
+async def test_library_permissions_preview_accepts_symlinked_library_root(
+    tmp_path: Path,
+) -> None:
+    real_root = tmp_path / "real-library"
+    linked_root = tmp_path / "linked-library"
+    folder = real_root / "Batman"
+    folder.mkdir(parents=True)
+    (folder / "Batman 001.cbz").write_bytes(b"one")
+    linked_root.symlink_to(real_root, target_is_directory=True)
+
+    preview = await build_library_permissions_preview(
+        LibraryPermissionsPreviewRequest(
+            scope="folder",
+            file_paths=[str(linked_root / "Batman")],
+            folder_mode="750",
+            file_mode="640",
+            include_folders=True,
+            include_files=True,
+        ),
+        session=_FakeSession(linked_root),
+    )
+
+    assert preview.scope == "folder"
+    assert preview.folder_count == 1
+    assert preview.file_count == 1
+    assert {item.name for item in preview.items} == {"Batman", "Batman 001.cbz"}


### PR DESCRIPTION
## Summary
- accept executor-generated permission preview paths under symlinked library roots
- preserve the existing behavior that keeps symlink items in previews without following their targets
- add regression coverage for symlinked library root previews

## Verification
- pytest tests/utilities/test_library_permissions_preview.py tests/api/test_utilities_preview_api.py tests/unit/test_mass_rename_preview_builder.py -q
- ruff check src/pullbox/utilities/preview_builders.py tests/utilities/test_library_permissions_preview.py
- ruff format --check src/pullbox/utilities/preview_builders.py tests/utilities/test_library_permissions_preview.py