### PR TITLE
Move CI and release automation to CircleCI

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,73 @@
+# Pullbox CircleCI Migration
+
+This folder moves Pullbox CI/CD into CircleCI while preserving the existing
+quality, security, workflow hygiene, Docker validation, release publish, image
+signing, and GitHub Release gates.
+
+## Files
+
+- `config.yml` - CircleCI 2.1 config covering CI, security, workflow hygiene,
+  Docker validation, Docker release, image signing, and GitHub Release creation.
+- `scripts/release_sync_check.py` - conservative release-sync fast-path detector.
+- `scripts/docker_validate_gate.py` - Docker-sensitive path and trust detector.
+- `scripts/circleci_oidc_claims.py` - extracts CircleCI OIDC issuer and subject
+  for Cosign signature verification.
+- `scripts/github_release.py` - GitHub Release create/update helper.
+
+## Speed Optimizations Included
+
+- Python 3.12, 3.13, and 3.14 run as separate workflow jobs.
+- Each Python test job uses CircleCI `parallelism` plus timing-based splitting.
+- Coverage is collected per shard and combined per Python version.
+- E2E tests use CircleCI `parallelism` plus timing-based file splitting.
+- JUnit results are stored with `store_test_results` to feed timing data and
+  enable CircleCI rerun-failed-tests behavior.
+- Pip, venv, npm, and Playwright browser caches are included.
+- Docker Validate and Docker Release build/push jobs use Docker Layer Caching.
+- Heavy jobs use larger resource classes by default.
+- Docker publish remains tag/manual only.
+
+## Required CircleCI Environment
+
+Create restricted project environment variables or contexts for:
+
+- `DHI_USERNAME`
+- `DHI_TOKEN`
+- `GHCR_TOKEN` with package write access
+- `DOCKERHUB_USERNAME`
+- `DOCKERHUB_TOKEN`
+- `GITHUB_RELEASE_TOKEN` with contents write access
+- `GITHUB_CODEQL_TOKEN` with `security_events` write access
+- `GITHUB_TOKEN` or `GH_TOKEN` with pull request read access for release-sync base detection
+
+Cosign uses CircleCI OIDC through `CIRCLE_OIDC_TOKEN_V2`. The signing job derives
+the certificate issuer and identity from the token used to sign, verifies both
+published registries by digest, and passes the verification values to the GitHub
+Release helper.
+
+## Migration Notes
+
+- CodeQL runs through the CodeQL CLI and uploads SARIF to GitHub code scanning.
+  It is part of `security-required`, so CodeQL setup/upload failures block the
+  required security aggregate.
+- `gitleaks`, `actionlint`, and `grype` are pinned to immutable image digests.
+- The initial parallelism defaults are intentionally tunable:
+  `python_test_parallelism=6` and `e2e_parallelism=4`.
+- A custom Pullbox CI image with Python, Node, browser OS deps, actionlint,
+  gitleaks, grype, cosign, and gh preinstalled would likely reduce cold-start
+  overhead further once the workflow shape is stable.
+
+## Expected Required Checks
+
+After migration, branch protection should point at the CircleCI aggregate jobs:
+
+- `ci/circleci: ci-required`
+- `ci/circleci: security-required`
+- `ci/circleci: workflow-hygiene-required`
+
+Docker Validate can remain non-required if it stays path-gated, matching the
+current GitHub Actions behavior.
+
+Keep the existing GitHub Actions workflows enabled until CircleCI has emitted
+these contexts at least once. Then update the branch ruleset and disable the old
+workflows in the same follow-up change.

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -33,6 +33,7 @@ Create restricted project environment variables or contexts for:
 
 - `DHI_USERNAME`
 - `DHI_TOKEN`
+- `GHCR_USERNAME`
 - `GHCR_TOKEN` with package write access
 - `DOCKERHUB_USERNAME`
 - `DOCKERHUB_TOKEN`
@@ -53,7 +54,7 @@ Release helper.
 - `gitleaks`, `actionlint`, and `grype` are pinned to immutable image digests.
 - The parallelism and in-job worker defaults are intentionally tunable:
   `python_test_parallelism=6`, `python_test_workers=4`,
-  `e2e_parallelism=4`, and `e2e_workers=2`.
+  `e2e_parallelism=4`, and `e2e_workers=1`.
 - A custom Pullbox CI image with Python, Node, browser OS deps, actionlint,
   gitleaks, grype, cosign, and gh preinstalled would likely reduce cold-start
   overhead further once the workflow shape is stable.
@@ -69,6 +70,5 @@ After migration, branch protection should point at the CircleCI aggregate jobs:
 Docker Validate can remain non-required if it stays path-gated, matching the
 current GitHub Actions behavior.
 
-Keep the existing GitHub Actions workflows enabled until CircleCI has emitted
-these contexts at least once. Then update the branch ruleset and disable the old
-workflows in the same follow-up change.
+The legacy GitHub Actions Docker release workflow must not run on release tag
+pushes after this migration. CircleCI is the release publisher for `v*` tags.

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -27,6 +27,17 @@ signing, and GitHub Release gates.
 - Heavy jobs use larger resource classes by default.
 - Docker publish remains tag/manual only.
 
+## Trigger Policy
+
+- Open pull requests run the full CI/security/workflow-hygiene gate.
+- Pushes to open PR branches rerun that gate.
+- Direct pushes to `develop`, `main`, or unreviewed feature branches do not run
+  the expensive PR workflow.
+- Version tags matching `v*` run the Docker release/sign/GitHub Release
+  workflow.
+- The old weekly clean-room schedule and job are intentionally removed; use
+  local `make ci-full` when clean-room validation is needed.
+
 ## Required CircleCI Environment
 
 Create restricted project environment variables or contexts for:

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -51,8 +51,9 @@ Release helper.
   It is part of `security-required`, so CodeQL setup/upload failures block the
   required security aggregate.
 - `gitleaks`, `actionlint`, and `grype` are pinned to immutable image digests.
-- The initial parallelism defaults are intentionally tunable:
-  `python_test_parallelism=6` and `e2e_parallelism=4`.
+- The parallelism and in-job worker defaults are intentionally tunable:
+  `python_test_parallelism=6`, `python_test_workers=4`,
+  `e2e_parallelism=4`, and `e2e_workers=2`.
 - A custom Pullbox CI image with Python, Node, browser OS deps, actionlint,
   gitleaks, grype, cosign, and gh preinstalled would likely reduce cold-start
   overhead further once the workflow shape is stable.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,15 @@ parameters:
   python_test_parallelism:
     type: integer
     default: 6
+  python_test_workers:
+    type: integer
+    default: 4
   e2e_parallelism:
     type: integer
     default: 4
+  e2e_workers:
+    type: integer
+    default: 2
 
 executors:
   python312:
@@ -274,12 +280,15 @@ jobs:
       resource_class:
         type: string
         default: large
+      pytest_workers:
+        type: integer
+        default: 4
     executor: << parameters.executor_name >>
     parallelism: << parameters.parallelism >>
     resource_class: << parameters.resource_class >>
     environment:
       PULLBOX_SECRET_KEY: test-ci-key
-      PYTEST_WORKERS: "2"
+      PYTEST_WORKERS: "<< parameters.pytest_workers >>"
     steps:
       - checkout
       - attach_release_sync_state
@@ -383,12 +392,16 @@ jobs:
         default: ""
       parallelism:
         type: integer
+      pytest_workers:
+        type: integer
+        default: 2
     executor: python314
     parallelism: << parameters.parallelism >>
-    resource_class: large
+    resource_class: xlarge
     environment:
       PULLBOX_SECRET_KEY: test-ci-key
       PULLBOX_RATE_LIMIT_ENABLED: "false"
+      PYTEST_WORKERS: "<< parameters.pytest_workers >>"
     steps:
       - checkout
       - attach_release_sync_state
@@ -407,7 +420,7 @@ jobs:
             circleci tests glob "tests/e2e/test_*.py" \
               | grep -v '^tests/e2e/test_accessibility.py$' \
               | circleci tests run \
-                  --command "xargs -r .venv/bin/pytest -v -m 'not accessibility' --browser << parameters.browser >> << parameters.extra_args >> --video retain-on-failure --screenshot only-on-failure --full-page-screenshot --output=test-results/e2e/<< parameters.browser >> --junitxml=test-results/e2e/<< parameters.browser >>/junit-${CIRCLE_NODE_INDEX}.xml" \
+                  --command "xargs -r .venv/bin/pytest -n ${PYTEST_WORKERS} -v -m 'not accessibility' --browser << parameters.browser >> << parameters.extra_args >> --video retain-on-failure --screenshot only-on-failure --full-page-screenshot --output=test-results/e2e/<< parameters.browser >> --junitxml=test-results/e2e/<< parameters.browser >>/junit-${CIRCLE_NODE_INDEX}.xml" \
                   --split-by=timings \
                   --timings-type=filename
       - store_pytest_results:
@@ -1066,7 +1079,8 @@ workflows:
           python_version: "3.12"
           executor_name: python312
           parallelism: << pipeline.parameters.python_test_parallelism >>
-          resource_class: large
+          resource_class: xlarge
+          pytest_workers: << pipeline.parameters.python_test_workers >>
           requires:
             - quality-gate
             - typecheck
@@ -1076,7 +1090,8 @@ workflows:
           python_version: "3.13"
           executor_name: python313
           parallelism: << pipeline.parameters.python_test_parallelism >>
-          resource_class: large
+          resource_class: xlarge
+          pytest_workers: << pipeline.parameters.python_test_workers >>
           requires:
             - quality-gate
             - typecheck
@@ -1086,7 +1101,8 @@ workflows:
           python_version: "3.14"
           executor_name: python314
           parallelism: << pipeline.parameters.python_test_parallelism >>
-          resource_class: large
+          resource_class: xlarge
+          pytest_workers: << pipeline.parameters.python_test_workers >>
           requires:
             - quality-gate
             - typecheck
@@ -1118,6 +1134,7 @@ workflows:
           name: e2e-chromium
           browser: chromium
           parallelism: << pipeline.parameters.e2e_parallelism >>
+          pytest_workers: << pipeline.parameters.e2e_workers >>
           requires:
             - coverage-python-3.12
             - coverage-python-3.13
@@ -1127,6 +1144,7 @@ workflows:
           browser: firefox
           extra_args: "--durations=25 --durations-min=1.0"
           parallelism: << pipeline.parameters.e2e_parallelism >>
+          pytest_workers: << pipeline.parameters.e2e_workers >>
           requires:
             - coverage-python-3.12
             - coverage-python-3.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -664,33 +664,6 @@ jobs:
           name: Workflow Hygiene Required aggregate
           command: echo "Workflow hygiene completed successfully."
 
-  clean-room:
-    executor: python314_node
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Create clean-room venv
-          command: |
-            set -euo pipefail
-            python -m venv /tmp/pullbox-clean-room
-            echo "/tmp/pullbox-clean-room/bin" >> "$BASH_ENV"
-      - run:
-          name: Install clean-room dependencies
-          command: |
-            set -euo pipefail
-            /tmp/pullbox-clean-room/bin/python -m pip install --upgrade "pip>=26.0" wheel
-            /tmp/pullbox-clean-room/bin/python -m pip install -e ".[dev]"
-            npm ci --prefer-offline --no-audit
-      - run:
-          name: Clean-room lint/type/unit checks
-          command: |
-            set -euo pipefail
-            /tmp/pullbox-clean-room/bin/ruff check src/ tests/
-            /tmp/pullbox-clean-room/bin/ruff format --check src/ tests/
-            /tmp/pullbox-clean-room/bin/mypy src/pullbox/
-            PULLBOX_SECRET_KEY=test-ci-key /tmp/pullbox-clean-room/bin/pytest tests/unit/ -n 4 -q
-
   docker-validate:
     machine:
       image: ubuntu-2404:current
@@ -1074,16 +1047,26 @@ jobs:
 workflows:
   pr-and-merge-checks:
     jobs:
-      - release-sync-check
+      - release-sync-check:
+          filters: &pr_checks_filters
+            branches:
+              ignore:
+                - main
+                - develop
+            tags:
+              ignore: /.*/
       - quality-gate:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - typecheck:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - migration-check:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - test-python:
           name: test-python-3.12
           python_version: "3.12"
@@ -1095,6 +1078,7 @@ workflows:
             - quality-gate
             - typecheck
             - migration-check
+          filters: *pr_checks_filters
       - test-python:
           name: test-python-3.13
           python_version: "3.13"
@@ -1106,6 +1090,7 @@ workflows:
             - quality-gate
             - typecheck
             - migration-check
+          filters: *pr_checks_filters
       - test-python:
           name: test-python-3.14
           python_version: "3.14"
@@ -1117,29 +1102,34 @@ workflows:
             - quality-gate
             - typecheck
             - migration-check
+          filters: *pr_checks_filters
       - coverage-python:
           name: coverage-python-3.12
           python_version: "3.12"
           executor_name: python312
           requires:
             - test-python-3.12
+          filters: *pr_checks_filters
       - coverage-python:
           name: coverage-python-3.13
           python_version: "3.13"
           executor_name: python313
           requires:
             - test-python-3.13
+          filters: *pr_checks_filters
       - coverage-python:
           name: coverage-python-3.14
           python_version: "3.14"
           executor_name: python314
           requires:
             - test-python-3.14
+          filters: *pr_checks_filters
       - accessibility:
           requires:
             - quality-gate
             - typecheck
             - migration-check
+          filters: *pr_checks_filters
       - e2e:
           name: e2e-chromium
           browser: chromium
@@ -1149,6 +1139,7 @@ workflows:
             - coverage-python-3.12
             - coverage-python-3.13
             - coverage-python-3.14
+          filters: *pr_checks_filters
       - e2e:
           name: e2e-firefox
           browser: firefox
@@ -1159,27 +1150,34 @@ workflows:
             - coverage-python-3.12
             - coverage-python-3.13
             - coverage-python-3.14
+          filters: *pr_checks_filters
       - ci-required:
           requires:
             - accessibility
             - e2e-chromium
             - e2e-firefox
+          filters: *pr_checks_filters
 
       - gitleaks:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - pip-audit:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - safety-check:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - bandit:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - codeql:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - security-required:
           requires:
             - gitleaks
@@ -1187,29 +1185,21 @@ workflows:
             - safety-check
             - bandit
             - codeql
