### PR TITLE
Add release sync CI fast path

### DIFF
--- a/.github/scripts/validate-release-sync-pr.py
+++ b/.github/scripts/validate-release-sync-pr.py
@@ -42,6 +42,11 @@ def expected_next_dev_version(released_version: str) -> str | None:
     return f"{major}.{minor}.{patch + 1}-dev"
 
 
+def replace_version_line(text: str, version: str) -> str:
+    """Return ``text`` with only the Pullbox version assignment changed."""
+    return VERSION_RE.sub(f'__version__ = "{version}"', text, count=1)
+
+
 def version_bump_is_release_sync(main_text: str, head_text: str) -> ValidationResult:
     main_version = extract_version(main_text)
     head_version = extract_version(head_text)
@@ -56,6 +61,12 @@ def version_bump_is_release_sync(main_text: str, head_text: str) -> ValidationRe
             False,
             f"expected {VERSION_FILE} to be bumped from {main_version} to {expected}; "
             f"found {head_version}",
+        )
+    expected_head_text = replace_version_line(main_text, expected)
+    if head_text != expected_head_text:
+        return ValidationResult(
+            False,
+            f"{VERSION_FILE} contains changes beyond the expected version bump",
         )
     return ValidationResult(True, f"release sync with dev bump {main_version} -> {head_version}")
 
@@ -75,7 +86,7 @@ def _git_succeeds(*args: str, cwd: Path) -> bool:
 
 
 def _git_stdout(*args: str, cwd: Path) -> str:
-    return _run_git(*args, cwd=cwd).stdout.strip()
+    return _run_git(*args, cwd=cwd).stdout
 
 
 def _fetch_release_refs(cwd: Path) -> None:

