### PR TITLE
chore: prepare v0.9.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.5] - 2026-06-17
+
+Corrective patch release for the unpublished `0.9.4` image publication.
+
+### Fixed
+
+- The release container scan now triages the current Debian 13 SQLite findings
+  from the Docker Hardened Images base while no stable trixie package fix is
+  available.
+
+### CI / Build
+
+- Release image publishing can proceed after the current Grype baseline passes
+  the documented DHI base-image triage.
+
 ## [0.9.4] - 2026-06-17
 
 Patch release for pre-sprint cleanup, dependency maintenance, and release

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.4"
+__version__ = "0.9.5"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- bump Pullbox version to 0.9.5
- add the curated CHANGELOG.md section for v0.9.5
- mark v0.9.5 as the corrective release after the unpublished v0.9.4 image publication was blocked by Grype

## Verification
- make release-changelog-check VERSION=0.9.5
- PYTHONPATH=src python3 -c 'import pullbox; print(pullbox.__version__)'
- pre-commit hooks via commit