### PR TITLE
Prepare release v0.9.10

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -507,7 +507,10 @@ jobs:
               index = json.load(handle)
 
           annotations = index.get("annotations") or {}
-          expected_description = "Modern comic book management and acquisition platform"
+          expected_description = (
+              "Modern comic book management and acquisition platform for "
+              "self-hosted environments"
+          )
           if annotations.get("org.opencontainers.image.description") != expected_description:
               print("Missing OCI index description annotation.", file=sys.stderr)
               sys.exit(1)

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -166,6 +166,8 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ needs.gate.outputs.build-sha }}
             org.opencontainers.image.licenses=GPL-3.0-or-later
+          annotations: |
+            org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments
 
       - name: Extract version
         id: version
@@ -453,6 +455,8 @@ jobs:
             org.opencontainers.image.revision=${{ needs.build.outputs.build-sha }}
             org.opencontainers.image.licenses=GPL-3.0-or-later
             org.opencontainers.image.version=${{ needs.build.outputs.image-version }}
+          annotations: |
+            org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments
 
       - name: Extract version
         id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [0.9.10] - 2026-06-18
+
+Corrective release for the `0.9.9` release workflow, which pushed registry
+images but failed while validating the OCI index package description.
+
+### CI / Build
+
+- Docker release metadata validation now checks the full index-level package
+  description that is actually published to GHCR and Docker Hub.
+- Workflow contract tests now guard against release image label and index
+  annotation validation drift.
+
 ## [0.9.9] - 2026-06-18
 
 Corrective release for the `0.9.8` release workflow, which pushed registry

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.9"
+__version__ = "0.9.10"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -417,6 +417,14 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
     metadata_env = metadata_steps[0].get("env")
     assert isinstance(metadata_env, dict)
     assert metadata_env.get("DOCKER_METADATA_ANNOTATIONS_LEVELS") == "manifest,index"
+    metadata_with = metadata_steps[0].get("with")
+    assert isinstance(metadata_with, dict)
+    assert (
+        "org.opencontainers.image.description=Modern comic book management and acquisition platform"
+    ) in metadata_with.get("labels", "")
+    assert "expected_description = (" in docker_workflow
+    assert "Modern comic book management and acquisition platform for " in docker_workflow
+    assert "self-hosted environments" in docker_workflow
 
     assert sign_job.get("runs-on") == "ubuntu-latest"
     assert sign_job.get("needs") == ["build", "push"]

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -422,6 +422,10 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
     assert (
         "org.opencontainers.image.description=Modern comic book management and acquisition platform"
     ) in metadata_with.get("labels", "")
+    assert (
+        "org.opencontainers.image.description=Modern comic book management and "
+        "acquisition platform for self-hosted environments"
+    ) in metadata_with.get("annotations", "")
     assert "expected_description = (" in docker_workflow
     assert "Modern comic book management and acquisition platform for " in docker_workflow
     assert "self-hosted environments" in docker_workflow


### PR DESCRIPTION
## Summary
- bump Pullbox to 0.9.10 after the v0.9.9 Docker release validation failure
- align Docker release OCI metadata validation with the published index-level package description
- add workflow contract coverage so label and index description validation cannot drift silently

## Verification
- .venv/bin/pytest tests/unit/test_github_actions_security_contracts.py -q
- make workflow-hygiene
- git diff --check