### PR TITLE
ci: triage SQLite Grype release findings

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -8,7 +8,7 @@
 # Python package vulnerabilities are not suppressed here; pip-audit covers
 # those separately in the security workflow.
 #
-# Reviewed against pullbox:ci-scan on 2026-06-10 using the local Grype DB.
+# Reviewed against pullbox:ci-scan on 2026-06-17 using the local Grype DB.
 # Re-audit after each DHI base-image refresh and remove entries when fixed
 # stable Python 3.14 or Debian 13 packages become available upstream.
 
@@ -140,6 +140,19 @@ ignore:
       version: 3.46.1-7+deb13u1
       type: deb
   - vulnerability: CVE-2025-70873
+    package:
+      name: libsqlite3-0
+      version: 3.46.1-7+deb13u1
+      type: deb
+
+  # Debian trixie marks these SQLite FTS5 findings as no-dsa/minor while the
+  # fixed 3.53.2 package is only available in unstable.
+  - vulnerability: CVE-2026-11822
+    package:
+      name: libsqlite3-0
+      version: 3.46.1-7+deb13u1
+      type: deb
+  - vulnerability: CVE-2026-11824
     package:
       name: libsqlite3-0
       version: 3.46.1-7+deb13u1

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -224,6 +224,8 @@ def test_grype_config_tracks_current_dhi_runtime() -> None:
     assert "Docker Hardened Images Python 3.14 on Debian 13" in config_text
     assert "python:3.13-slim" not in config_text
     assert "CVE-2026-7210" in config_text
+    assert "CVE-2026-11822" in config_text
+    assert "CVE-2026-11824" in config_text
     assert "3.14.6" in config_text
     assert config.get("ignore")
 


### PR DESCRIPTION
## Summary
- add Grype triage entries for Debian 13 libsqlite3 CVE-2026-11822 and CVE-2026-11824
- update the Grype runtime snapshot date
- assert the new Grype config entries in the workflow contract test

## Context
The v0.9.4 Docker release build passed image build and smoke testing, but Grype blocked publication on these two high SQLite findings from the DHI Debian 13 base image. Debian trixie currently has no fixed package for these findings and marks them no-dsa/minor; unstable has the fixed 3.53.2 package.

## Verification
- pytest tests/unit/test_github_actions_security_contracts.py -q
- make workflow-hygiene
- .venv/bin/mypy --strict src/pullbox/
- git diff --cached --check