### PR TITLE
Document release sync fast path

### DIFF
--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -197,6 +197,10 @@ GitHub Actions workflows live in `.github/workflows/`.
 
 - PR and merge queue checks are the authoritative correctness gate. Ordinary
   `main` merges should not rerun full CI or publish container images.
+- Post-release `main` to `develop` sync PRs may use the release-sync fast path
+  only when they are same-repository, version-only `feature/sync-develop-*`
+  PRs that carry `origin/main` forward and bump `src/pullbox/__init__.py` from
+  the released version to the next patch `-dev` version.
 - Docker validation is a PR/manual workflow. It never logs in to publish
   registries and never pushes images.
 - Docker publication depends on trusted refs and release tags.

--- a/docs/development/SECURITY_STANDARDS.md
+++ b/docs/development/SECURITY_STANDARDS.md
@@ -751,6 +751,9 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 - Public branch rulesets require the stable aggregate checks `CI Required`,
   `Security Required`, and `Workflow Hygiene Required` rather than brittle
   matrix or path-filtered job names.
+- The post-release sync fast path is intentionally narrow and executes its
+  validator from trusted `origin/main` before honoring any output that skips
+  heavyweight CI, security, workflow hygiene, or Docker validation jobs.
 
 **Required standard**
 
@@ -758,6 +761,9 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 - `pull_request_target` stays forbidden.
 - Workflows define explicit default permissions.
 - Jobs declare required permissions.
+- Any workflow fast path that can skip required work must be decided by trusted
+  base-ref code or an explicitly verified trusted blob, not by PR-controlled
+  scripts from the checkout.
 - Dependency scanning remains active in CI.
 - Container scanning remains active for Docker artifacts.
 - CodeQL must run on GitHub-hosted runners only.


### PR DESCRIPTION
## Summary
- document the release-sync fast path in infrastructure standards
- document the trusted-validator security rule for required-check fast paths

## Validation
- docs-only pre-commit hooks passed
- git diff --check