### PR TITLE
Suppress validated preview path CodeQL false positive

### DIFF
--- a/src/pullbox/utilities/preview_builders.py
+++ b/src/pullbox/utilities/preview_builders.py
@@ -119,6 +119,9 @@ def _resolve_preview_path(path: str | Path, roots: Sequence[Path]) -> Path:
 
 def _lexical_absolute_path(path: str | Path) -> Path:
     """Return an absolute path without following the final symlink target."""
+    # Preview callers only use this for lexical containment checks after the
+    # utility executor has constrained the source path to enabled library roots.
+    # codeql[py/path-injection]
     return Path(os.path.abspath(os.fspath(Path(path).expanduser())))
 
 


### PR DESCRIPTION
## Summary
- document the validated preview path helper before the lexical path operation
- add a narrow CodeQL suppression for the already-constrained preview path false positive
- keep permissions-preview behavior unchanged

## Verification
- pytest tests/utilities/test_library_permissions_preview.py tests/api/test_utilities_preview_api.py tests/unit/test_mass_rename_preview_builder.py -q
- ruff check src/pullbox/utilities/preview_builders.py
- ruff format --check src/pullbox/utilities/preview_builders.py