### PR TITLE
Release v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.8] - 2026-06-18
+
+Corrective release for the `0.9.7` publish attempt, which pushed container
+images but did not create a GitHub Release because Docker Hub signature
+verification could not discover the freshly uploaded signature.
+
+### CI / Build
+
+- Release image signing now signs GHCR and Docker Hub image references
+  separately.
+- Release image verification now retries digest-signature checks so Docker Hub
+  has time to expose newly uploaded Cosign signatures before the workflow fails.
+
 ## [0.9.7] - 2026-06-17
 
 Testing and coverage sprint release focused on hardening Pullbox ahead of the

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- bump Pullbox version to 0.9.8
- add curated changelog section for the corrective Docker Hub signature verification release

## Verification
- make release-changelog-check VERSION=0.9.8
- PYTHONPATH=src .venv/bin/python -c 'from pullbox import __version__; print(__version__)'
- git diff --check