### PR TITLE
Fix Docker Hub release signature verification

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -586,9 +586,8 @@ jobs:
             exit 1
           fi
 
-          cosign sign --yes \
-            "${GHCR_IMAGE}@${DIGEST}" \
-            "${DOCKERHUB_IMAGE}@${DIGEST}"
+          cosign sign --yes "${GHCR_IMAGE}@${DIGEST}"
+          cosign sign --yes "${DOCKERHUB_IMAGE}@${DIGEST}"
 
       - name: Verify published image signatures
         env:
@@ -596,15 +595,32 @@ jobs:
           CERTIFICATE_IDENTITY_REGEXP: ^https://github.com/${{ github.repository }}/\.github/workflows/docker\.yml@refs/(tags/v.*|heads/.*)$
           CERTIFICATE_OIDC_ISSUER: https://token.actions.githubusercontent.com
         run: |
-          cosign verify \
-            --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
-            --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" \
-            "${GHCR_IMAGE}@${DIGEST}"
+          verify_image_signature() {
+            local image_ref="$1"
+            local label="$2"
+            local attempt
+            local max_attempts=6
 
-          cosign verify \
-            --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
-            --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" \
-            "${DOCKERHUB_IMAGE}@${DIGEST}"
+            for attempt in $(seq 1 "${max_attempts}"); do
+              if cosign verify \
+                --certificate-identity-regexp "${CERTIFICATE_IDENTITY_REGEXP}" \
+                --certificate-oidc-issuer "${CERTIFICATE_OIDC_ISSUER}" \
+                "${image_ref}"; then
+                return 0
+              fi
+
+              if [ "${attempt}" -eq "${max_attempts}" ]; then
+                echo "::error::Signature for ${label} was not discoverable after ${max_attempts} attempts."
+                return 1
+              fi
+
+              echo "::notice::Signature for ${label} was not discoverable yet; retrying in 10 seconds (${attempt}/${max_attempts})."
+              sleep 10
+            done
+          }
+
+          verify_image_signature "${GHCR_IMAGE}@${DIGEST}" "GHCR"
+          verify_image_signature "${DOCKERHUB_IMAGE}@${DIGEST}" "Docker Hub"
 
       - name: Write release image digest artifact
         env:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -313,6 +313,8 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
     assert "digest.txt" in docker_workflow
     assert "actions/upload-artifact@" in docker_workflow
     assert "cosign verify" in docker_workflow
+    assert "verify_image_signature()" in docker_workflow
+    assert "Signature for ${label} was not discoverable yet" in docker_workflow
     assert "--certificate-identity-regexp" in docker_workflow
     assert "--certificate-oidc-issuer" in docker_workflow
 


### PR DESCRIPTION
## Summary
- sign GHCR and Docker Hub release images with separate cosign commands
- retry signature verification so Docker Hub has time to expose the uploaded signature
- extend the workflow contract test for release signature verification retry behavior

## Verification
- .venv/bin/pytest tests/unit/test_github_actions_security_contracts.py::test_docker_workflow_signs_and_verifies_published_images -q
- make workflow-hygiene