+          filters: *pr_checks_filters
 
       - workflow-hygiene:
           requires:
             - release-sync-check
+          filters: *pr_checks_filters
       - workflow-hygiene-required:
           requires:
             - workflow-hygiene
+          filters: *pr_checks_filters
 
       - docker-validate:
           requires:
             - release-sync-check
-
-  weekly-clean-room:
-    triggers:
-      - schedule:
-          cron: "30 6 * * 3"
-          filters:
-            branches:
-              only:
-                - develop
-                - main
-    jobs:
-      - clean-room
+          filters: *pr_checks_filters
 
   docker-release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ parameters:
     default: 4
   e2e_workers:
     type: integer
-    default: 2
+    default: 1
 
 executors:
   python312:
@@ -394,7 +394,7 @@ jobs:
         type: integer
       pytest_workers:
         type: integer
-        default: 2
+        default: 1
     executor: python314
     parallelism: << parameters.parallelism >>
     resource_class: xlarge
@@ -417,10 +417,14 @@ jobs:
             set -euo pipefail
             mkdir -p test-results/e2e/<< parameters.browser >>
             export PULLBOX_DB_URL="sqlite+aiosqlite:///test_e2e_${CIRCLE_WORKFLOW_ID}_${CIRCLE_NODE_INDEX}_<< parameters.browser >>.db"
+            PYTEST_XDIST_ARGS=""
+            if [ "${PYTEST_WORKERS}" -gt 1 ]; then
+              PYTEST_XDIST_ARGS="-n ${PYTEST_WORKERS}"
+            fi
             circleci tests glob "tests/e2e/test_*.py" \
               | grep -v '^tests/e2e/test_accessibility.py$' \
               | circleci tests run \
-                  --command "xargs -r .venv/bin/pytest -n ${PYTEST_WORKERS} -v -m 'not accessibility' --browser << parameters.browser >> << parameters.extra_args >> --video retain-on-failure --screenshot only-on-failure --full-page-screenshot --output=test-results/e2e/<< parameters.browser >> --junitxml=test-results/e2e/<< parameters.browser >>/junit-${CIRCLE_NODE_INDEX}.xml" \
+                  --command "xargs -r .venv/bin/pytest ${PYTEST_XDIST_ARGS} -v -m 'not accessibility' --browser << parameters.browser >> << parameters.extra_args >> --video retain-on-failure --screenshot only-on-failure --full-page-screenshot --output=test-results/e2e/<< parameters.browser >> --junitxml=test-results/e2e/<< parameters.browser >>/junit-${CIRCLE_NODE_INDEX}.xml" \
                   --split-by=timings \
                   --timings-type=filename
       - store_pytest_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -927,7 +927,7 @@ jobs:
               --metadata-file /tmp/image-metadata.json \
               .
             mkdir -p /tmp/pullbox-workspace/release-image-digest
-            python3 - \<<'PY'
+            python3 -c '
             import json
             from pathlib import Path
 
@@ -936,7 +936,7 @@ jobs:
             if not digest.startswith("sha256:"):
                 raise SystemExit(f"Could not determine pushed image digest from metadata: {metadata}")
             Path("/tmp/pullbox-workspace/release-image-digest/digest.txt").write_text(digest + "\n")
