### PR TITLE
Release v0.9.9

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -499,7 +499,7 @@ jobs:
           DIGEST: ${{ steps.push-image.outputs.digest }}
         run: |
           docker buildx imagetools inspect "${GHCR_IMAGE}@${DIGEST}" --raw > image-index.json
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import sys
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.9] - 2026-06-18
+
+Corrective release for the `0.9.8` release workflow, which pushed registry
+images but failed while validating OCI metadata on the Docker runner.
+
+### CI / Build
+
+- Docker release metadata validation now uses the runner-available `python3`
+  executable instead of assuming a `python` shim exists on the hardened Docker
+  runner.
+- Workflow contract tests now guard the release metadata validation command so
+  future release-only checks stay compatible with the Docker runner image.
+
 ## [0.9.8] - 2026-06-18
 
 Release-pipeline hardening focused on making release automation predictable,

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -446,6 +446,8 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
     assert "digest.txt" in docker_workflow
     assert "actions/upload-artifact@" in docker_workflow
     assert "Validate pushed image metadata" in docker_workflow
+    assert "python3 - <<'PY'" in docker_workflow
+    assert "python - <<'PY'" not in docker_workflow
     assert "org.opencontainers.image.description" in docker_workflow
     assert "attestation-manifest" in docker_workflow
     assert "cosign verify" in docker_workflow


### PR DESCRIPTION
## Summary
- Prepare corrective Pullbox v0.9.9 release
- Fix Docker Release metadata validation to use python3 on the Docker runner
- Add workflow contract coverage for the release metadata validation command

## Verification
- .venv/bin/pytest tests/unit/test_github_actions_security_contracts.py -q
- make workflow-hygiene
- git diff --check