### PR TITLE
Release v0.9.11-rc2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -954,8 +954,8 @@ jobs:
           name: Install Cosign
           command: |
             set -euo pipefail
-            curl -sSfL https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-amd64 -o /usr/local/bin/cosign
-            chmod +x /usr/local/bin/cosign
+            curl -sSfL https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-amd64 -o /tmp/cosign
+            sudo install -m 0755 /tmp/cosign /usr/local/bin/cosign
       - run:
           name: Sign and verify release image digest
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-## [0.9.11-rc1] - 2026-06-21
+## [0.9.11-rc2] - 2026-06-21
 
 Release candidate focused on production bug-bash validation, large-library
 import reliability, restore readiness, CircleCI release automation, and pre-v1
@@ -93,6 +93,7 @@ confidence.
 - Kept legacy GitHub Actions workflows as manual fallback only.
 - Added release-candidate container tagging safeguards so RC tags do not update
   `latest`.
+- Fixed Cosign installation in the CircleCI Docker release signing job.
 - Fixed Docker smoke validation to avoid fixed host-port collisions.
 - Added and documented the release-sync fast path for version-only
   post-release sync PRs.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.11-rc1"
+__version__ = "0.9.11-rc2"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Prepares v0.9.11-rc2 after the v0.9.11-rc1 signing workflow failed before GitHub Release creation.
- Installs Cosign via a writable temp file and sudo install before release signing.
- Keeps the already-pushed v0.9.11-rc1 tag immutable and moves the next release attempt to v0.9.11-rc2.

## Validation
- circleci config validate .circleci/config.yml
- .venv/bin/pytest tests/unit/test_circleci_config_contracts.py -q
- make release-changelog-check VERSION=0.9.11-rc2
- .venv/bin/python -c 'from pullbox import __version__; print(__version__)'
- git diff --check