-            PY
+            '
       - persist_to_workspace:
           root: /tmp/pullbox-workspace
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,1252 @@
+version: 2.1
+
+# Design goals:
+# - Preserve existing gates: CI Required, Security Required, Workflow Hygiene Required.
+# - Preserve release-sync fast path, Docker validation, release image publish/sign/verify.
+# - Optimize for speed with timing-based splitting, dependency caches, Playwright cache,
+#   larger resource classes, and Docker Layer Caching for Docker jobs.
+
+parameters:
+  run_docker_release:
+    type: boolean
+    default: false
+  tag_override:
+    type: string
+    default: edge
+  python_test_parallelism:
+    type: integer
+    default: 6
+  e2e_parallelism:
+    type: integer
+    default: 4
+
+executors:
+  python312:
+    docker:
+      - image: cimg/python:3.12
+    working_directory: ~/project
+    environment:
+      PIP_CACHE_DIR: ~/.cache/pip
+      PYTHON_DEFAULT: "3.14"
+
+  python313:
+    docker:
+      - image: cimg/python:3.13
+    working_directory: ~/project
+    environment:
+      PIP_CACHE_DIR: ~/.cache/pip
+      PYTHON_DEFAULT: "3.14"
+
+  python314:
+    docker:
+      - image: cimg/python:3.14
+    working_directory: ~/project
+    environment:
+      PIP_CACHE_DIR: ~/.cache/pip
+      PYTHON_DEFAULT: "3.14"
+
+  python314_node:
+    docker:
+      - image: cimg/python:3.14-node
+    working_directory: ~/project
+    environment:
+      PIP_CACHE_DIR: ~/.cache/pip
+      PYTHON_DEFAULT: "3.14"
+
+  base:
+    docker:
+      - image: cimg/base:current
+    working_directory: ~/project
+
+commands:
+  restore_python_env:
+    description: Restore or build a Python venv and pip cache.
+    parameters:
+      python_version:
+        type: string
+      extras:
+        type: string
+        default: dev
+    steps:
+      - restore_cache:
+          keys:
+            - v4-venv-py<< parameters.python_version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+      - restore_cache:
+          keys:
+            - v4-pip-py<< parameters.python_version >>-{{ checksum "pyproject.toml" }}
+            - v4-pip-py<< parameters.python_version >>-
+      - run:
+          name: Install Python dependencies
+          command: |
+            set -euo pipefail
+            if [ ! -x .venv/bin/python ]; then
+              python -m venv .venv
+            fi
+            . .venv/bin/activate
+            python -m pip install --upgrade "pip>=26.0" wheel
+            python -m pip install -e ".[<< parameters.extras >>]"
+      - save_cache:
+          key: v4-pip-py<< parameters.python_version >>-{{ checksum "pyproject.toml" }}
+          paths:
+            - ~/.cache/pip
+      - save_cache:
+          key: v4-venv-py<< parameters.python_version >>-<< parameters.extras >>-{{ checksum "pyproject.toml" }}
+          paths:
+            - .venv
+
+  restore_node_deps:
+    description: Restore npm cache and install locked Node dependencies.
+    steps:
+      - restore_cache:
+          keys:
+            - v4-npm-{{ checksum "package-lock.json" }}
+            - v4-npm-
+      - run:
+          name: Install Node dependencies
+          command: npm ci --prefer-offline --no-audit
+      - save_cache:
+          key: v4-npm-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.npm
+
+  restore_playwright:
+    description: Restore Playwright browser cache and install required browser.
+    parameters:
+      browser:
+        type: string
+    steps:
+      - restore_cache:
+          keys:
+            - v4-playwright-<< parameters.browser >>-{{ checksum "pyproject.toml" }}
+            - v4-playwright-<< parameters.browser >>-
+      - run:
+          name: Install Playwright << parameters.browser >>
+          command: |
+            set -euo pipefail
+            . .venv/bin/activate
+            playwright install --with-deps << parameters.browser >>
+      - save_cache:
+          key: v4-playwright-<< parameters.browser >>-{{ checksum "pyproject.toml" }}
+          paths:
+            - ~/.cache/ms-playwright
+
+  attach_release_sync_state:
+    description: Attach release-sync fast-path decision.
+    steps:
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - run:
+          name: Load release-sync decision
+          command: |
+            set -euo pipefail
+            if [ -f /tmp/pullbox-workspace/release-sync/release_sync.env ]; then
+              cp /tmp/pullbox-workspace/release-sync/release_sync.env /tmp/release_sync.env
+            else
+              printf 'RELEASE_SYNC=false\nRELEASE_SYNC_REASON=missing release sync state\n' > /tmp/release_sync.env
+            fi
+            cat /tmp/release_sync.env
+
+  halt_if_release_sync:
+    description: Halt heavyweight work for trusted release-sync PRs.
+    steps:
+      - run:
+          name: Release-sync fast path
+          command: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            . /tmp/release_sync.env
+            if [ "${RELEASE_SYNC:-false}" = "true" ]; then
+              echo "Trusted release-sync PR detected: ${RELEASE_SYNC_REASON:-no reason recorded}"
+              circleci-agent step halt
+            fi
+
+  store_pytest_results:
+    description: Store pytest JUnit output and artifacts.
+    parameters:
+      path:
+        type: string
+    steps:
+      - store_test_results:
+          path: << parameters.path >>
+      - store_artifacts:
+          path: << parameters.path >>
+
+jobs:
+  release-sync-check:
+    executor: python314
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Detect safe post-release sync PR
+          command: |
+            set -euo pipefail
+            mkdir -p /tmp/pullbox-workspace/release-sync
+            git fetch --no-tags origin main:refs/remotes/origin/main develop:refs/remotes/origin/develop || true
+            if git cat-file -e origin/main:.circleci/scripts/release_sync_check.py 2>/dev/null; then
+              git show origin/main:.circleci/scripts/release_sync_check.py > /tmp/pullbox-release-sync-validator.py
+            else
+              cp .circleci/scripts/release_sync_check.py /tmp/pullbox-release-sync-validator.py
+            fi
+            python /tmp/pullbox-release-sync-validator.py > /tmp/pullbox-workspace/release-sync/release_sync.env
+            cat /tmp/pullbox-workspace/release-sync/release_sync.env
+      - persist_to_workspace:
+          root: /tmp/pullbox-workspace
+          paths:
+            - release-sync/release_sync.env
+
+  quality-gate:
+    executor: python314_node
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - restore_node_deps
+      - run:
+          name: Ruff lint
+          command: .venv/bin/ruff check src/ tests/
+      - run:
+          name: Ruff format check
+          command: .venv/bin/ruff format --check src/ tests/
+      - run:
+          name: Rebuild Tailwind CSS
+          command: npm run css:build
+      - run:
+          name: Check generated CSS
+          command: |
+            set -euo pipefail
+            git diff --exit-code src/pullbox/ui/static/css/tailwind.css || {
+              echo "Tailwind CSS output is stale. Run make css-build and commit the result."
+              exit 1
+            }
+
+  typecheck:
+    executor: python314
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Mypy
+          command: .venv/bin/mypy src/pullbox/
+
+  migration-check:
+    executor: python314
+    resource_class: medium
+    environment:
+      PULLBOX_SECRET_KEY: test-ci-key
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Verify migrations apply from empty DB
+          command: |
+            set -euo pipefail
+            PULLBOX_DB_URL="sqlite+aiosqlite:///test_migration.db" .venv/bin/alembic -c alembic/alembic.ini upgrade head
+            PULLBOX_DB_URL="sqlite+aiosqlite:///test_migration.db" .venv/bin/alembic -c alembic/alembic.ini downgrade base
+      - run:
+          name: Verify app boots after migration
+          command: |
+            set -euo pipefail
+            PULLBOX_DB_URL="sqlite+aiosqlite:///test_boot.db" .venv/bin/alembic -c alembic/alembic.ini upgrade head
+            PULLBOX_DB_URL="sqlite+aiosqlite:///test_boot.db" timeout 10 .venv/bin/python -c "from pullbox.app import create_app; create_app(); print('App factory created successfully')"
+
+  test-python:
+    parameters:
+      python_version:
+        type: string
+      executor_name:
+        type: executor
+      parallelism:
+        type: integer
+      resource_class:
+        type: string
+        default: large
+    executor: << parameters.executor_name >>
+    parallelism: << parameters.parallelism >>
+    resource_class: << parameters.resource_class >>
+    environment:
+      PULLBOX_SECRET_KEY: test-ci-key
+      PYTEST_WORKERS: "2"
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: << parameters.python_version >>
+          extras: dev
+      - run:
+          name: Run pytest shard with coverage
+          command: |
+            set -euo pipefail
+            mkdir -p test-results/pytest/python-<< parameters.python_version >> coverage/python-<< parameters.python_version >>
+            export COVERAGE_FILE="coverage/python-<< parameters.python_version >>/.coverage.${CIRCLE_NODE_INDEX}"
+            circleci tests glob "tests/**/*.py" \
+              | grep -v '^tests/e2e/' \
+              | circleci tests run \
+                  --command "xargs -r .venv/bin/pytest -n ${PYTEST_WORKERS} --cov=pullbox --cov-report=term-missing --junitxml=test-results/pytest/python-<< parameters.python_version >>/junit-${CIRCLE_NODE_INDEX}.xml -v" \
+                  --split-by=timings \
+                  --timings-type=filename
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage/python-<< parameters.python_version >>
+      - store_pytest_results:
+          path: test-results/pytest/python-<< parameters.python_version >>
+
+  coverage-python:
+    parameters:
+      python_version:
+        type: string
+      executor_name:
+        type: executor
+    executor: << parameters.executor_name >>
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - attach_workspace:
+          at: .
+      - restore_python_env:
+          python_version: << parameters.python_version >>
+          extras: dev
+      - run:
+          name: Combine coverage and enforce 90 percent threshold
+          command: |
+            set -euo pipefail
+            . .venv/bin/activate
+            coverage combine coverage/python-<< parameters.python_version >>
+            coverage report --fail-under=90 --show-missing
+            coverage xml -o coverage-python-<< parameters.python_version >>.xml
+      - store_artifacts:
+          path: coverage-python-<< parameters.python_version >>.xml
+          destination: coverage/coverage-python-<< parameters.python_version >>.xml
+
+  accessibility:
+    executor: python314_node
+    resource_class: large
+    environment:
+      PULLBOX_SECRET_KEY: test-ci-key
+      PULLBOX_DB_URL: sqlite+aiosqlite:///test_a11y.db
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_node_deps
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev,e2e
+      - restore_playwright:
+          browser: chromium
+      - run:
+          name: Run contrast audit
+          command: .venv/bin/python scripts/check_ui_contrast.py
+      - run:
+          name: Run accessibility browser tests
+          command: |
+            set -euo pipefail
+            mkdir -p test-results/accessibility test-results/e2e
+            .venv/bin/pytest tests/e2e/ \
+              -v \
+              -m accessibility \
+              --browser chromium \
+              --video retain-on-failure \
+              --screenshot only-on-failure \
+              --full-page-screenshot \
+              --output=test-results/e2e \
+              --junitxml=test-results/accessibility/junit.xml
+      - store_pytest_results:
+          path: test-results/accessibility
+      - store_artifacts:
+          path: test-results/e2e
+          destination: accessibility-artifacts
+
+  e2e:
+    parameters:
+      browser:
+        type: string
+      extra_args:
+        type: string
+        default: ""
+      parallelism:
+        type: integer
+    executor: python314
+    parallelism: << parameters.parallelism >>
+    resource_class: large
+    environment:
+      PULLBOX_SECRET_KEY: test-ci-key
+      PULLBOX_RATE_LIMIT_ENABLED: "false"
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev,e2e
+      - restore_playwright:
+          browser: << parameters.browser >>
+      - run:
+          name: Run E2E << parameters.browser >> shard
+          command: |
+            set -euo pipefail
+            mkdir -p test-results/e2e/<< parameters.browser >>
+            export PULLBOX_DB_URL="sqlite+aiosqlite:///test_e2e_${CIRCLE_WORKFLOW_ID}_${CIRCLE_NODE_INDEX}_<< parameters.browser >>.db"
+            circleci tests glob "tests/e2e/test_*.py" \
+              | grep -v '^tests/e2e/test_accessibility.py$' \
+              | circleci tests run \
+                  --command "xargs -r .venv/bin/pytest -v -m 'not accessibility' --browser << parameters.browser >> << parameters.extra_args >> --video retain-on-failure --screenshot only-on-failure --full-page-screenshot --output=test-results/e2e/<< parameters.browser >> --junitxml=test-results/e2e/<< parameters.browser >>/junit-${CIRCLE_NODE_INDEX}.xml" \
+                  --split-by=timings \
+                  --timings-type=filename
+      - store_pytest_results:
+          path: test-results/e2e/<< parameters.browser >>
+      - store_artifacts:
+          path: test-results/e2e/<< parameters.browser >>
+          destination: playwright-artifacts/<< parameters.browser >>
+
+  ci-required:
+    executor: base
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - run:
+          name: CI Required aggregate
+          command: |
+            set -euo pipefail
+            cat /tmp/pullbox-workspace/release-sync/release_sync.env || true
+            echo "All required CI jobs completed successfully."
+
+  gitleaks:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: medium
+    environment:
+      GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - run:
+          name: Run gitleaks
+          command: |
+            set -euo pipefail
+            mkdir -p test-results/security
+            if [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+              BASE_SHA="$(git merge-base origin/develop HEAD || true)"
+              if [ -n "${BASE_SHA}" ]; then
+                docker run --rm \
+                  --user "$(id -u):$(id -g)" \
+                  -v "$PWD:/repo" \
+                  -w /repo \
+                  "${GITLEAKS_IMAGE}" \
+                  git . \
+                  --log-opts="--no-merges ${BASE_SHA}..HEAD" \
+                  --no-banner \
+                  --redact \
+                  --timeout=300 \
+                  --report-format sarif \
+                  --report-path test-results/security/gitleaks.sarif
+              fi
+            else
+              docker run --rm \
+                --user "$(id -u):$(id -g)" \
+                -v "$PWD:/repo" \
+                -w /repo \
+                "${GITLEAKS_IMAGE}" \
+                dir . \
+                --no-banner \
+                --redact \
+                --timeout=300 \
+                --report-format sarif \
+                --report-path test-results/security/gitleaks.sarif
+            fi
+      - store_artifacts:
+          path: test-results/security/gitleaks.sarif
+          destination: security/gitleaks.sarif
+
+  pip-audit:
+    executor: python314
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Run pip-audit
+          command: |
+            set -euo pipefail
+            . .venv/bin/activate
+            pip freeze --exclude-editable | grep -v "^pullbox==" > /tmp/requirements-audit.txt
+            pip-audit --strict --desc on -r /tmp/requirements-audit.txt \
+              --ignore-vuln GHSA-rf74-v2fm-23pw \
+              --ignore-vuln CVE-2026-33230 \
+              --ignore-vuln CVE-2026-33231 \
+              --ignore-vuln CVE-2026-4539
+
+  safety-check:
+    executor: python314
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Run Safety advisory scan
+          command: .venv/bin/safety check --save-json safety-report.json || true
+      - store_artifacts:
+          path: safety-report.json
+          destination: security/safety-report.json
+
+  bandit:
+    executor: python314
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Run Bandit advisory scan
+          command: .venv/bin/bandit -r src/pullbox/ -ll -f json -o bandit-report.json || true
+      - store_artifacts:
+          path: bandit-report.json
+          destination: security/bandit-report.json
+
+  codeql:
+    executor: base
+    resource_class: large
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - restore_cache:
+          keys:
+            - v1-codeql-cli-v2.25.6
+      - run:
+          name: Install CodeQL CLI
+          command: |
+            set -euo pipefail
+            CODEQL_VERSION="v2.25.6"
+            CODEQL_HOME="${HOME}/.cache/codeql/${CODEQL_VERSION}"
+            CODEQL_BIN="${CODEQL_HOME}/codeql/codeql"
+            if [ ! -x "${CODEQL_BIN}" ]; then
+              sudo apt-get update
+              sudo apt-get install -y unzip
+              rm -rf "${CODEQL_HOME}"
+              mkdir -p "${CODEQL_HOME}"
+              curl -sSfL "https://github.com/github/codeql-cli-binaries/releases/download/${CODEQL_VERSION}/codeql-linux64.zip" -o /tmp/codeql-linux64.zip
+              unzip -q /tmp/codeql-linux64.zip -d "${CODEQL_HOME}"
+              rm -f /tmp/codeql-linux64.zip
+            fi
+            echo "export CODEQL_BIN=${CODEQL_BIN}" >> "${BASH_ENV}"
+      - save_cache:
+          key: v1-codeql-cli-v2.25.6
+          paths:
+            - ~/.cache/codeql/v2.25.6
+      - run:
+          name: Create and analyze CodeQL database
+          command: |
+            set -euo pipefail
+            # shellcheck disable=SC1090
+            . "${BASH_ENV}"
+            mkdir -p codeql-results
+            "${CODEQL_BIN}" database create codeql-db \
+              --language=python \
+              --source-root=. \
+              --build-mode=none \
+              --codescanning-config=.github/codeql/codeql-config.yml \
+              --overwrite
+            "${CODEQL_BIN}" database analyze codeql-db \
+              --format=sarifv2.1.0 \
+              --output=codeql-results/codeql-results.sarif \
+              --sarif-category="/language:python" \
+              --threads=0
+      - run:
+          name: Upload CodeQL SARIF to GitHub
+          command: |
+            set -euo pipefail
+            # shellcheck disable=SC1090
+            . "${BASH_ENV}"
+            : "${GITHUB_CODEQL_TOKEN:?GITHUB_CODEQL_TOKEN with security_events write access is required}"
+            if [ -n "${CIRCLE_TAG:-}" ]; then
+              CODEQL_REF="refs/tags/${CIRCLE_TAG}"
+            elif [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
+              PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
+              if [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
+                CODEQL_REF="refs/pull/${PR_NUMBER}/head"
+              else
+                CODEQL_REF="refs/heads/${CIRCLE_BRANCH}"
+              fi
+            else
+              CODEQL_REF="refs/heads/${CIRCLE_BRANCH}"
+            fi
+            printf '%s' "${GITHUB_CODEQL_TOKEN}" | "${CODEQL_BIN}" github upload-results \
+              --sarif=codeql-results/codeql-results.sarif \
+              --repository="${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" \
+              --ref="${CODEQL_REF}" \
+              --commit="${CIRCLE_SHA1}" \
+              --github-auth-stdin \
+              --wait-for-processing-timeout=120
+      - store_artifacts:
+          path: codeql-results/codeql-results.sarif
+          destination: security/codeql-results.sarif
+
+  security-required:
+    executor: base
+    resource_class: small
+    steps:
+      - run:
+          name: Security Required aggregate
+          command: echo "All required security jobs completed successfully."
+
+  workflow-hygiene:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - run:
+          name: Run actionlint
+          command: |
+            set -euo pipefail
+            docker run --rm \
+              --user "$(id -u):$(id -g)" \
+              -v "$PWD:/repo" \
+              -w /repo \
+              docker.io/rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+              -shellcheck= -pyflakes=
+
+  workflow-hygiene-required:
+    executor: base
+    resource_class: small
+    steps:
+      - run:
+          name: Workflow Hygiene Required aggregate
+          command: echo "Workflow hygiene completed successfully."
+
+  clean-room:
+    executor: python314_node
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Create clean-room venv
+          command: |
+            set -euo pipefail
+            python -m venv /tmp/pullbox-clean-room
+            echo "/tmp/pullbox-clean-room/bin" >> "$BASH_ENV"
+      - run:
+          name: Install clean-room dependencies
+          command: |
+            set -euo pipefail
+            /tmp/pullbox-clean-room/bin/python -m pip install --upgrade "pip>=26.0" wheel
+            /tmp/pullbox-clean-room/bin/python -m pip install -e ".[dev]"
+            npm ci --prefer-offline --no-audit
+      - run:
+          name: Clean-room lint/type/unit checks
+          command: |
+            set -euo pipefail
+            /tmp/pullbox-clean-room/bin/ruff check src/ tests/
+            /tmp/pullbox-clean-room/bin/ruff format --check src/ tests/
+            /tmp/pullbox-clean-room/bin/mypy src/pullbox/
+            PULLBOX_SECRET_KEY=test-ci-key /tmp/pullbox-clean-room/bin/pytest tests/unit/ -n 4 -q
+
+  docker-validate:
+    machine:
+      image: ubuntu-2404:current
+      docker_layer_caching: true
+    resource_class: xlarge
+    environment:
+      PYTHON_DEFAULT: "3.14"
+      GRYPE_IMAGE: docker.io/anchore/grype@sha256:7a9fc7f89ccef78ae5a7691a115d3f0d41b1f319d589dd8cc1dcb9ab3f01dd28
+    steps:
+      - checkout
+      - attach_release_sync_state
+      - halt_if_release_sync
+      - run:
+          name: Decide Docker validation mode
+          command: |
+            set -euo pipefail
+            python .circleci/scripts/docker_validate_gate.py > /tmp/docker_validate.env
+            cat /tmp/docker_validate.env
+      - run:
+          name: Run Docker validation
+          command: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            . /tmp/docker_validate.env
+            if [ "${DOCKER_VALIDATE_REQUIRED}" != "true" ]; then
+              echo "Docker-sensitive files did not change; halting Docker Validate."
+              circleci-agent step halt
+            fi
+
+            if [ "${DOCKER_VALIDATE_MODE}" = "untrusted" ]; then
+              docker build -f docker/Dockerfile.dev -t pullbox:pr-sanity .
+              docker image inspect pullbox:pr-sanity >/dev/null
+              exit 0
+            fi
+
+            if [ -z "${DHI_USERNAME:-}" ] || [ -z "${DHI_TOKEN:-}" ]; then
+              echo "DHI_USERNAME and DHI_TOKEN are required for trusted Docker validation."
+              exit 1
+            fi
+            echo "${DHI_TOKEN}" | docker login dhi.io -u "${DHI_USERNAME}" --password-stdin
+            BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            GIT_SHA="${CIRCLE_SHA1}"
+            docker build \
+              -f docker/Dockerfile \
+              -t pullbox:validate \
+              --build-arg BUILD_DATE="${BUILD_DATE}" \
+              --build-arg GIT_SHA="${GIT_SHA}" \
+              --build-arg GIT_BRANCH="${CIRCLE_BRANCH}" \
+              --build-arg VERSION="validate-${GIT_SHA:0:7}" \
+              .
+            docker image inspect pullbox:validate >/dev/null
+      - run:
+          name: Scan and smoke-test production image
+          command: |
+            set -euo pipefail
+            # shellcheck disable=SC1091
+            . /tmp/docker_validate.env
+            if [ "${DOCKER_VALIDATE_REQUIRED}" != "true" ] || [ "${DOCKER_VALIDATE_MODE}" = "untrusted" ]; then
+              circleci-agent step halt
+            fi
+            docker run --rm \
+              -v "$PWD/.grype.yaml:/workspace/.grype.yaml:ro" \
+              "${GRYPE_IMAGE}" \
+              pullbox:validate \
+              --config /workspace/.grype.yaml \
+              --fail-on high
+            docker run --rm --entrypoint python pullbox:validate -c '
+            import pullbox.app
+            assets = [
+                pullbox.app.STATIC_DIR / "css" / "tailwind.css",
+                pullbox.app.STATIC_DIR / "js" / "htmx.min.js",
+            ]
+            missing = [str(asset) for asset in assets if not asset.is_file()]
+            if missing:
+                raise SystemExit("Missing packaged static assets: " + ", ".join(missing))
+            print("Packaged static assets verified")
+            '
+            docker run -d \
+              --name pullbox-validate \
+              -p 127.0.0.1::8585 \
+              -e PULLBOX_SECRET_KEY=docker-validate-secret-key-for-ci \
+              -e PULLBOX_LOG_LEVEL=WARNING \
+              pullbox:validate
+            validate_port="$(docker port pullbox-validate 8585/tcp | awk -F: 'NR == 1 { print $NF }')"
+            for i in $(seq 1 30); do
+              if curl -sf "http://127.0.0.1:${validate_port}/ping" >/dev/null 2>&1; then
+                exit 0
+              fi
+              sleep 1
+            done
+            docker logs pullbox-validate
+            exit 1
+      - run:
+          name: Cleanup Docker Validate
+          when: always
+          command: docker rm -f pullbox-validate || true
+
+  docker-release-build:
+    machine:
+      image: ubuntu-2404:current
+      docker_layer_caching: true
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Build amd64 image for scan and smoke
+          command: |
+            set -euo pipefail
+            if [ -z "${DHI_USERNAME:-}" ] || [ -z "${DHI_TOKEN:-}" ]; then
+              echo "DHI_USERNAME and DHI_TOKEN are required for Docker release builds."
+              exit 1
+            fi
+            echo "${DHI_TOKEN}" | docker login dhi.io -u "${DHI_USERNAME}" --password-stdin
+            VERSION="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)"
+            BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            docker buildx create --use --name pullbox-builder || docker buildx use pullbox-builder
+            docker buildx build \
+              -f docker/Dockerfile \
+              --platform linux/amd64 \
+              --load \
+              -t pullbox:ci-scan \
+              --build-arg BUILD_DATE="${BUILD_DATE}" \
+              --build-arg GIT_SHA="${CIRCLE_SHA1}" \
+              --build-arg GIT_BRANCH="${CIRCLE_BRANCH:-${CIRCLE_TAG:-tag}}" \
+              --build-arg VERSION="${VERSION}" \
+              .
+            mkdir -p /tmp/pullbox-workspace/docker-image
+            docker save pullbox:ci-scan | gzip > /tmp/pullbox-workspace/docker-image/pullbox-image.tar.gz
+      - persist_to_workspace:
+          root: /tmp/pullbox-workspace
+          paths:
+            - docker-image/pullbox-image.tar.gz
+
+  docker-release-scan:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: large
+    environment:
+      GRYPE_IMAGE: docker.io/anchore/grype@sha256:7a9fc7f89ccef78ae5a7691a115d3f0d41b1f319d589dd8cc1dcb9ab3f01dd28
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - run:
+          name: Load and scan release image
+          command: |
+            set -euo pipefail
+            docker load < /tmp/pullbox-workspace/docker-image/pullbox-image.tar.gz
+            docker run --rm \
+              -v "$PWD/.grype.yaml:/workspace/.grype.yaml:ro" \
+              "${GRYPE_IMAGE}" \
+              pullbox:ci-scan \
+              --config /workspace/.grype.yaml \
+              --fail-on high
+
+  docker-release-smoke:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: large
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - run:
+          name: Smoke-test release image
+          command: |
+            set -euo pipefail
+            docker load < /tmp/pullbox-workspace/docker-image/pullbox-image.tar.gz
+            docker run --rm --entrypoint python pullbox:ci-scan -c '
+            import pullbox.app
+            assets = [
+                pullbox.app.STATIC_DIR / "css" / "tailwind.css",
+                pullbox.app.STATIC_DIR / "js" / "htmx.min.js",
+            ]
+            missing = [str(asset) for asset in assets if not asset.is_file()]
+            if missing:
+                raise SystemExit("Missing packaged static assets: " + ", ".join(missing))
+            print("Packaged static assets verified")
+            '
+            docker run -d \
+              --name pullbox-smoke \
+              -p 127.0.0.1::8585 \
+              -e PULLBOX_SECRET_KEY=smoke-test-secret-key-for-docker-ci \
+              -e PULLBOX_LOG_LEVEL=WARNING \
+              pullbox:ci-scan
+            smoke_port="$(docker port pullbox-smoke 8585/tcp | awk -F: 'NR == 1 { print $NF }')"
+            for i in $(seq 1 30); do
+              if curl -sf "http://127.0.0.1:${smoke_port}/ping" >/dev/null 2>&1; then
+                exit 0
+              fi
+              sleep 1
+            done
+            docker logs pullbox-smoke
+            exit 1
+      - run:
+          name: Cleanup release smoke container
+          when: always
+          command: docker rm -f pullbox-smoke || true
+
+  docker-release-push:
+    machine:
+      image: ubuntu-2404:current
+      docker_layer_caching: true
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run:
+          name: Build and push multi-arch image
+          command: |
+            set -euo pipefail
+            : "${DHI_USERNAME:?DHI_USERNAME is required}"
+            : "${DHI_TOKEN:?DHI_TOKEN is required}"
+            : "${GHCR_TOKEN:?GHCR_TOKEN with package write access is required}"
+            : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME is required}"
+            : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN is required}"
+            echo "${DHI_TOKEN}" | docker login dhi.io -u "${DHI_USERNAME}" --password-stdin
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${CIRCLE_PROJECT_USERNAME}" --password-stdin
+            echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
+            VERSION="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)"
+            BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            RELEASE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.tag_override >>}"
+            if [ -n "${CIRCLE_TAG:-}" ] && [[ "${CIRCLE_TAG}" == v* ]]; then
+              SEMVER_TAG="${CIRCLE_TAG#v}"
+            else
+              SEMVER_TAG="<< pipeline.parameters.tag_override >>"
+            fi
+            GHCR_IMAGE="ghcr.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            DOCKERHUB_IMAGE="docker.io/pullbox/pullbox"
+            SHA_TAG="sha-${CIRCLE_SHA1:0:7}"
+            TAG_ARGS=(
+              -t "${GHCR_IMAGE}:${SEMVER_TAG}"
+              -t "${GHCR_IMAGE}:${SHA_TAG}"
+              -t "${DOCKERHUB_IMAGE}:${SEMVER_TAG}"
+              -t "${DOCKERHUB_IMAGE}:${SHA_TAG}"
+            )
+            if [ -n "${CIRCLE_TAG:-}" ] && [[ "${CIRCLE_TAG}" != *-* ]]; then
+              TAG_ARGS+=(-t "${GHCR_IMAGE}:latest" -t "${DOCKERHUB_IMAGE}:latest")
+            fi
+            docker buildx create --use --name pullbox-builder || docker buildx use pullbox-builder
+            docker buildx build \
+              -f docker/Dockerfile \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              "${TAG_ARGS[@]}" \
+              --label org.opencontainers.image.title=Pullbox \
+              --label "org.opencontainers.image.description=Modern comic book management and acquisition platform" \
+              --label "org.opencontainers.image.source=https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" \
+              --label "org.opencontainers.image.revision=${CIRCLE_SHA1}" \
+              --label "org.opencontainers.image.version=${VERSION}" \
+              --build-arg BUILD_DATE="${BUILD_DATE}" \
+              --build-arg GIT_SHA="${CIRCLE_SHA1}" \
+              --build-arg GIT_BRANCH="${CIRCLE_BRANCH:-${RELEASE_TAG}}" \
+              --build-arg VERSION="${VERSION}" \
+              --provenance=mode=max \
+              --sbom=true \
+              --metadata-file /tmp/image-metadata.json \
+              .
+            mkdir -p /tmp/pullbox-workspace/release-image-digest
+            python3 - \<<'PY'
+            import json
+            from pathlib import Path
+
+            metadata = json.loads(Path("/tmp/image-metadata.json").read_text())
+            digest = metadata.get("containerimage.digest") or metadata.get("image.name", "").split("@")[-1]
+            if not digest.startswith("sha256:"):
+                raise SystemExit(f"Could not determine pushed image digest from metadata: {metadata}")
+            Path("/tmp/pullbox-workspace/release-image-digest/digest.txt").write_text(digest + "\n")
+            PY
+      - persist_to_workspace:
+          root: /tmp/pullbox-workspace
+          paths:
+            - release-image-digest/digest.txt
+
+  docker-release-sign:
+    machine:
+      image: ubuntu-2404:current
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - run:
+          name: Install Cosign
+          command: |
+            set -euo pipefail
+            curl -sSfL https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-amd64 -o /usr/local/bin/cosign
+            chmod +x /usr/local/bin/cosign
+      - run:
+          name: Sign and verify release image digest
+          command: |
+            set -euo pipefail
+            : "${CIRCLE_OIDC_TOKEN_V2:?CircleCI OIDC token is required for keyless signing}"
+            : "${GHCR_TOKEN:?GHCR_TOKEN is required}"
+            : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME is required}"
+            : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN is required}"
+            mkdir -p /tmp/pullbox-workspace/release-signing
+            python3 .circleci/scripts/circleci_oidc_claims.py > /tmp/pullbox-workspace/release-signing/cosign.env
+            # shellcheck disable=SC1091
+            . /tmp/pullbox-workspace/release-signing/cosign.env
+            DIGEST="$(tr -d '[:space:]' < /tmp/pullbox-workspace/release-image-digest/digest.txt)"
+            GHCR_IMAGE="ghcr.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
+            DOCKERHUB_IMAGE="docker.io/pullbox/pullbox"
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${CIRCLE_PROJECT_USERNAME}" --password-stdin
+            echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
+            cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${GHCR_IMAGE}@${DIGEST}"
+            cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${DOCKERHUB_IMAGE}@${DIGEST}"
+
+            verify_image_signature() {
+              local image_ref="$1"
+              local label="$2"
+              local attempt
+              local max_attempts=6
+
+              for attempt in $(seq 1 "${max_attempts}"); do
+                if cosign verify \
+                  --certificate-identity "${COSIGN_CERTIFICATE_IDENTITY}" \
+                  --certificate-oidc-issuer "${COSIGN_CERTIFICATE_OIDC_ISSUER}" \
+                  "${image_ref}"; then
+                  return 0
+                fi
+
+                if [ "${attempt}" -eq "${max_attempts}" ]; then
+                  echo "Signature for ${label} was not discoverable after ${max_attempts} attempts."
+                  return 1
+                fi
+
+                echo "Signature for ${label} was not discoverable yet; retrying in 10 seconds (${attempt}/${max_attempts})."
+                sleep 10
+              done
+            }
+
+            verify_image_signature "${GHCR_IMAGE}@${DIGEST}" "GHCR"
+            verify_image_signature "${DOCKERHUB_IMAGE}@${DIGEST}" "Docker Hub"
+      - persist_to_workspace:
+          root: /tmp/pullbox-workspace
+          paths:
+            - release-signing/cosign.env
+      - store_artifacts:
+          path: /tmp/pullbox-workspace/release-image-digest/digest.txt
+          destination: release/digest.txt
+      - store_artifacts:
+          path: /tmp/pullbox-workspace/release-signing/cosign.env
+          destination: release/cosign.env
+
+  github-release:
+    executor: python314
+    resource_class: medium
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/pullbox-workspace
+      - restore_python_env:
+          python_version: "3.14"
+          extras: dev
+      - run:
+          name: Create or update GitHub Release
+          command: |
+            set -euo pipefail
+            : "${GITHUB_RELEASE_TOKEN:?GITHUB_RELEASE_TOKEN with contents write access is required}"
+            TAG="${CIRCLE_TAG:?Git tag is required}"
+            VERSION="${TAG#v}"
+            .venv/bin/python scripts/extract_changelog_section.py --version "${VERSION}" --output curated_changelog.md
+            DIGEST="$(tr -d '[:space:]' < /tmp/pullbox-workspace/release-image-digest/digest.txt)"
+            if [ -f /tmp/pullbox-workspace/release-signing/cosign.env ]; then
+              # shellcheck disable=SC1091
+              . /tmp/pullbox-workspace/release-signing/cosign.env
+            fi
+            python .circleci/scripts/github_release.py \
+              --repository "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" \
+              --tag "${TAG}" \
+              --version "${VERSION}" \
+              --digest "${DIGEST}" \
+              --changelog curated_changelog.md
+
+workflows:
+  pr-and-merge-checks:
+    jobs:
+      - release-sync-check
+      - quality-gate:
+          requires:
+            - release-sync-check
+      - typecheck:
+          requires:
+            - release-sync-check
+      - migration-check:
+          requires:
+            - release-sync-check
+      - test-python:
+          name: test-python-3.12
+          python_version: "3.12"
+          executor_name: python312
+          parallelism: << pipeline.parameters.python_test_parallelism >>
+          resource_class: large
+          requires:
+            - quality-gate
+            - typecheck
+            - migration-check
+      - test-python:
+          name: test-python-3.13
+          python_version: "3.13"
+          executor_name: python313
+          parallelism: << pipeline.parameters.python_test_parallelism >>
+          resource_class: large
+          requires:
+            - quality-gate
+            - typecheck
+            - migration-check
+      - test-python:
+          name: test-python-3.14
+          python_version: "3.14"
+          executor_name: python314
+          parallelism: << pipeline.parameters.python_test_parallelism >>
+          resource_class: large
+          requires:
+            - quality-gate
+            - typecheck
+            - migration-check
+      - coverage-python:
+          name: coverage-python-3.12
+          python_version: "3.12"
+          executor_name: python312
+          requires:
+            - test-python-3.12
+      - coverage-python:
+          name: coverage-python-3.13
+          python_version: "3.13"
+          executor_name: python313
+          requires:
+            - test-python-3.13
+      - coverage-python:
+          name: coverage-python-3.14
+          python_version: "3.14"
+          executor_name: python314
+          requires:
+            - test-python-3.14
+      - accessibility:
+          requires:
+            - quality-gate
+            - typecheck
+            - migration-check
+      - e2e:
+          name: e2e-chromium
+          browser: chromium
+          parallelism: << pipeline.parameters.e2e_parallelism >>
+          requires:
+            - coverage-python-3.12
+            - coverage-python-3.13
+            - coverage-python-3.14
+      - e2e:
+          name: e2e-firefox
+          browser: firefox
+          extra_args: "--durations=25 --durations-min=1.0"
+          parallelism: << pipeline.parameters.e2e_parallelism >>
+          requires:
+            - coverage-python-3.12
+            - coverage-python-3.13
+            - coverage-python-3.14
+      - ci-required:
+          requires:
+            - accessibility
+            - e2e-chromium
+            - e2e-firefox
+
+      - gitleaks:
+          requires:
+            - release-sync-check
+      - pip-audit:
+          requires:
+            - release-sync-check
+      - safety-check:
+          requires:
+            - release-sync-check
+      - bandit:
+          requires:
+            - release-sync-check
+      - codeql:
+          requires:
+            - release-sync-check
+      - security-required:
+          requires:
+            - gitleaks
+            - pip-audit
+            - safety-check
+            - bandit
+            - codeql
+
+      - workflow-hygiene:
+          requires:
+            - release-sync-check
+      - workflow-hygiene-required:
+          requires:
+            - workflow-hygiene
+
+      - docker-validate:
+          requires:
+            - release-sync-check
+
+  weekly-clean-room:
+    triggers:
+      - schedule:
+          cron: "30 6 * * 3"
+          filters:
+            branches:
+              only:
+                - develop
+                - main
+    jobs:
+      - clean-room
+
+  docker-release:
+    jobs:
+      - docker-release-build:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - docker-release-scan:
+          requires:
+            - docker-release-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - docker-release-smoke:
+          requires:
+            - docker-release-build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - docker-release-push:
+          requires:
+            - docker-release-scan
+            - docker-release-smoke
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - docker-release-sign:
+          requires:
+            - docker-release-push
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - github-release:
+          requires:
+            - docker-release-sign
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+  manual-docker-release:
+    when: << pipeline.parameters.run_docker_release >>
+    jobs:
+      - docker-release-build
+      - docker-release-scan:
+          requires:
+            - docker-release-build
+      - docker-release-smoke:
+          requires:
+            - docker-release-build
+      - docker-release-push:
+          requires:
+            - docker-release-scan
+            - docker-release-smoke
+      - docker-release-sign:
+          requires:
+            - docker-release-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -907,11 +907,12 @@ jobs:
             set -euo pipefail
             : "${DHI_USERNAME:?DHI_USERNAME is required}"
             : "${DHI_TOKEN:?DHI_TOKEN is required}"