--- a/.github/scripts/validate-release-sync-pr.py
+++ b/.github/scripts/validate-release-sync-pr.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Detect safe post-release sync PRs that can skip heavyweight checks.
+
+This script is intentionally conservative. It only marks a PR as a release sync
+when it carries main back to develop and the only additional change is the
+standard next patch ``-dev`` version bump.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+VERSION_FILE = "src/pullbox/__init__.py"
+ALLOWED_SYNC_CHANGES = {VERSION_FILE}
+SYNC_BRANCH_PREFIX = "feature/sync-develop-"
+VERSION_RE = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
+RELEASE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_sync: bool
+    reason: str
+
+
+def extract_version(text: str) -> str | None:
+    """Extract the Pullbox package version from ``src/pullbox/__init__.py``."""
+    match = VERSION_RE.search(text)
+    return match.group(1) if match else None
+
+
+def expected_next_dev_version(released_version: str) -> str | None:
+    """Return the expected post-release dev version for a final release."""
+    match = RELEASE_VERSION_RE.fullmatch(released_version)
+    if not match:
+        return None
+    major, minor, patch = (int(part) for part in match.groups())
+    return f"{major}.{minor}.{patch + 1}-dev"
+
+
+def version_bump_is_release_sync(main_text: str, head_text: str) -> ValidationResult:
+    main_version = extract_version(main_text)
+    head_version = extract_version(head_text)
+    if main_version is None or head_version is None:
+        return ValidationResult(False, "could not read Pullbox version")
+
+    expected = expected_next_dev_version(main_version)
+    if expected is None:
+        return ValidationResult(False, f"main version is not a final release: {main_version}")
+    if head_version != expected:
+        return ValidationResult(
+            False,
+            f"expected {VERSION_FILE} to be bumped from {main_version} to {expected}; "
+            f"found {head_version}",
+        )
+    return ValidationResult(True, f"release sync with dev bump {main_version} -> {head_version}")
+
+
+def _run_git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _git_succeeds(*args: str, cwd: Path) -> bool:
+    return _run_git(*args, cwd=cwd, check=False).returncode == 0
+
+
+def _git_stdout(*args: str, cwd: Path) -> str:
+    return _run_git(*args, cwd=cwd).stdout.strip()
+
+
+def _fetch_release_refs(cwd: Path) -> None:
+    _run_git(
+        "fetch",
+        "--no-tags",
+        "origin",
+        "main:refs/remotes/origin/main",
+        "develop:refs/remotes/origin/develop",
+        cwd=cwd,
+    )
+
+
+def validate_release_sync_pr(
+    env: dict[str, str], cwd: Path, *, fetch_refs: bool = True
+) -> ValidationResult:
+    if env.get("RELEASE_SYNC_EVENT_NAME") != "pull_request":
+        return ValidationResult(False, "not a pull request")
+    if env.get("RELEASE_SYNC_BASE_REF") != "develop":
+        return ValidationResult(False, "base branch is not develop")
+
+    head_ref = env.get("RELEASE_SYNC_HEAD_REF", "")
+    if not head_ref.startswith(SYNC_BRANCH_PREFIX):
+        return ValidationResult(False, f"head branch does not start with {SYNC_BRANCH_PREFIX}")
+
+    repository = env.get("RELEASE_SYNC_REPOSITORY", "")
+    head_repository = env.get("RELEASE_SYNC_HEAD_REPOSITORY", "")
+    actor = env.get("RELEASE_SYNC_ACTOR", "")
+    if head_repository != repository:
+        return ValidationResult(False, "fork pull requests cannot use the sync fast path")
+    if actor == "dependabot[bot]":
+        return ValidationResult(False, "Dependabot pull requests cannot use the sync fast path")
+
+    try:
+        if fetch_refs:
+            _fetch_release_refs(cwd)
+
+        if not _git_succeeds(
+            "merge-base", "--is-ancestor", "origin/develop", "origin/main", cwd=cwd
+        ):
+            return ValidationResult(False, "origin/main is not a descendant of origin/develop")
+        if not _git_succeeds("merge-base", "--is-ancestor", "origin/main", "HEAD", cwd=cwd):
+            return ValidationResult(False, "pull request head does not include origin/main")
+
+        changed = set(
+            filter(
+                None,
+                _git_stdout("diff", "--name-only", "origin/main..HEAD", cwd=cwd).splitlines(),
+            )
+        )
+        if changed != ALLOWED_SYNC_CHANGES:
+            return ValidationResult(
+                False,
+                "release sync fast path only allows "
+                f"{sorted(ALLOWED_SYNC_CHANGES)} after origin/main; found {sorted(changed)}",
+            )
+
+        main_text = _git_stdout("show", f"origin/main:{VERSION_FILE}", cwd=cwd)
+        head_text = (cwd / VERSION_FILE).read_text(encoding="utf-8")
+        return version_bump_is_release_sync(main_text, head_text)
+    except Exception as exc:
+        return ValidationResult(False, f"could not validate release sync PR: {exc}")
+
+
+def _write_output(result: ValidationResult) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with Path(output_path).open("a", encoding="utf-8") as output:
+            output.write(f"is_sync={str(result.is_sync).lower()}\n")
+            output.write(f"reason={result.reason}\n")
+
+    print(f"release_sync={str(result.is_sync).lower()}")
+    print(f"reason={result.reason}")
+
+
+def main() -> int:
+    result = validate_release_sync_pr(os.environ, Path.cwd())
+    _write_output(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,17 @@ jobs:
           RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
           RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
           RELEASE_SYNC_ACTOR: ${{ github.actor }}
-        run: python .github/scripts/validate-release-sync-pr.py
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git cat-file -e origin/main:.github/scripts/validate-release-sync-pr.py 2>/dev/null; then
+            echo "is_sync=false" >> "$GITHUB_OUTPUT"
+            echo "reason=trusted release sync validator is not available on origin/main yet" >> "$GITHUB_OUTPUT"
+            echo "release_sync=false"
+            echo "reason=trusted release sync validator is not available on origin/main yet"
+            exit 0
+          fi
+          git show origin/main:.github/scripts/validate-release-sync-pr.py > /tmp/pullbox-release-sync-validator.py
+          python /tmp/pullbox-release-sync-validator.py
 
   # ──────────────────────────────────────────────
   # Job 1: Quality Gate (~45s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,37 @@ env:
   PYTEST_WORKERS: "4"
 
 jobs:
+  release_sync_check:
+    name: Release Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_sync: ${{ steps.release-sync.outputs.is_sync }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect safe post-release sync PR
+        id: release-sync
+        env:
+          RELEASE_SYNC_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_SYNC_BASE_REF: ${{ github.base_ref || '' }}
+          RELEASE_SYNC_HEAD_REF: ${{ github.head_ref || '' }}
+          RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
+          RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          RELEASE_SYNC_ACTOR: ${{ github.actor }}
+        run: python .github/scripts/validate-release-sync-pr.py
+
   # ──────────────────────────────────────────────
   # Job 1: Quality Gate (~45s)
   # ──────────────────────────────────────────────
   quality-gate:
     name: Quality Gate
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -77,6 +103,8 @@ jobs:
   # ──────────────────────────────────────────────
   typecheck:
     name: Type Check
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -103,7 +131,8 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
-    needs: [quality-gate, typecheck, alembic-check]
+    needs: [release_sync_check, quality-gate, typecheck, alembic-check]
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     timeout-minutes: 30
     permissions:
       contents: read
@@ -161,6 +190,8 @@ jobs:
   # ──────────────────────────────────────────────
   alembic-check:
     name: Migration Check
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -207,7 +238,8 @@ jobs:
   accessibility:
     name: Accessibility Checks
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
-    needs: [quality-gate, typecheck, alembic-check]
+    needs: [release_sync_check, quality-gate, typecheck, alembic-check]
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     timeout-minutes: 30
     permissions:
       contents: read
@@ -287,7 +319,8 @@ jobs:
   e2e:
     name: E2E Tests (${{ matrix.browser }})
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
-    needs: [test]
+    needs: [release_sync_check, test]
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     timeout-minutes: 30
     permissions:
       contents: read
@@ -365,6 +398,7 @@ jobs:
     name: CI Required
     runs-on: ubuntu-latest
     needs:
+      - release_sync_check
       - quality-gate
       - typecheck
       - alembic-check
@@ -379,6 +413,7 @@ jobs:
       - name: Verify required CI jobs
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
+          RELEASE_SYNC_PR: ${{ needs.release_sync_check.outputs.is_sync }}
         run: |
           python - <<'PY'
           import json
@@ -386,6 +421,23 @@ jobs:
           import sys
 
           needs = json.loads(os.environ["NEEDS_CONTEXT"])
+          release_sync_pr = os.environ["RELEASE_SYNC_PR"].lower() == "true"
+          if release_sync_pr:
+              release_sync = needs.get("release_sync_check", {}).get("result")
+              if release_sync != "success":
+                  print(f"Release sync validation failed: {release_sync}", file=sys.stderr)
+                  sys.exit(1)
+              unexpected = {
+                  name: info.get("result")
+                  for name, info in needs.items()
+                  if name != "release_sync_check" and info.get("result") not in {"skipped", "success"}
+              }
+              if unexpected:
+                  print(f"Release sync fast path saw unexpected job results: {unexpected}", file=sys.stderr)
+                  sys.exit(1)
+              print("Release sync fast path validated; heavyweight CI jobs intentionally skipped.")
+              sys.exit(0)
+
           failed = {
               name: info.get("result")
               for name, info in needs.items()

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -59,7 +59,17 @@ jobs:
           RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
           RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
           RELEASE_SYNC_ACTOR: ${{ github.actor }}
-        run: python .github/scripts/validate-release-sync-pr.py
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git cat-file -e origin/main:.github/scripts/validate-release-sync-pr.py 2>/dev/null; then
+            echo "is_sync=false" >> "$GITHUB_OUTPUT"
+            echo "reason=trusted release sync validator is not available on origin/main yet" >> "$GITHUB_OUTPUT"
+            echo "release_sync=false"
+            echo "reason=trusted release sync validator is not available on origin/main yet"
+            exit 0
+          fi
+          git show origin/main:.github/scripts/validate-release-sync-pr.py > /tmp/pullbox-release-sync-validator.py
+          python /tmp/pullbox-release-sync-validator.py
 
   untrusted-sanity:
     name: Docker Sanity (untrusted PR)

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -37,6 +37,30 @@ env:
   PYTHON_DEFAULT: "3.14"
 
 jobs:
+  release_sync_check:
+    name: Release Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_sync: ${{ steps.release-sync.outputs.is_sync }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect safe post-release sync PR
+        id: release-sync
+        env:
+          RELEASE_SYNC_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_SYNC_BASE_REF: ${{ github.base_ref || '' }}
+          RELEASE_SYNC_HEAD_REF: ${{ github.head_ref || '' }}
+          RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
+          RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          RELEASE_SYNC_ACTOR: ${{ github.actor }}
+        run: python .github/scripts/validate-release-sync-pr.py
+
   untrusted-sanity:
     name: Docker Sanity (untrusted PR)
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
@@ -64,7 +88,12 @@ jobs:
 
   trusted-production-validate:
     name: Production Docker Validate (trusted)
-    if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
+    needs: release_sync_check
+    if: >-
+      needs.release_sync_check.outputs.is_sync != 'true' &&
+      (github.event_name != 'pull_request' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'))
     runs-on: [self-hosted, Linux, X64, docker]
     timeout-minutes: 35
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,17 @@ jobs:
           RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
           RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
           RELEASE_SYNC_ACTOR: ${{ github.actor }}
-        run: python .github/scripts/validate-release-sync-pr.py
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git cat-file -e origin/main:.github/scripts/validate-release-sync-pr.py 2>/dev/null; then
+            echo "is_sync=false" >> "$GITHUB_OUTPUT"
+            echo "reason=trusted release sync validator is not available on origin/main yet" >> "$GITHUB_OUTPUT"
+            echo "release_sync=false"
+            echo "reason=trusted release sync validator is not available on origin/main yet"
+            exit 0
+          fi
+          git show origin/main:.github/scripts/validate-release-sync-pr.py > /tmp/pullbox-release-sync-validator.py
+          python /tmp/pullbox-release-sync-validator.py
 
   # ──────────────────────────────────────────────
   # Job 1: gitleaks (blocking secret scan)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,11 +32,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release_sync_check:
+    name: Release Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_sync: ${{ steps.release-sync.outputs.is_sync }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect safe post-release sync PR
+        id: release-sync
+        env:
+          RELEASE_SYNC_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_SYNC_BASE_REF: ${{ github.base_ref || '' }}
+          RELEASE_SYNC_HEAD_REF: ${{ github.head_ref || '' }}
+          RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
+          RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          RELEASE_SYNC_ACTOR: ${{ github.actor }}
+        run: python .github/scripts/validate-release-sync-pr.py
+
   # ──────────────────────────────────────────────
   # Job 1: gitleaks (blocking secret scan)
   # ──────────────────────────────────────────────
   gitleaks:
     name: Gitleaks
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 20
     permissions:
@@ -124,6 +150,8 @@ jobs:
   # ──────────────────────────────────────────────
   dependency-audit:
     name: pip-audit
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -159,6 +187,8 @@ jobs:
   # ──────────────────────────────────────────────
   safety-check:
     name: Safety Check
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -194,6 +224,8 @@ jobs:
   # ──────────────────────────────────────────────
   bandit:
     name: Bandit
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -238,7 +270,8 @@ jobs:
   # ──────────────────────────────────────────────
   codeql:
     name: CodeQL Analysis
-    if: github.repository_visibility == 'public' || vars.PULLBOX_ENABLE_CODEQL == 'true'
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true' && (github.repository_visibility == 'public' || vars.PULLBOX_ENABLE_CODEQL == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -265,6 +298,7 @@ jobs:
     name: Security Required
     runs-on: ubuntu-latest
     needs:
+      - release_sync_check
       - gitleaks
       - dependency-audit
       - safety-check
@@ -279,6 +313,7 @@ jobs:
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
           CODEQL_BLOCKING: ${{ vars.PULLBOX_REQUIRE_CODEQL == 'true' }}
+          RELEASE_SYNC_PR: ${{ needs.release_sync_check.outputs.is_sync }}
         run: |
           python - <<'PY'
           import json
@@ -287,6 +322,23 @@ jobs:
 
           needs = json.loads(os.environ["NEEDS_CONTEXT"])
           codeql_blocking = os.environ["CODEQL_BLOCKING"].lower() == "true"
+          release_sync_pr = os.environ["RELEASE_SYNC_PR"].lower() == "true"
+          if release_sync_pr:
+              release_sync = needs.get("release_sync_check", {}).get("result")
+              if release_sync != "success":
+                  print(f"Release sync validation failed: {release_sync}", file=sys.stderr)
+                  sys.exit(1)
+              unexpected = {
+                  name: info.get("result")
+                  for name, info in needs.items()
+                  if name != "release_sync_check" and info.get("result") not in {"skipped", "success"}
+              }
+              if unexpected:
+                  print(f"Release sync fast path saw unexpected job results: {unexpected}", file=sys.stderr)
+                  sys.exit(1)
+              print("Release sync fast path validated; heavyweight security jobs intentionally skipped.")
+              sys.exit(0)
+
           failed = {}
           for name, info in needs.items():
               result = info.get("result")

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -22,8 +22,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release_sync_check:
+    name: Release Sync Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      is_sync: ${{ steps.release-sync.outputs.is_sync }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Detect safe post-release sync PR
+        id: release-sync
+        env:
+          RELEASE_SYNC_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_SYNC_BASE_REF: ${{ github.base_ref || '' }}
+          RELEASE_SYNC_HEAD_REF: ${{ github.head_ref || '' }}
+          RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
+          RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          RELEASE_SYNC_ACTOR: ${{ github.actor }}
+        run: python .github/scripts/validate-release-sync-pr.py
+
   actionlint:
     name: actionlint
+    needs: release_sync_check
+    if: needs.release_sync_check.outputs.is_sync != 'true'
     runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
     timeout-minutes: 15
     permissions:
@@ -50,6 +76,7 @@ jobs:
     name: Workflow Hygiene Required
     runs-on: ubuntu-latest
     needs:
+      - release_sync_check
       - actionlint
     if: always()
     timeout-minutes: 5
@@ -59,6 +86,7 @@ jobs:
       - name: Verify workflow hygiene jobs
         env:
           NEEDS_CONTEXT: ${{ toJson(needs) }}
+          RELEASE_SYNC_PR: ${{ needs.release_sync_check.outputs.is_sync }}
         run: |
           python - <<'PY'
           import json
@@ -66,6 +94,19 @@ jobs:
           import sys
 
           needs = json.loads(os.environ["NEEDS_CONTEXT"])
+          release_sync_pr = os.environ["RELEASE_SYNC_PR"].lower() == "true"
+          if release_sync_pr:
+              release_sync = needs.get("release_sync_check", {}).get("result")
+              if release_sync != "success":
+                  print(f"Release sync validation failed: {release_sync}", file=sys.stderr)
+                  sys.exit(1)
+              actionlint = needs.get("actionlint", {}).get("result")
+              if actionlint not in {"skipped", "success"}:
+                  print(f"Release sync fast path saw unexpected actionlint result: {actionlint}", file=sys.stderr)
+                  sys.exit(1)
+              print("Release sync fast path validated; actionlint intentionally skipped.")
+              sys.exit(0)
+
           failed = {
               name: info.get("result")
               for name, info in needs.items()

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -44,7 +44,17 @@ jobs:
           RELEASE_SYNC_REPOSITORY: ${{ github.repository }}
           RELEASE_SYNC_HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
           RELEASE_SYNC_ACTOR: ${{ github.actor }}
-        run: python .github/scripts/validate-release-sync-pr.py
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git cat-file -e origin/main:.github/scripts/validate-release-sync-pr.py 2>/dev/null; then
+            echo "is_sync=false" >> "$GITHUB_OUTPUT"
+            echo "reason=trusted release sync validator is not available on origin/main yet" >> "$GITHUB_OUTPUT"
+            echo "release_sync=false"
+            echo "reason=trusted release sync validator is not available on origin/main yet"
+            exit 0
+          fi
+          git show origin/main:.github/scripts/validate-release-sync-pr.py > /tmp/pullbox-release-sync-validator.py
+          python /tmp/pullbox-release-sync-validator.py
 
   actionlint:
     name: actionlint

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -408,18 +408,20 @@ make ci-full
 Step 2: bump the version for release.
 
 ```bash
+git switch -c release/prepare-X.Y.Z
+
 # Edit src/pullbox/__init__.py from X.Y.Z-dev to X.Y.Z
 # Update CHANGELOG.md by moving curated Unreleased notes into X.Y.Z
 make release-changelog-check VERSION=X.Y.Z
 git add src/pullbox/__init__.py CHANGELOG.md
 git commit -m "chore: bump version to X.Y.Z for release"
-git push origin develop
+git push -u origin release/prepare-X.Y.Z
 ```
 
-Step 3: open a PR from `develop` to `main`.
+Step 3: open a PR from the release branch to `main`.
 
 ```bash
-gh pr create --base main --head develop --title "Release vX.Y.Z" --body "Release vX.Y.Z
+gh pr create --base main --head release/prepare-X.Y.Z --title "Release vX.Y.Z" --body "Release vX.Y.Z
 
 ## Summary
 - Release summary goes here.
@@ -531,26 +533,50 @@ git push origin vX.Y.Z-rc1
 
 ### 9.2 Required standard
 
-After the release tag is pushed and release automation is healthy:
+After the release tag is pushed and release automation is healthy, open a
+post-release sync PR back to `develop`:
 
 ```bash
-git switch develop
-git pull --ff-only origin develop
+git switch main
+git pull --ff-only origin main
+git switch -c feature/sync-develop-X.Y.Z
 
-# Edit src/pullbox/__init__.py from X.Y.Z to next-dev-version
+# Edit src/pullbox/__init__.py from X.Y.Z to the next patch dev version,
+# for example 0.9.10 -> 0.9.11-dev.
 git add src/pullbox/__init__.py
-git commit -m "chore: bump version to next-dev-version"
-git push origin develop
+git commit -m "chore: sync develop after vX.Y.Z release"
+git push -u origin feature/sync-develop-X.Y.Z
+gh pr create --base develop --head feature/sync-develop-X.Y.Z \
+  --title "Sync develop after vX.Y.Z release" \
+  --body "Syncs main back to develop after vX.Y.Z and reopens the dev version."
 ```
 
-If a release fix lands on `main`, bring it back into `develop` before starting
-more feature work:
+The required CI, Security, Workflow Hygiene, and Docker Validate workflows have
+a narrow fast path for this exact PR shape:
+
+- base branch is `develop`;
+- head branch starts with `feature/sync-develop-`;
+- PR is same-repository, not a fork or Dependabot PR;
+- `origin/main` contains `origin/develop`;
+- PR head contains `origin/main`;
+- the only change after `origin/main` is `src/pullbox/__init__.py`;
+- the version changes from the released `X.Y.Z` to the next patch
+  `X.Y.(Z+1)-dev`.
+
+Any other sync, hotfix, workflow, or source-code change falls back to the normal
+full required checks.
+
+If a release fix lands on `main` outside the normal release PR, bring it back
+into `develop` before starting more feature work through a normal PR:
 
 ```bash
 git switch develop
 git pull --ff-only origin develop
+git switch -c feature/sync-develop-hotfix
 git merge origin/main
-git push origin develop
+git push -u origin feature/sync-develop-hotfix
+gh pr create --base develop --head feature/sync-develop-hotfix \
+  --title "Sync develop after release hotfix"
 ```
 
 ### 9.3 Current repo nuances

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
 import re
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +18,7 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
 CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 GRYPE_CONFIG = REPO_ROOT / ".grype.yaml"
+RELEASE_SYNC_SCRIPT = REPO_ROOT / ".github" / "scripts" / "validate-release-sync-pr.py"
 
 ACTION_REF_RE = re.compile(
     r"""
@@ -36,6 +40,27 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     assert isinstance(data, dict)
     return data
+
+
+def _load_release_sync_module() -> Any:
+    spec = importlib.util.spec_from_file_location("release_sync_validator", RELEASE_SYNC_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
 
 
 def _non_comment_uses_lines(path: Path) -> list[tuple[int, str]]:
@@ -229,6 +254,144 @@ def test_required_gate_workflows_do_not_rerun_on_main_push() -> None:
         triggers = data.get(True, data.get("on"))
         assert isinstance(triggers, dict)
         assert "push" not in triggers
+
+
+def test_release_sync_fast_path_requires_next_patch_dev_version() -> None:
+    validator = _load_release_sync_module()
+
+    assert validator.extract_version('__version__ = "0.9.10"\n') == "0.9.10"
+    assert validator.expected_next_dev_version("0.9.10") == "0.9.11-dev"
+
+    valid = validator.version_bump_is_release_sync(
+        '__version__ = "0.9.10"\n',
+        '__version__ = "0.9.11-dev"\n',
+    )
+    assert valid.is_sync is True
+
+    unchanged = validator.version_bump_is_release_sync(
+        '__version__ = "0.9.10"\n',
+        '__version__ = "0.9.10"\n',
+    )
+    assert unchanged.is_sync is False
+    assert "0.9.11-dev" in unchanged.reason
+
+
+def test_release_sync_validator_accepts_only_main_plus_next_dev_bump(tmp_path: Path) -> None:
+    validator = _load_release_sync_module()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    _git(repo, "init", "--initial-branch=develop")
+    _git(repo, "config", "user.email", "tests@example.invalid")
+    _git(repo, "config", "user.name", "Pullbox Tests")
+    version_file = repo / "src" / "pullbox" / "__init__.py"
+    version_file.parent.mkdir(parents=True)
+    version_file.write_text('__version__ = "0.9.9-dev"\n', encoding="utf-8")
+    _git(repo, "add", "src/pullbox/__init__.py")
+    _git(repo, "commit", "-m", "seed develop")
+    _git(repo, "update-ref", "refs/remotes/origin/develop", "HEAD")
+
+    _git(repo, "switch", "-c", "main")
+    version_file.write_text('__version__ = "0.9.10"\n', encoding="utf-8")
+    _git(repo, "commit", "-am", "release")
+    _git(repo, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    _git(repo, "switch", "-c", "feature/sync-develop-0.9.10")
+    version_file.write_text('__version__ = "0.9.11-dev"\n', encoding="utf-8")
+    _git(repo, "commit", "-am", "dev bump")
+
+    env = {
+        "RELEASE_SYNC_EVENT_NAME": "pull_request",
+        "RELEASE_SYNC_BASE_REF": "develop",
+        "RELEASE_SYNC_HEAD_REF": "feature/sync-develop-0.9.10",
+        "RELEASE_SYNC_REPOSITORY": "pullboxapp/pullbox",
+        "RELEASE_SYNC_HEAD_REPOSITORY": "pullboxapp/pullbox",
+        "RELEASE_SYNC_ACTOR": "maintainer",
+    }
+
+    valid = validator.validate_release_sync_pr(env, repo, fetch_refs=False)
+    assert valid.is_sync is True
+
+    (repo / "README.md").write_text("extra change\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "extra change")
+
+    invalid = validator.validate_release_sync_pr(env, repo, fetch_refs=False)
+    assert invalid.is_sync is False
+    assert "only allows" in invalid.reason
+
+
+def test_release_sync_fast_path_is_wired_to_required_aggregate_workflows() -> None:
+    required_contracts = {
+        "ci.yml": {
+            "aggregate": "ci-required",
+            "heavy": [
+                "quality-gate",
+                "typecheck",
+                "alembic-check",
+                "test",
+                "accessibility",
+                "e2e",
+            ],
+            "message": "heavyweight CI jobs intentionally skipped",
+        },
+        "security.yml": {
+            "aggregate": "security-required",
+            "heavy": ["gitleaks", "dependency-audit", "safety-check", "bandit", "codeql"],
+            "message": "heavyweight security jobs intentionally skipped",
+        },
+        "workflow-hygiene.yml": {
+            "aggregate": "workflow-hygiene-required",
+            "heavy": ["actionlint"],
+            "message": "actionlint intentionally skipped",
+        },
+    }
+
+    for workflow_name, contract in required_contracts.items():
+        workflow_path = WORKFLOW_DIR / workflow_name
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        data = _load_yaml(workflow_path)
+        jobs = data.get("jobs")
+        assert isinstance(jobs, dict)
+
+        release_sync = jobs.get("release_sync_check")
+        assert isinstance(release_sync, dict)
+        assert release_sync.get("name") == "Release Sync Check"
+        assert release_sync.get("runs-on") == "ubuntu-latest"
+        assert release_sync.get("outputs", {}).get("is_sync") == (
+            "${{ steps.release-sync.outputs.is_sync }}"
+        )
+        assert "python .github/scripts/validate-release-sync-pr.py" in workflow_text
+
+        aggregate = jobs.get(contract["aggregate"])
+        assert isinstance(aggregate, dict)
+        assert "release_sync_check" in aggregate.get("needs", [])
+        assert "RELEASE_SYNC_PR" in workflow_text
+        assert contract["message"] in workflow_text
+
+        for job_name in contract["heavy"]:
+            job = jobs.get(job_name)
+            assert isinstance(job, dict)
+            needs = job.get("needs")
+            if isinstance(needs, str):
+                needs = [needs]
+            assert "release_sync_check" in needs
+            assert "needs.release_sync_check.outputs.is_sync != 'true'" in str(job.get("if"))
+
+
+def test_docker_validation_skips_trusted_docker_runner_for_release_sync_prs() -> None:
+    data = _load_yaml(WORKFLOW_DIR / "docker-validate.yml")
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict)
+
+    release_sync = jobs.get("release_sync_check")
+    assert isinstance(release_sync, dict)
+    assert release_sync.get("runs-on") == "ubuntu-latest"
+
+    trusted = jobs.get("trusted-production-validate")
+    assert isinstance(trusted, dict)
+    assert trusted.get("needs") == "release_sync_check"
+    assert "needs.release_sync_check.outputs.is_sync != 'true'" in trusted.get("if", "")
 
 
 def test_trusted_jobs_use_explicit_self_hosted_runner_labels() -> None:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -275,6 +275,13 @@ def test_release_sync_fast_path_requires_next_patch_dev_version() -> None:
     assert unchanged.is_sync is False
     assert "0.9.11-dev" in unchanged.reason
 
+    extra_version_file_change = validator.version_bump_is_release_sync(
+        '__version__ = "0.9.10"\nSTARTED_AT = "safe"\n',
+        '__version__ = "0.9.11-dev"\nSTARTED_AT = "changed"\n',
+    )
+    assert extra_version_file_change.is_sync is False
+    assert "beyond the expected version bump" in extra_version_file_change.reason
+
 
 def test_release_sync_validator_accepts_only_main_plus_next_dev_bump(tmp_path: Path) -> None:
     validator = _load_release_sync_module()
@@ -361,7 +368,9 @@ def test_release_sync_fast_path_is_wired_to_required_aggregate_workflows() -> No
         assert release_sync.get("outputs", {}).get("is_sync") == (
             "${{ steps.release-sync.outputs.is_sync }}"
         )
-        assert "python .github/scripts/validate-release-sync-pr.py" in workflow_text
+        assert "git show origin/main:.github/scripts/validate-release-sync-pr.py" in workflow_text
+        assert "python /tmp/pullbox-release-sync-validator.py" in workflow_text
+        assert "python .github/scripts/validate-release-sync-pr.py" not in workflow_text
 
         aggregate = jobs.get(contract["aggregate"])
         assert isinstance(aggregate, dict)
@@ -380,7 +389,9 @@ def test_release_sync_fast_path_is_wired_to_required_aggregate_workflows() -> No
 
 
 def test_docker_validation_skips_trusted_docker_runner_for_release_sync_prs() -> None:
-    data = _load_yaml(WORKFLOW_DIR / "docker-validate.yml")
+    workflow_path = WORKFLOW_DIR / "docker-validate.yml"
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+    data = _load_yaml(workflow_path)
     jobs = data.get("jobs")
     assert isinstance(jobs, dict)
 
@@ -392,6 +403,9 @@ def test_docker_validation_skips_trusted_docker_runner_for_release_sync_prs() ->
     assert isinstance(trusted, dict)
     assert trusted.get("needs") == "release_sync_check"
     assert "needs.release_sync_check.outputs.is_sync != 'true'" in trusted.get("if", "")
+    assert "git show origin/main:.github/scripts/validate-release-sync-pr.py" in workflow_text
+    assert "python /tmp/pullbox-release-sync-validator.py" in workflow_text
+    assert "python .github/scripts/validate-release-sync-pr.py" not in workflow_text
 
 
 def test_trusted_jobs_use_explicit_self_hosted_runner_labels() -> None:


### PR DESCRIPTION
## Summary
- add a narrow post-release sync detector for main-to-develop PRs
- let required aggregate checks fast-pass only for safe version-only develop sync PRs
- document the protected-branch release sync workflow

## Versioning
- main remains at 0.9.10
- no release tag or Docker publish is needed for this infrastructure-only change

## Validation
- pytest tests/unit/test_github_actions_security_contracts.py -q
- make workflow-hygiene
- ruff check .github/scripts/validate-release-sync-pr.py tests/unit/test_github_actions_security_contracts.py
- ruff format --check .github/scripts/validate-release-sync-pr.py tests/unit/test_github_actions_security_contracts.py
- python3 -m py_compile .github/scripts/validate-release-sync-pr.py
- git diff --check