+            : "${GHCR_USERNAME:?GHCR_USERNAME is required}"
             : "${GHCR_TOKEN:?GHCR_TOKEN with package write access is required}"
             : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME is required}"
             : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN is required}"
             echo "${DHI_TOKEN}" | docker login dhi.io -u "${DHI_USERNAME}" --password-stdin
-            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${CIRCLE_PROJECT_USERNAME}" --password-stdin
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
             echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
             VERSION="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)"
             BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -987,6 +988,7 @@ jobs:
           command: |
             set -euo pipefail
             : "${CIRCLE_OIDC_TOKEN_V2:?CircleCI OIDC token is required for keyless signing}"
+            : "${GHCR_USERNAME:?GHCR_USERNAME is required}"
             : "${GHCR_TOKEN:?GHCR_TOKEN is required}"
             : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME is required}"
             : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN is required}"
@@ -997,7 +999,7 @@ jobs:
             DIGEST="$(tr -d '[:space:]' < /tmp/pullbox-workspace/release-image-digest/digest.txt)"
             GHCR_IMAGE="ghcr.io/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}"
             DOCKERHUB_IMAGE="docker.io/pullbox/pullbox"
-            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${CIRCLE_PROJECT_USERNAME}" --password-stdin
+            echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
             echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
             cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${GHCR_IMAGE}@${DIGEST}"
             cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${DOCKERHUB_IMAGE}@${DIGEST}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -747,10 +747,12 @@ jobs:
             if [ "${DOCKER_VALIDATE_REQUIRED}" != "true" ] || [ "${DOCKER_VALIDATE_MODE}" = "untrusted" ]; then
               circleci-agent step halt
             fi
+            docker save pullbox:validate -o /tmp/pullbox-validate.tar
             docker run --rm \
               -v "$PWD/.grype.yaml:/workspace/.grype.yaml:ro" \
+              -v /tmp/pullbox-validate.tar:/workspace/pullbox-validate.tar:ro \
               "${GRYPE_IMAGE}" \
-              pullbox:validate \
+              docker-archive:/workspace/pullbox-validate.tar \
               --config /workspace/.grype.yaml \
               --fail-on high
             docker run --rm --entrypoint python pullbox:validate -c '
@@ -835,10 +837,12 @@ jobs:
           command: |
             set -euo pipefail
             docker load < /tmp/pullbox-workspace/docker-image/pullbox-image.tar.gz
+            docker save pullbox:ci-scan -o /tmp/pullbox-ci-scan.tar
             docker run --rm \
               -v "$PWD/.grype.yaml:/workspace/.grype.yaml:ro" \
+              -v /tmp/pullbox-ci-scan.tar:/workspace/pullbox-ci-scan.tar:ro \
               "${GRYPE_IMAGE}" \
-              pullbox:ci-scan \
+              docker-archive:/workspace/pullbox-ci-scan.tar \
               --config /workspace/.grype.yaml \
               --fail-on high
 

--- a/.circleci/scripts/circleci_oidc_claims.py
+++ b/.circleci/scripts/circleci_oidc_claims.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Extract CircleCI OIDC claims needed for Cosign verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shlex
+
+
+def decode_payload(token: str) -> dict[str, object]:
+    parts = token.split(".")
+    if len(parts) < 2:
+        raise SystemExit("CIRCLE_OIDC_TOKEN_V2 is not a valid JWT")
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    decoded = base64.urlsafe_b64decode(payload.encode("ascii"))
+    data = json.loads(decoded.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise SystemExit("CIRCLE_OIDC_TOKEN_V2 payload was not a JSON object")
+    return data
+
+
+def require_string(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"CIRCLE_OIDC_TOKEN_V2 is missing required claim: {key}")
+    return value
+
+
+def main() -> int:
+    token = os.environ.get("CIRCLE_OIDC_TOKEN_V2", "")
+    if not token:
+        raise SystemExit("CIRCLE_OIDC_TOKEN_V2 is required")
+
+    payload = decode_payload(token)
+    issuer = require_string(payload, "iss")
+    subject = require_string(payload, "sub")
+    project_id = payload.get("oidc.circleci.com/project-id", "")
+    vcs_origin = payload.get("oidc.circleci.com/vcs-origin", "")
+    vcs_ref = payload.get("oidc.circleci.com/vcs-ref", "")
+
+    values = {
+        "COSIGN_CERTIFICATE_OIDC_ISSUER": issuer,
+        "COSIGN_CERTIFICATE_IDENTITY": subject,
+        "CIRCLECI_OIDC_PROJECT_ID": project_id if isinstance(project_id, str) else "",
+        "CIRCLECI_OIDC_VCS_ORIGIN": vcs_origin if isinstance(vcs_origin, str) else "",
+        "CIRCLECI_OIDC_VCS_REF": vcs_ref if isinstance(vcs_ref, str) else "",
+    }
+    for name, value in values.items():
+        print(f"export {name}={shlex.quote(value)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.circleci/scripts/docker_validate_gate.py
+++ b/.circleci/scripts/docker_validate_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Decide whether Pullbox Docker validation should run in CircleCI."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from fnmatch import fnmatch
+
+DOCKER_PATHS = (
+    "docker/**",
+    "src/**",
+    "alembic/**",
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    ".grype.yaml",
+    ".circleci/**",
+    ".github/workflows/docker-release.yml",
+    ".github/workflows/docker-validate.yml",
+    ".github/workflows/release.yml",
+    ".github/scripts/preflight-runner.sh",
+)
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "")
+
+
+def _git(*args: str, check: bool = True) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+    return completed.stdout
+
+
+def changed_files() -> list[str]:
+    _git("fetch", "--no-tags", "origin", "develop:refs/remotes/origin/develop", check=False)
+    base = _git("merge-base", "origin/develop", "HEAD", check=False).strip()
+    diff_range = f"{base}..HEAD" if base else "HEAD~1..HEAD"
+    return [
+        line for line in _git("diff", "--name-only", diff_range, check=False).splitlines() if line
+    ]
+
+
+def docker_relevant(paths: list[str]) -> bool:
+    return any(any(fnmatch(path, pattern) for pattern in DOCKER_PATHS) for path in paths)
+
+
+def is_untrusted_pr() -> bool:
+    if not _env("CIRCLE_PULL_REQUEST"):
+        return False
+    pr_username = _env("CIRCLE_PR_USERNAME") or _env("CIRCLE_PROJECT_USERNAME")
+    pr_reponame = _env("CIRCLE_PR_REPONAME") or _env("CIRCLE_PROJECT_REPONAME")
+    same_repo = pr_username == _env("CIRCLE_PROJECT_USERNAME") and pr_reponame == _env(
+        "CIRCLE_PROJECT_REPONAME"
+    )
+    actor = _env("CIRCLE_USERNAME")
+    return (
+        not same_repo
+        or actor == "dependabot[bot]"
+        or _env("CIRCLE_BRANCH").startswith("dependabot/")
+    )
+
+
+def main() -> int:
+    files = changed_files()
+    required = docker_relevant(files)
+    mode = "untrusted" if is_untrusted_pr() else "trusted"
+    print(f"DOCKER_VALIDATE_REQUIRED={str(required).lower()}")
+    print(f"DOCKER_VALIDATE_MODE={mode}")
+    print(f"DOCKER_VALIDATE_CHANGED_FILES={shlex.quote(chr(10).join(files))}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.circleci/scripts/github_release.py
+++ b/.circleci/scripts/github_release.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Create or update a Pullbox GitHub Release from CircleCI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def request_json(
+    method: str, url: str, payload: dict[str, object] | None = None
+) -> dict[str, object]:
+    token = os.environ["GITHUB_RELEASE_TOKEN"]
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def git_output(*args: str) -> str:
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def commit_details(current_tag: str) -> str:
+    try:
+        previous_tag = git_output("tag", "--sort=-creatordate", "--merged", "HEAD").splitlines()
+        previous = next(
+            (tag for tag in previous_tag if tag != current_tag and tag.startswith("v")), ""
+        )
+    except Exception:
+        previous = ""
+    revision_range = f"{previous}..HEAD" if previous else "HEAD"
+    try:
+        subjects = git_output(
+            "log", revision_range, "--pretty=format:%s", "--no-merges"
+        ).splitlines()
+    except Exception:
+        subjects = []
+    if not subjects:
+        return ""
+    lines = ["## Commit Details", ""]
+    for subject in subjects:
+        lines.append(f"- {subject}")
+    return "\n".join(lines)
+
+
+def release_body(args: argparse.Namespace) -> str:
+    changelog = Path(args.changelog).read_text(encoding="utf-8").strip()
+    issuer = os.environ.get("COSIGN_CERTIFICATE_OIDC_ISSUER", "<circleci-oidc-issuer>")
+    identity = os.environ.get("COSIGN_CERTIFICATE_IDENTITY", "<circleci-identity>")
+    issuer_arg = shlex.quote(issuer)
+    identity_arg = shlex.quote(identity)
+    repository = args.repository
+    return f"""## What's Changed
+
+{changelog}
+
+{commit_details(args.tag)}
+
+## Docker Images
+
+```bash
+docker pull ghcr.io/{repository}:{args.version}
+docker pull docker.io/pullbox/pullbox:{args.version}
+```
+
+Digest: `{args.digest}`
+
+## Image Verification
+
+Release images are signed with keyless Sigstore/Cosign using CircleCI OIDC.
+
+```bash
+cosign verify \\
+  --certificate-identity {identity_arg} \\
+  --certificate-oidc-issuer {issuer_arg} \\
+  ghcr.io/{repository}@{args.digest}
+
+cosign verify \\
+  --certificate-identity {identity_arg} \\
+  --certificate-oidc-issuer {issuer_arg} \\
+  docker.io/pullbox/pullbox@{args.digest}
+```
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--digest", required=True)
+    parser.add_argument("--changelog", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    prerelease = args.version.startswith("0.") or "-" in args.version
+    payload = {
+        "tag_name": args.tag,
+        "name": f"Pullbox {args.tag}",
+        "body": release_body(args),
+        "draft": False,
+        "prerelease": prerelease,
+    }
+    releases_url = f"https://api.github.com/repos/{args.repository}/releases"
+    try:
+        request_json("POST", releases_url, payload)
+        print(f"Created release {args.tag}")
+    except urllib.error.HTTPError as exc:
+        if exc.code != 422:
+            raise
+        existing = request_json("GET", f"{releases_url}/tags/{args.tag}")
+        release_id = existing["id"]
+        request_json("PATCH", f"{releases_url}/{release_id}", payload)
+        print(f"Updated release {args.tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.circleci/scripts/release_sync_check.py
+++ b/.circleci/scripts/release_sync_check.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Detect Pullbox release-sync PRs that may skip heavyweight CircleCI jobs.
+
+The logic mirrors the existing GitHub Actions validator:
+
+- PR base must be develop.
+- Head branch must start with feature/sync-develop-.
+- PR must be same-repository and not Dependabot.
+- origin/main must contain origin/develop.
+- PR head must contain origin/main.
+- The only change after origin/main must be src/pullbox/__init__.py.
+- Version must move from X.Y.Z to X.Y.(Z+1)-dev.
+
+Output is a shell env file consumed by later CircleCI jobs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+VERSION_FILE = "src/pullbox/__init__.py"
+ALLOWED_SYNC_CHANGES = {VERSION_FILE}
+SYNC_BRANCH_PREFIX = "feature/sync-develop-"
+VERSION_RE = re.compile(r'^__version__ = "([^"]+)"$', re.MULTILINE)
+RELEASE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    is_sync: bool
+    reason: str
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "")
+
+
+def _run_git(*args: str, cwd: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _git_succeeds(*args: str, cwd: Path) -> bool:
+    return _run_git(*args, cwd=cwd, check=False).returncode == 0
+
+
+def _git_stdout(*args: str, cwd: Path) -> str:
+    return _run_git(*args, cwd=cwd).stdout
+
+
+def _fetch_refs(cwd: Path) -> None:
+    _run_git(
+        "fetch",
+        "--no-tags",
+        "origin",
+        "main:refs/remotes/origin/main",
+        "develop:refs/remotes/origin/develop",
+        cwd=cwd,
+        check=False,
+    )
+
+
+def _github_api_json(url: str) -> dict[str, object] | None:
+    token = _env("GITHUB_TOKEN") or _env("GH_TOKEN") or _env("GITHUB_RELEASE_TOKEN")
+    request = urllib.request.Request(url, headers={"Accept": "application/vnd.github+json"})
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def _pull_request_base_branch(repository: str) -> str:
+    for key in ("CIRCLE_PR_BASE_BRANCH", "GITHUB_BASE_REF", "PULLBOX_BASE_BRANCH"):
+        if _env(key):
+            return _env(key)
+
+    pull_request_url = _env("CIRCLE_PULL_REQUEST")
+    if not pull_request_url or not repository:
+        return ""
+
+    pr_number = pull_request_url.rstrip("/").split("/")[-1]
+    if not pr_number.isdigit():
+        return ""
+
+    data = _github_api_json(f"https://api.github.com/repos/{repository}/pulls/{pr_number}")
+    if not data:
+        return ""
+    base = data.get("base")
+    if isinstance(base, dict):
+        ref = base.get("ref")
+        if isinstance(ref, str):
+            return ref
+    return ""
+
+
+def extract_version(text: str) -> str | None:
+    match = VERSION_RE.search(text)
+    return match.group(1) if match else None
+
+
+def expected_next_dev_version(released_version: str) -> str | None:
+    match = RELEASE_VERSION_RE.fullmatch(released_version)
+    if not match:
+        return None
+    major, minor, patch = (int(part) for part in match.groups())
+    return f"{major}.{minor}.{patch + 1}-dev"
+
+
+def replace_version_line(text: str, version: str) -> str:
+    return VERSION_RE.sub(f'__version__ = "{version}"', text, count=1)
+
+
+def version_bump_is_release_sync(main_text: str, head_text: str) -> ValidationResult:
+    main_version = extract_version(main_text)
+    head_version = extract_version(head_text)
+    if main_version is None or head_version is None:
+        return ValidationResult(False, "could not read Pullbox version")
+
+    expected = expected_next_dev_version(main_version)
+    if expected is None:
+        return ValidationResult(False, f"main version is not a final release: {main_version}")
+    if head_version != expected:
+        return ValidationResult(
+            False,
+            f"expected {VERSION_FILE} to be bumped from {main_version} to {expected}; "
+            f"found {head_version}",
+        )
+    expected_head_text = replace_version_line(main_text, expected)
+    if head_text != expected_head_text:
+        return ValidationResult(
+            False,
+            f"{VERSION_FILE} contains changes beyond the expected version bump",
+        )
+    return ValidationResult(True, f"release sync with dev bump {main_version} -> {head_version}")
+
+
+def validate(cwd: Path) -> ValidationResult:
+    pull_request_url = _env("CIRCLE_PULL_REQUEST")
+    if not pull_request_url:
+        return ValidationResult(False, "not a pull request")
+
+    repository = f"{_env('CIRCLE_PROJECT_USERNAME')}/{_env('CIRCLE_PROJECT_REPONAME')}".strip("/")
+    base_branch = _pull_request_base_branch(repository)
+    if base_branch != "develop":
+        return ValidationResult(False, f"base branch is not develop: {base_branch or '<unknown>'}")
+
+    head_ref = _env("CIRCLE_BRANCH")
+    if not head_ref.startswith(SYNC_BRANCH_PREFIX):
+        return ValidationResult(False, f"head branch does not start with {SYNC_BRANCH_PREFIX}")
+
+    pr_username = _env("CIRCLE_PR_USERNAME") or _env("CIRCLE_PROJECT_USERNAME")
+    pr_reponame = _env("CIRCLE_PR_REPONAME") or _env("CIRCLE_PROJECT_REPONAME")
+    head_repository = f"{pr_username}/{pr_reponame}".strip("/")
+    actor = _env("CIRCLE_USERNAME")
+    if head_repository != repository:
+        return ValidationResult(False, "fork pull requests cannot use the sync fast path")
+    if actor == "dependabot[bot]" or head_ref.startswith("dependabot/"):
+        return ValidationResult(False, "Dependabot pull requests cannot use the sync fast path")
+
+    try:
+        _fetch_refs(cwd)
+        if not _git_succeeds(
+            "merge-base", "--is-ancestor", "origin/develop", "origin/main", cwd=cwd
+        ):
+            return ValidationResult(False, "origin/main is not a descendant of origin/develop")
+        if not _git_succeeds("merge-base", "--is-ancestor", "origin/main", "HEAD", cwd=cwd):
+            return ValidationResult(False, "pull request head does not include origin/main")
+
+        changed = set(
+            filter(
+                None,
+                _git_stdout("diff", "--name-only", "origin/main..HEAD", cwd=cwd).splitlines(),
+            )
+        )
+        if changed != ALLOWED_SYNC_CHANGES:
+            return ValidationResult(
+                False,
+                "release sync fast path only allows "
+                f"{sorted(ALLOWED_SYNC_CHANGES)} after origin/main; found {sorted(changed)}",
+            )
+
+        main_text = _git_stdout("show", f"origin/main:{VERSION_FILE}", cwd=cwd)
+        head_text = (cwd / VERSION_FILE).read_text(encoding="utf-8")
+        return version_bump_is_release_sync(main_text, head_text)
+    except Exception as exc:
+        return ValidationResult(False, f"could not validate release sync PR: {exc}")
+
+
+def main() -> int:
+    result = validate(Path.cwd())
+    print(f"RELEASE_SYNC={str(result.is_sync).lower()}")
+    print(f"RELEASE_SYNC_REASON={shlex.quote(result.reason)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 ---
 # Pullbox CI Pipeline
 # Quality gate — lint, typecheck, test, migration check, accessibility, E2E.
+# Legacy GitHub Actions fallback. CircleCI is the canonical PR CI runner.
 #
 # Security: All actions pinned to full SHA. No pull_request_target.
 # See: docs/development/INFRASTRUCTURE.md
@@ -8,10 +9,6 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main, develop]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/clean-room.yml
+++ b/.github/workflows/clean-room.yml
@@ -2,12 +2,11 @@
 # Pullbox Clean-Room Verification
 # Fresh install sanity lane to catch cache-masked dependency or environment
 # drift without slowing normal PR CI.
+# Legacy/manual fallback. The scheduled clean-room lane is disabled.
 
 name: Clean Room
 
 on:
-  schedule:
-    - cron: "30 6 * * 3"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codeql-branch-probe.yml
+++ b/.github/workflows/codeql-branch-probe.yml
@@ -2,6 +2,7 @@
 # Pullbox CodeQL Branch Probe
 # Fast feedback for trusted security-cleanup branches without waiting for a
 # default-branch merge to refresh the Security and quality dashboard.
+# Legacy/manual fallback. CircleCI owns CodeQL for PR checks.
 #
 # Security: All actions pinned to full SHA. No pull_request_target.
 # This workflow intentionally does not run on pull_request.
@@ -9,14 +10,6 @@
 name: CodeQL Branch Probe
 
 on:
-  push:
-    branches:
-      - main
-      - develop
-      - feature/ci-cd-*
-      - feature/code-scanning-*
-      - feature/codeql-*
-      - feature/security-*
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -10,8 +10,8 @@
 # See: docs/development/INFRASTRUCTURE.md
 #
 # Trigger rules:
-#   push tags    → builds semver release images for tagged commits
-#   dispatch     → manual release image builds from the selected ref
+#   dispatch     → legacy/manual release image builds from the selected ref
+# CircleCI is the canonical publisher for release tag pushes.
 # Trusted Docker publish stays on the self-hosted runner. This workflow is not
 # governed by the general checks-runner toggle.
 #
@@ -29,9 +29,6 @@
 name: Docker Release
 
 on:
-  push:
-    tags: ["v*"]
-
   workflow_dispatch:
     inputs:
       tag_override:

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -6,31 +6,18 @@
 # Trusted pull requests run the full production Docker Hardened Images build on
 # the dedicated Docker runner. Untrusted pull requests fall back to a reduced
 # public sanity check that does not require secrets or self-hosted runners.
+# Legacy/manual fallback. CircleCI owns Docker validation for PR checks.
 
 name: Docker Validate
 
 on:
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - "docker/**"
-      - "src/**"
-      - "alembic/**"
-      - "pyproject.toml"
-      - "package.json"
-      - "package-lock.json"
-      - ".grype.yaml"
-      - ".github/workflows/docker-release.yml"
-      - ".github/workflows/docker-validate.yml"
-      - ".github/workflows/release.yml"
-      - ".github/scripts/preflight-runner.sh"
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: docker-validate-${{ github.event.pull_request.number || github.ref }}
+  group: docker-validate-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@
 # Pullbox Release Pipeline
 # Creates or updates a GitHub Release after the Docker Release workflow
 # publishes, signs, and verifies images for a tagged commit.
+# Legacy GitHub Actions release creation is retained for reference only.
+# CircleCI is the canonical release creator for current tag pushes.
 #
 # Security: All actions pinned to full SHA.
 # See: docs/development/INFRASTRUCTURE.md

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,6 +1,7 @@
 ---
 # Pullbox Security Pipeline
 # Dependency audits, secret scanning, and static analysis hardening.
+# Legacy GitHub Actions fallback. CircleCI is the canonical security runner.
 #
 # Security: All actions pinned to full SHA. No pull_request_target.
 # See: docs/development/INFRASTRUCTURE.md
@@ -15,13 +16,6 @@
 name: Security
 
 on:
-  schedule:
-    # Weekly on Monday at 4:30 AM UTC
-    - cron: "30 4 * * 1"
-  pull_request:
-    branches: [main, develop]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -1,6 +1,7 @@
 ---
 # Pullbox Workflow Hygiene
 # Validates GitHub Actions workflow syntax and expressions with actionlint.
+# Legacy/manual fallback. CircleCI is the canonical workflow-hygiene runner.
 #
 # Security: All actions pinned to full SHA. actionlint runs from an immutable
 # container image digest.
@@ -8,10 +9,6 @@
 name: Workflow Hygiene
 
 on:
-  pull_request:
-    branches: [main, develop]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 permissions:

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -25,7 +25,7 @@ tags are signed before automation publishes artifacts.
 - TDD is the expected development loop for behavior changes.
 - `make validate`, `make ci-local`, and `make ci-full` are the main local gates.
 - Release tags are signed.
-- Tag pushes trigger release and Docker publication workflows.
+- Tag pushes trigger CircleCI release and Docker publication workflows.
 - After a release, `develop` is bumped back to the next `-dev` version.
 
 ## Table of Contents
@@ -386,7 +386,7 @@ Example PR body:
 - Release PRs merge `develop` into `main`.
 - Release tags are created from `main`.
 - Release tags are signed.
-- Tag pushes trigger:
+- Tag pushes trigger CircleCI:
   - GitHub Release creation
   - Docker Release build, Grype scan, smoke test, GHCR/Docker Hub publish,
     Cosign signing, signature verification, and digest artifact upload
@@ -456,7 +456,7 @@ Pullbox has two release-note artifacts:
 | Artifact | Source | When Updated | Purpose |
 |---|---|---|---|
 | `CHANGELOG.md` | Curated by maintainers | During release prep PR | Human-readable project history in the repo |
-| GitHub Release notes | Curated `CHANGELOG.md` release section plus generated commit details from `.github/workflows/release.yml` | After a signed version tag and successful Docker Release workflow | Public release summary, detailed release event log, Docker pull commands, and image signature verification commands |
+| GitHub Release notes | Curated `CHANGELOG.md` release section plus generated commit details from `.circleci/scripts/github_release.py` | After a signed version tag and successful CircleCI Docker Release workflow | Public release summary, detailed release event log, Docker pull commands, and image signature verification commands |
 
 `CHANGELOG.md` is not generated automatically. Keep it concise and user-facing:
 summarize the release, do not paste every commit. During release prep, move
@@ -491,8 +491,8 @@ Recommended mapping:
 
 - Signed tags let GitHub show verified tag provenance when signing is configured
   correctly.
-- Release images are signed separately from Git tags. Docker Release uses
-  keyless Sigstore/Cosign with GitHub Actions OIDC, verifies GHCR and Docker
+- Release images are signed separately from Git tags. CircleCI Docker Release
+  uses keyless Sigstore/Cosign with CircleCI OIDC, verifies GHCR and Docker
   Hub signatures by digest before the workflow succeeds, and uploads that digest
   for the GitHub Release notes.
 - If `git tag -s` fails, stop and configure a verified GPG or SSH signing key

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -19,7 +19,7 @@ requirements.
 ## Current Baseline Notes
 
 - `make validate`, `make ci-local`, and `make ci-full` are the main local gates.
-- GitHub Actions run lint, format, typecheck, tests, migration checks,
+- CircleCI runs lint, format, typecheck, tests, migration checks,
   accessibility checks, E2E, security scans, Docker validation, and release
   automation.
 - CI tests Python 3.12, 3.13, and 3.14.
@@ -168,18 +168,15 @@ Key gates:
 
 ### 3.1 Current Pullbox implementation
 
-GitHub Actions workflows live in `.github/workflows/`.
+CircleCI workflows live in `.circleci/config.yml`. Legacy GitHub Actions
+workflows remain in `.github/workflows/` only where explicitly retained as
+manual/reference fallback.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `ci.yml` | PR to `main` or `develop`, merge queue, manual dispatch | Lint, format, typecheck, tests, migration check, accessibility, E2E, `CI Required` aggregate |
-| `docker-validate.yml` | Docker-relevant PR changes, manual dispatch | Trusted production Docker build, Grype scan, and smoke validation; reduced no-secrets sanity build for untrusted PRs |
-| `docker-release.yml` | Version tag push, manual dispatch | Release image build, Grype scan, smoke test, GHCR/Docker Hub publish, Cosign signing, signature verification, and digest artifact upload |
-| `security.yml` | PR to `main` or `develop`, merge queue, schedule, manual dispatch | gitleaks, `pip-audit`, Safety, Bandit, public-gated CodeQL, `Security Required` aggregate |
-| `workflow-hygiene.yml` | PR to `main` or `develop`, merge queue, manual dispatch | actionlint, workflow expression validation, `Workflow Hygiene Required` aggregate |
-| `codeql-branch-probe.yml` | Trusted branch push, manual dispatch | Lightweight CodeQL-only branch/default-branch feedback and dashboard refresh |
-| `clean-room.yml` | Schedule, manual dispatch | Fresh install validation outside runner-local cache |
-| `release.yml` | Docker Release success for tagged commits | Changelog and GitHub Release creation |
+| `pr-and-merge-checks` | PR, merge, scheduled clean-room, manual pipeline | Lint, format, typecheck, tests, migration check, accessibility, E2E, Docker validation, security, workflow hygiene, and aggregate required checks |
+| `docker-release` | Version tag push | Release image build, Grype scan, smoke test, GHCR/Docker Hub publish, Cosign signing, signature verification, and GitHub Release creation |
+| `manual-docker-release` | Manual CircleCI pipeline parameter | Explicit release-image build/publish path for controlled operator use |
 
 ### 3.2 Required standard
 
@@ -201,7 +198,7 @@ GitHub Actions workflows live in `.github/workflows/`.
   only when they are same-repository, version-only `feature/sync-develop-*`
   PRs that carry `origin/main` forward and bump `src/pullbox/__init__.py` from
   the released version to the next patch `-dev` version.
-- Docker validation is a PR/manual workflow. It never logs in to publish
+- Docker validation is a PR/manual CircleCI workflow. It never logs in to publish
   registries and never pushes images.
 - Docker publication depends on trusted refs and release tags.
 - DHI credentials are required for Docker builds that pull `dhi.io` base images.
@@ -573,14 +570,15 @@ Development dependency categories:
 
 ### 8.1 Current Pullbox implementation
 
-- Version tags trigger release and Docker automation.
-- `docker-release.yml` builds, scans, smoke-tests, publishes, signs, and verifies
-  release images only for version tags or explicit release dispatches.
-- `docker-validate.yml` validates Docker-sensitive PR changes without publishing.
+- Version tags trigger CircleCI release and Docker automation.
+- CircleCI `docker-release` builds, scans, smoke-tests, publishes, signs, and
+  verifies release images only for version tags or explicit release dispatches.
+- CircleCI Docker Validate validates Docker-sensitive PR changes without
+  publishing.
 - Published container images are signed with keyless Sigstore/Cosign using
-  GitHub Actions OIDC after the registry push completes. `Docker Release`
+  CircleCI OIDC after the registry push completes. `Docker Release`
   verifies GHCR and Docker Hub signatures by digest before reporting success.
-- `release.yml` creates or updates GitHub Releases for tagged commits after the
+- CircleCI creates or updates GitHub Releases for tagged commits after the
   Docker Release workflow succeeds.
 - GitHub Release notes start with the curated `CHANGELOG.md` release section,
   then append generated commit details grouped by conventional commit prefixes.

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -174,7 +174,7 @@ manual/reference fallback.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `pr-and-merge-checks` | PR, merge, scheduled clean-room, manual pipeline | Lint, format, typecheck, tests, migration check, accessibility, E2E, Docker validation, security, workflow hygiene, and aggregate required checks |
+| `pr-and-merge-checks` | Open PR source branches and explicit manual pipelines | Lint, format, typecheck, tests, migration check, accessibility, E2E, Docker validation, security, workflow hygiene, and aggregate required checks |
 | `docker-release` | Version tag push | Release image build, Grype scan, smoke test, GHCR/Docker Hub publish, Cosign signing, signature verification, and GitHub Release creation |
 | `manual-docker-release` | Manual CircleCI pipeline parameter | Explicit release-image build/publish path for controlled operator use |
 
@@ -192,7 +192,7 @@ manual/reference fallback.
 
 ### 3.3 Current repo nuances
 
-- PR and merge queue checks are the authoritative correctness gate. Ordinary
+- PR checks are the authoritative correctness gate. Ordinary `develop` and
   `main` merges should not rerun full CI or publish container images.
 - Post-release `main` to `develop` sync PRs may use the release-sync fast path
   only when they are same-repository, version-only `feature/sync-develop-*`
@@ -205,7 +205,7 @@ manual/reference fallback.
 - Forked or Dependabot PRs may not have repository secrets. PR workflows should
   skip secret-dependent validation in those untrusted contexts rather than fail
   before meaningful validation can start.
-- Ordinary CI, security, workflow hygiene, and clean-room jobs may be routed by
+- Ordinary CI, security, and workflow hygiene jobs may be routed by
   the repository variable `PULLBOX_CHECKS_RUNNER`:
   - `self-hosted` keeps trusted checks on the local runner
   - `github-hosted` moves trusted checks to `ubuntu-latest`

--- a/docs/development/SECURITY_STANDARDS.md
+++ b/docs/development/SECURITY_STANDARDS.md
@@ -805,7 +805,7 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
   `docs/development/INFRASTRUCTURE.md`.
 - Container publication uses GHCR and Docker Hub.
 - Published container images are signed with keyless Sigstore/Cosign using
-  GitHub Actions OIDC after registry publication.
+  CircleCI OIDC after registry publication.
 - The Docker Release workflow publishes SBOM/provenance attestations and
   verifies GHCR and Docker Hub signatures by digest before reporting success.
 - Docker metadata rules may publish semver-derived aliases depending on the

--- a/src/pullbox/api/v1/system_logs.py
+++ b/src/pullbox/api/v1/system_logs.py
@@ -73,19 +73,25 @@ def list_log_file_responses(logs_dir: Path) -> list[LogFileResponse]:
     if not logs_dir.is_dir():
         return []
 
-    files: list[LogFileResponse] = []
-    for path in sorted(logs_dir.glob("*.log*"), key=lambda p: p.stat().st_mtime, reverse=True):
+    files: list[tuple[int, str, LogFileResponse]] = []
+    for path in logs_dir.glob("*.log*"):
         if not path.is_file():
             continue
         stat = path.stat()
         files.append(
-            LogFileResponse(
-                filename=path.name,
-                size_bytes=stat.st_size,
-                modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+            (
+                stat.st_mtime_ns,
+                path.name,
+                LogFileResponse(
+                    filename=path.name,
+                    size_bytes=stat.st_size,
+                    modified_at=datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat(),
+                ),
             )
         )
-    return files
+    return [
+        response for _mtime, _filename, response in sorted(files, key=lambda row: (-row[0], row[1]))
+    ]
 
 
 def read_log_content(logs_dir: Path, filename: str, *, tail: int) -> LogContentResponse:

--- a/src/pullbox/services/import_file_execution.py
+++ b/src/pullbox/services/import_file_execution.py
@@ -167,18 +167,26 @@ def _resolve_import_file_issue_id(
     return None
 
 
-async def _requires_serial_skip_existing_processing(
+def _prepared_file_name_collision_key(job: ImportJob, imp_file: ImportedFile) -> str:
+    """Return the basename workers may hand to the library target resolver."""
+    file_name = str(imp_file.file_name or Path(str(imp_file.file_path)).name)
+    path = Path(file_name)
+    if (
+        job.move_to_library
+        and (job.convert_to_preferred_format or job.update_embedded_comicinfo_from_match)
+        and path.suffix.lower() != ".cbz"
+    ):
+        path = path.with_suffix(".cbz")
+    return path.name.casefold()
+
+
+async def _requires_serial_file_processing(
     session: AsyncSession,
     job: ImportJob,
     *,
     resolved_series_id: int,
     importable_files: list[ImportedFile],
-    load_media_settings: LoadMediaSettingsFunc,
 ) -> bool:
-    media_settings = await load_media_settings(session, job)
-    if media_settings["skip_existing_files"].lower() != "true":
-        return False
-
     cv_id_to_issue, number_to_issue = await load_issue_lookup_for_series(
         session,
         resolved_series_id,
@@ -194,7 +202,13 @@ async def _requires_serial_skip_existing_processing(
         if issue.id is not None
     }
     seen_issue_ids: set[int] = set()
+    seen_file_names: set[str] = set()
     for imp_file in importable_files:
+        file_name_key = _prepared_file_name_collision_key(job, imp_file)
+        if file_name_key in seen_file_names:
+            return True
+        seen_file_names.add(file_name_key)
+
         resolved_issue_id = _resolve_import_file_issue_id(
             imp_file,
             cv_id_to_issue_id=cv_id_to_issue_id,
@@ -488,12 +502,11 @@ async def process_import_series_files(
         and effective_worker_count > 1
         and len(importable_file_ids) > 1
     )
-    if parallel_processing_available and not await _requires_serial_skip_existing_processing(
+    if parallel_processing_available and not await _requires_serial_file_processing(
         session,
         job,
         resolved_series_id=resolved_series_id,
         importable_files=importable_files,
-        load_media_settings=load_media_settings,
     ):
         assert session_factory is not None
         await session.commit()

--- a/src/pullbox/services/import_series_matching.py
+++ b/src/pullbox/services/import_series_matching.py
@@ -69,6 +69,7 @@ class _VolumeSubtitleRebucketMatch:
 
     imp_file: ImportedFile
     hint: VolumeSubtitleHint
+    raw_year: int | None
     cv_result: dict[str, Any]
     diagnostics: dict[str, Any]
 
@@ -773,6 +774,7 @@ async def _rebucket_collection_volume_subtitle_series(
             _VolumeSubtitleRebucketMatch(
                 imp_file=imp_file,
                 hint=hint,
+                raw_year=raw_year,
                 cv_result=cv_result,
                 diagnostics=dict(evaluation.diagnostics or {}),
             )
@@ -797,7 +799,7 @@ async def _rebucket_collection_volume_subtitle_series(
                 import_job_id=job.id,
                 status=ImportSeriesStatus.MATCHED,
                 raw_series_name=cv_result["cv_title"],
-                raw_year=cv_result["cv_year"] or raw_year,
+                raw_year=cv_result["cv_year"] or rebucket_match.raw_year,
                 raw_publisher=cv_result["cv_publisher"] or item.raw_publisher,
                 file_count=0,
                 files_total=0,

--- a/tests/api/test_system_log_files.py
+++ b/tests/api/test_system_log_files.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,8 @@ def test_list_log_file_responses_returns_log_files_newest_first(tmp_path: Path) 
     old_log.write_text("old\n", encoding="utf-8")
     new_log = tmp_path / "pullbox.log"
     new_log.write_text("new\n", encoding="utf-8")
+    os.utime(old_log, (1_700_000_000, 1_700_000_000))
+    os.utime(new_log, (1_700_000_000, 1_700_000_000))
     ignored = tmp_path / "pullbox.txt"
     ignored.write_text("ignored\n", encoding="utf-8")
 

--- a/tests/e2e/test_health_page.py
+++ b/tests/e2e/test_health_page.py
@@ -316,6 +316,24 @@ class TestHealthPage:
         health = HealthPage(authed_page, seeded_server)
         health.goto()
 
+        with (
+            authed_page.expect_response(
+                lambda response: (
+                    response.url.endswith("/api/v1/health/refresh")
+                    and response.request.method == "POST"
+                )
+            ) as refresh_info,
+            authed_page.expect_response(
+                lambda response: (
+                    response.url.endswith("/health/status") and response.request.method == "GET"
+                )
+            ) as status_info,
+        ):
+            health.refresh_button.click()
+
+        assert refresh_info.value.status == 200
+        assert status_info.value.status == 200
+
         system_card = authed_page.locator("[data-testid='health-component-card-system']")
         assert system_card.is_visible()
         assert system_card.locator(

--- a/tests/e2e/test_library_page.py
+++ b/tests/e2e/test_library_page.py
@@ -301,7 +301,7 @@ class TestLibraryPage:
         library.rename_modal.wait_for(state="hidden", timeout=5000)
         assert payload["path"].endswith("/pullbox-e2e-library/01-batman/Batman 001 (2016).cbz")
         assert payload["proposed_name"] == "Batman cover.cbz"
-        assert authed_page.get_by_text("Rename completed.", exact=True).is_visible()
+        expect(authed_page.get_by_text("Rename completed.", exact=True)).to_be_visible()
 
     def test_library_folder_rename_submits_on_enter(
         self,
@@ -341,7 +341,7 @@ class TestLibraryPage:
         library.rename_modal.wait_for(state="hidden", timeout=5000)
         assert payload["path"].endswith("/pullbox-e2e-library/01-batman")
         assert payload["proposed_name"] == "01-batman deluxe"
-        assert authed_page.get_by_text("Rename completed.", exact=True).is_visible()
+        expect(authed_page.get_by_text("Rename completed.", exact=True)).to_be_visible()
 
     def test_library_rename_blocked_modal_uses_structured_contract(
         self,
@@ -546,7 +546,7 @@ class TestLibraryPage:
         library.auto_rename_modal.wait_for(state="hidden", timeout=5000)
         assert payload["path"].endswith("/pullbox-e2e-library/01-batman")
         assert payload["proposed_name"] == "Batman (2016)"
-        assert authed_page.get_by_text("Rename completed.", exact=True).is_visible()
+        expect(authed_page.get_by_text("Rename completed.", exact=True)).to_be_visible()
 
     def test_library_file_auto_rename_modal_uses_structured_modal_contract(
         self,

--- a/tests/unit/test_circleci_config_contracts.py
+++ b/tests/unit/test_circleci_config_contracts.py
@@ -1,0 +1,61 @@
+"""Static contracts for CircleCI workflow trigger policy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CIRCLECI_CONFIG = REPO_ROOT / ".circleci" / "config.yml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _workflow_job_configs(workflow: dict[str, Any]) -> list[dict[str, Any]]:
+    job_configs: list[dict[str, Any]] = []
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, list)
+
+    for entry in jobs:
+        assert isinstance(entry, dict)
+        assert len(entry) == 1
+        _, config = next(iter(entry.items()))
+        assert isinstance(config, dict)
+        job_configs.append(config)
+
+    return job_configs
+
+
+def test_pr_workflow_ignores_merge_pushes_and_tags() -> None:
+    """Expensive checks should run for PR branches, not protected-branch pushes."""
+    data = _load_yaml(CIRCLECI_CONFIG)
+    workflows = data.get("workflows")
+    assert isinstance(workflows, dict)
+    pr_workflow = workflows.get("pr-and-merge-checks")
+    assert isinstance(pr_workflow, dict)
+
+    for config in _workflow_job_configs(pr_workflow):
+        filters = config.get("filters")
+        assert isinstance(filters, dict)
+        assert filters.get("branches") == {"ignore": ["main", "develop"]}
+        assert filters.get("tags") == {"ignore": "/.*/"}
+
+
+def test_weekly_clean_room_schedule_is_disabled() -> None:
+    data = _load_yaml(CIRCLECI_CONFIG)
+    jobs = data.get("jobs")
+    workflows = data.get("workflows")
+    assert isinstance(jobs, dict)
+    assert isinstance(workflows, dict)
+
+    assert "clean-room" not in jobs
+    assert "weekly-clean-room" not in workflows
+    assert all(
+        "triggers" not in workflow for workflow in workflows.values() if isinstance(workflow, dict)
+    )

--- a/tests/unit/test_circleci_config_contracts.py
+++ b/tests/unit/test_circleci_config_contracts.py
@@ -59,3 +59,13 @@ def test_weekly_clean_room_schedule_is_disabled() -> None:
     assert all(
         "triggers" not in workflow for workflow in workflows.values() if isinstance(workflow, dict)
     )
+
+
+def test_release_digest_extraction_avoids_circleci_heredoc_parsing() -> None:
+    config_text = CIRCLECI_CONFIG.read_text(encoding="utf-8")
+
+    assert "python3 -c '" in config_text
+    assert "python3 - <<'PY'" not in config_text
+    assert "python3 - \\<<'PY'" not in config_text
+    assert "/tmp/image-metadata.json" in config_text
+    assert "/tmp/pullbox-workspace/release-image-digest/digest.txt" in config_text

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -133,7 +133,7 @@ def test_dependabot_covers_primary_supply_chain_inputs() -> None:
     assert {"pip", "github-actions", "docker", "npm"} <= ecosystems
 
 
-def test_security_workflow_keeps_required_scanners_and_schedule() -> None:
+def test_security_workflow_keeps_required_scanners_as_manual_fallback() -> None:
     security_workflow = WORKFLOW_DIR / "security.yml"
     data = _load_yaml(security_workflow)
     text = security_workflow.read_text(encoding="utf-8")
@@ -141,7 +141,11 @@ def test_security_workflow_keeps_required_scanners_and_schedule() -> None:
     # PyYAML follows YAML 1.1 and parses the key "on" as True.
     triggers = data.get(True, data.get("on"))
     assert isinstance(triggers, dict)
-    assert "schedule" in triggers
+    assert "workflow_dispatch" in triggers
+    assert "schedule" not in triggers
+    assert "pull_request" not in triggers
+    assert "merge_group" not in triggers
+    assert "push" not in triggers
 
     required_markers = [
         "GITLEAKS_IMAGE: ghcr.io/gitleaks/gitleaks@sha256:",
@@ -174,7 +178,7 @@ def test_codeql_analysis_uses_product_scope_config() -> None:
     } <= set(config.get("paths-ignore", []))
 
 
-def test_codeql_branch_probe_scans_trusted_push_refs_with_summary() -> None:
+def test_codeql_branch_probe_is_manual_fallback_with_summary() -> None:
     workflow_path = WORKFLOW_DIR / "codeql-branch-probe.yml"
     data = _load_yaml(workflow_path)
     workflow_text = workflow_path.read_text(encoding="utf-8")
@@ -182,18 +186,10 @@ def test_codeql_branch_probe_scans_trusted_push_refs_with_summary() -> None:
     # PyYAML follows YAML 1.1 and parses the key "on" as True.
     triggers = data.get(True, data.get("on"))
     assert isinstance(triggers, dict)
+    assert "workflow_dispatch" in triggers
+    assert "push" not in triggers
     assert "pull_request" not in triggers
-
-    push = triggers.get("push")
-    assert isinstance(push, dict)
-    assert push.get("branches") == [
-        "main",
-        "develop",
-        "feature/ci-cd-*",
-        "feature/code-scanning-*",
-        "feature/codeql-*",
-        "feature/security-*",
-    ]
+    assert "merge_group" not in triggers
 
     jobs = data.get("jobs")
     assert isinstance(jobs, dict)
@@ -247,13 +243,17 @@ def test_ci_uploads_coverage_for_each_python_matrix_version() -> None:
     assert upload_with.get("name") == "coverage-report-py${{ matrix.python-version }}"
 
 
-def test_required_gate_workflows_do_not_rerun_on_main_push() -> None:
-    """PRs and merge queue are the correctness gate; main merges stay quiet."""
-    for workflow_name in ["ci.yml", "security.yml", "workflow-hygiene.yml"]:
+def test_legacy_required_gate_workflows_are_manual_only() -> None:
+    """CircleCI is the automatic correctness gate; legacy Actions stay quiet."""
+    for workflow_name in ["ci.yml", "clean-room.yml", "security.yml", "workflow-hygiene.yml"]:
         data = _load_yaml(WORKFLOW_DIR / workflow_name)
         triggers = data.get(True, data.get("on"))
         assert isinstance(triggers, dict)
+        assert "workflow_dispatch" in triggers
         assert "push" not in triggers
+        assert "pull_request" not in triggers
+        assert "merge_group" not in triggers
+        assert "schedule" not in triggers
 
 
 def test_release_sync_fast_path_requires_next_patch_dev_version() -> None:
@@ -475,11 +475,11 @@ def test_docker_validation_workflow_never_publishes_images() -> None:
     data = _load_yaml(docker_validate_path)
     triggers = data.get(True, data.get("on"))
     assert isinstance(triggers, dict)
-    assert "pull_request" in triggers
+    assert "workflow_dispatch" in triggers
+    assert "pull_request" not in triggers
     assert "push" not in triggers
-    pull_request = triggers.get("pull_request")
-    assert isinstance(pull_request, dict)
-    assert ".grype.yaml" in pull_request.get("paths", [])
+    assert "merge_group" not in triggers
+    assert "schedule" not in triggers
 
     assert "push: true" not in docker_validate
     assert "packages: write" not in docker_validate

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -540,15 +540,17 @@ def test_docker_smoke_workflows_use_valid_application_secrets() -> None:
     assert failures == []
 
 
-def test_docker_release_workflow_runs_grype_before_publish() -> None:
+def test_legacy_docker_release_workflow_is_manual_only_and_scans_before_publish() -> None:
     docker_workflow_path = WORKFLOW_DIR / "docker-release.yml"
     docker_workflow = docker_workflow_path.read_text(encoding="utf-8")
     data = _load_yaml(docker_workflow_path)
     triggers = data.get(True, data.get("on"))
     assert isinstance(triggers, dict)
-    assert triggers.get("push", {}).get("tags") == ["v*"]
+    assert "push" not in triggers
     assert "pull_request" not in triggers
     assert "workflow_run" not in triggers
+    assert "workflow_dispatch" in triggers
+    assert "CircleCI is the canonical publisher for release tag pushes." in docker_workflow
 
     jobs = data.get("jobs")
     assert isinstance(jobs, dict)

--- a/tests/unit/test_import_file_execution.py
+++ b/tests/unit/test_import_file_execution.py
@@ -1448,6 +1448,134 @@ class TestImportExecutionAutoflushDiscipline:
             assert imported_series.files_failed == 0
 
     @pytest.mark.asyncio
+    async def test_parallel_processing_serializes_duplicate_issue_targets_without_skip_existing(
+        self,
+        async_engine,
+        tmp_path: Path,
+    ) -> None:
+        import asyncio
+        from datetime import UTC, datetime
+
+        from sqlalchemy import select as sa_select
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        from pullbox.models.library import FileFormat
+        from pullbox.services.import_file_execution import process_import_series_files
+
+        session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
+        async with session_factory() as setup_session:
+            job, imp_series, imp_files, _series, issues = await _setup_full_scenario(
+                setup_session,
+                num_issues=2,
+            )
+            imp_files[1].matched_issue_id = issues[0].id
+            imp_files[1].matched_issue_cv_id = issues[0].comicvine_id
+            imp_files[1].parsed_issue_number = issues[0].issue_number
+            await setup_session.commit()
+            job_id = job.id
+            item_id = imp_series.id
+            imported_file_ids = [imp_file.id for imp_file in imp_files]
+
+        current_concurrency = 0
+        max_concurrency = 0
+
+        async def _prepare_file(
+            session: AsyncSession,
+            current_job: ImportJob,
+            imp_file: ImportedFile,
+            *,
+            progress_callback=None,
+        ) -> SimpleNamespace:
+            _ = session, current_job, progress_callback
+            nonlocal current_concurrency, max_concurrency
+            current_concurrency += 1
+            max_concurrency = max(max_concurrency, current_concurrency)
+            try:
+                await asyncio.sleep(0.05)
+                source_path = tmp_path / imp_file.file_name
+                source_path.write_text("prepared")
+                return SimpleNamespace(
+                    registration_source=source_path,
+                    original_source=source_path,
+                    converted=False,
+                )
+            finally:
+                current_concurrency -= 1
+
+        async def _register_file(
+            session: AsyncSession,
+            source: Path,
+            issue_arg: Issue,
+            confidence: MatchConfidence,
+            **kwargs: object,
+        ) -> LibraryFile:
+            _ = kwargs
+            final_path = tmp_path / "library" / source.name
+            final_path.parent.mkdir(exist_ok=True)
+            final_path.write_text("library")
+            library_file = LibraryFile(
+                file_path=str(final_path),
+                file_name=final_path.name,
+                file_size=final_path.stat().st_size,
+                file_format=FileFormat.CBZ,
+                file_modified_at=datetime.now(tz=UTC),
+                match_confidence=confidence,
+                issue_id=issue_arg.id,
+                library_root_id=1,
+            )
+            session.add(library_file)
+            await session.flush()
+            return library_file
+
+        async with session_factory() as session:
+            job = await session.get(ImportJob, job_id)
+            imp_series = await session.get(ImportedSeries, item_id)
+            assert job is not None
+            assert imp_series is not None
+            files_imported, files_failed = await process_import_series_files(
+                session,
+                job,
+                imp_series,
+                load_media_settings=AsyncMock(return_value={"skip_existing_files": "false"}),
+                load_trash_dir=AsyncMock(return_value=tmp_path / ".trash"),
+                load_ingest_policy=AsyncMock(return_value=object()),
+                load_permission_policy=AsyncMock(return_value=object()),
+                raise_if_cancelled=AsyncMock(),
+                prepare_file=_prepare_file,
+                build_comicinfo_payload=AsyncMock(return_value={}),
+                apply_comicinfo=lambda *_args, **_kwargs: None,
+                cleanup_prepared_file=lambda *_args, **_kwargs: None,
+                record_action=AsyncMock(),
+                log_event=AsyncMock(),
+                register_file=_register_file,
+                move_to_trash=lambda *args, **kwargs: tmp_path / ".trash" / "source.cbz",
+                session_factory=session_factory,
+                file_worker_count=2,
+            )
+            await session.commit()
+
+        assert files_imported == 2
+        assert files_failed == 0
+        assert max_concurrency == 1
+        async with session_factory() as session:
+            statuses = (
+                (
+                    await session.execute(
+                        sa_select(ImportedFile.status)
+                        .where(ImportedFile.id.in_(imported_file_ids))
+                        .order_by(ImportedFile.id)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            imported_series = await session.get(ImportedSeries, item_id)
+            assert statuses == [ImportedFileStatus.IMPORTED, ImportedFileStatus.IMPORTED]
+            assert imported_series is not None
+            assert imported_series.files_imported == 2
+            assert imported_series.files_failed == 0
+
+    @pytest.mark.asyncio
     async def test_series_file_processing_emits_comicinfo_metadata_heartbeat(
         self,
         db_session: AsyncSession,

--- a/tests/unit/test_import_series_matching.py
+++ b/tests/unit/test_import_series_matching.py
@@ -1268,6 +1268,110 @@ async def test_collection_volume_subtitles_rebucket_to_separate_one_issue_series
     }
 
 
+async def test_collection_volume_rebucket_preserves_each_file_year_when_cv_year_missing(
+    async_engine,
+) -> None:
+    factory = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    async with factory() as seed_session:
+        job = ImportJob(
+            source_path="/tmp/imports",
+            source_type=ImportSourceType.FILESYSTEM,
+            status=ImportJobStatus.MATCHING,
+            scan_started_at=datetime.now(UTC),
+        )
+        seed_session.add(job)
+        await seed_session.flush()
+        item = ImportedSeries(
+            import_job_id=job.id,
+            raw_series_name="Marvel Action Spider-Man",
+            raw_year=2019,
+            status=ImportSeriesStatus.PENDING,
+            file_count=2,
+            files_total=2,
+            sample_paths=[],
+            source_folder="/tmp/imports",
+        )
+        seed_session.add(item)
+        await seed_session.flush()
+        seed_session.add_all(
+            [
+                ImportedFile(
+                    import_job_id=job.id,
+                    import_series_id=item.id,
+                    file_path="/tmp/imports/Marvel Action Spider-Man v01 - New Beginning.cbr",
+                    file_name="Marvel Action Spider-Man v01 - New Beginning (2019) (Digital).cbr",
+                    file_format="cbr",
+                    parsed_series="Marvel Action Spider-Man",
+                    parsed_issue_number=1.0,
+                    parsed_year=2019,
+                    status=ImportedFileStatus.PENDING,
+                    diagnostics={"source_issue_type": IssueType.VOLUME.value},
+                ),
+                ImportedFile(
+                    import_job_id=job.id,
+                    import_series_id=item.id,
+                    file_path="/tmp/imports/Marvel Action Spider-Man v02 - Spider-Chase.cbr",
+                    file_name="Marvel Action Spider-Man v02 - Spider-Chase (2020) (Digital).cbr",
+                    file_format="cbr",
+                    parsed_series="Marvel Action Spider-Man",
+                    parsed_issue_number=2.0,
+                    parsed_year=2020,
+                    status=ImportedFileStatus.PENDING,
+                    diagnostics={"source_issue_type": IssueType.VOLUME.value},
+                ),
+            ]
+        )
+        await seed_session.commit()
+        job_id = job.id
+
+    async def evaluate_match(**kwargs: Any) -> ComicVineMatchEvaluation:
+        raw_name = str(kwargs["raw_name"])
+        if raw_name == "Marvel Action Spider-Man":
+            return _matched_eval(
+                cv_id=124930,
+                title="Marvel Action: Spider-Man",
+                year=2020,
+                issue_count=3,
+                raw_name=raw_name,
+            )
+        if "New Beginning" in raw_name:
+            return _matched_eval(
+                cv_id=119728,
+                title="Marvel Action: Spider-Man: A New Beginning",
+                year=2019,
+                issue_count=1,
+                raw_name=raw_name,
+            )
+        if "Spider-Chase" in raw_name:
+            evaluation = _matched_eval(
+                cv_id=122410,
+                title="Marvel Action: Spider-Man: Spider-Chase",
+                year=2020,
+                issue_count=1,
+                raw_name=raw_name,
+            )
+            assert evaluation.match is not None
+            evaluation.match["cv_year"] = None
+            return evaluation
+        return ComicVineMatchEvaluation(match=None, diagnostics={"kind": "series_no_match"})
+
+    await _run_matching_for_test(
+        factory,
+        job_id,
+        evaluate_match=evaluate_match,
+    )
+
+    async with factory() as verify_session:
+        split_row = await verify_session.scalar(
+            select(ImportedSeries).where(ImportedSeries.cv_id == 122410)
+        )
+
+    assert split_row is not None
+    assert split_row.cv_year is None
+    assert split_row.raw_year == 2020
+
+
 async def test_collection_volume_rebucket_does_not_block_persistent_cache_writes(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary

- Moves Pullbox CI/security/workflow hygiene and release publication into CircleCI.
- Adds optimized Python, coverage, E2E, Docker validation, release, signing, and GitHub Release workflows.
- Limits automatic CircleCI runs to open PRs and release tags so merge pushes do not rerun the expensive pipeline.
- Retains legacy GitHub Actions release workflows only as manual/reference fallback.

## Validation

- `make ci-full`
- `circleci config validate .circleci/config.yml`
- `make workflow-hygiene`
- `.venv/bin/pytest tests/unit/test_circleci_config_contracts.py tests/unit/test_github_actions_security_contracts.py -q`
- pre-commit hook on latest commit, including Ruff, format, YAML checks, mypy, and fast unit tests