### PR TITLE
Release v0.9.11-rc3

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -10,8 +10,8 @@ signing, and GitHub Release gates.
   Docker validation, Docker release, image signing, and GitHub Release creation.
 - `scripts/release_sync_check.py` - conservative release-sync fast-path detector.
 - `scripts/docker_validate_gate.py` - Docker-sensitive path and trust detector.
-- `scripts/circleci_oidc_claims.py` - extracts CircleCI OIDC issuer and subject
-  for Cosign signature verification.
+- `scripts/circleci_oidc_claims.py` - extracts CircleCI OIDC issuer and
+  certificate identity for Cosign signature verification.
 - `scripts/github_release.py` - GitHub Release create/update helper.
 
 ## Speed Optimizations Included
@@ -52,10 +52,10 @@ Create restricted project environment variables or contexts for:
 - `GITHUB_CODEQL_TOKEN` with `security_events` write access
 - `GITHUB_TOKEN` or `GH_TOKEN` with pull request read access for release-sync base detection
 
-Cosign uses CircleCI OIDC through `CIRCLE_OIDC_TOKEN_V2`. The signing job derives
-the certificate issuer and identity from the token used to sign, verifies both
-published registries by digest, and passes the verification values to the GitHub
-Release helper.
+Cosign uses CircleCI OIDC through a job-generated Sigstore-audience token. The
+signing job derives the certificate issuer and CircleCI pipeline-definition
+identity from that token, verifies both published registries by digest, and
+passes the verification values to the GitHub Release helper.
 
 ## Migration Notes
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -966,6 +966,8 @@ jobs:
             : "${DOCKERHUB_USERNAME:?DOCKERHUB_USERNAME is required}"
             : "${DOCKERHUB_TOKEN:?DOCKERHUB_TOKEN is required}"
             mkdir -p /tmp/pullbox-workspace/release-signing
+            SIGSTORE_ID_TOKEN="$(circleci run oidc get --claims '{"aud": "sigstore"}')"
+            export SIGSTORE_ID_TOKEN
             python3 .circleci/scripts/circleci_oidc_claims.py > /tmp/pullbox-workspace/release-signing/cosign.env
             # shellcheck disable=SC1091
             . /tmp/pullbox-workspace/release-signing/cosign.env
@@ -974,8 +976,8 @@ jobs:
             DOCKERHUB_IMAGE="docker.io/pullbox/pullbox"
             echo "${GHCR_TOKEN}" | docker login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
             echo "${DOCKERHUB_TOKEN}" | docker login docker.io -u "${DOCKERHUB_USERNAME}" --password-stdin
-            cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${GHCR_IMAGE}@${DIGEST}"
-            cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}" "${DOCKERHUB_IMAGE}@${DIGEST}"
+            cosign sign --yes --identity-token "${SIGSTORE_ID_TOKEN}" "${GHCR_IMAGE}@${DIGEST}"
+            cosign sign --yes --identity-token "${SIGSTORE_ID_TOKEN}" "${DOCKERHUB_IMAGE}@${DIGEST}"
 
             verify_image_signature() {
               local image_ref="$1"

--- a/.circleci/scripts/circleci_oidc_claims.py
+++ b/.circleci/scripts/circleci_oidc_claims.py
@@ -30,21 +30,26 @@ def require_string(payload: dict[str, object], key: str) -> str:
 
 
 def main() -> int:
-    token = os.environ.get("CIRCLE_OIDC_TOKEN_V2", "")
+    token = os.environ.get("SIGSTORE_ID_TOKEN") or os.environ.get("CIRCLE_OIDC_TOKEN_V2", "")
     if not token:
-        raise SystemExit("CIRCLE_OIDC_TOKEN_V2 is required")
+        raise SystemExit("SIGSTORE_ID_TOKEN or CIRCLE_OIDC_TOKEN_V2 is required")
 
     payload = decode_payload(token)
     issuer = require_string(payload, "iss")
-    subject = require_string(payload, "sub")
-    project_id = payload.get("oidc.circleci.com/project-id", "")
+    project_id = require_string(payload, "oidc.circleci.com/project-id")
+    pipeline_definition_id = require_string(payload, "oidc.circleci.com/pipeline-definition-id")
     vcs_origin = payload.get("oidc.circleci.com/vcs-origin", "")
     vcs_ref = payload.get("oidc.circleci.com/vcs-ref", "")
+    certificate_identity = (
+        "https://circleci.com/api/v2/projects/"
+        f"{project_id}/pipeline-definitions/{pipeline_definition_id}"
+    )
 
     values = {
         "COSIGN_CERTIFICATE_OIDC_ISSUER": issuer,
-        "COSIGN_CERTIFICATE_IDENTITY": subject,
-        "CIRCLECI_OIDC_PROJECT_ID": project_id if isinstance(project_id, str) else "",
+        "COSIGN_CERTIFICATE_IDENTITY": certificate_identity,
+        "CIRCLECI_OIDC_PROJECT_ID": project_id,
+        "CIRCLECI_OIDC_PIPELINE_DEFINITION_ID": pipeline_definition_id,
         "CIRCLECI_OIDC_VCS_ORIGIN": vcs_origin if isinstance(vcs_origin, str) else "",
         "CIRCLECI_OIDC_VCS_REF": vcs_ref if isinstance(vcs_ref, str) else "",
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
-## [0.9.11-rc2] - 2026-06-21
+## [0.9.11-rc3] - 2026-06-21
 
 Release candidate focused on production bug-bash validation, large-library
 import reliability, restore readiness, CircleCI release automation, and pre-v1
@@ -94,6 +94,8 @@ confidence.
 - Added release-candidate container tagging safeguards so RC tags do not update
   `latest`.
 - Fixed Cosign installation in the CircleCI Docker release signing job.
+- Fixed CircleCI release signing to request a Sigstore-audience OIDC token and
+  verify the CircleCI pipeline-definition certificate identity.
 - Fixed Docker smoke validation to avoid fixed host-port collisions.
 - Added and documented the release-sync fast path for version-only
   post-release sync PRs.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "0.9.11-rc2"
+__version__ = "0.9.11-rc3"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/tests/unit/test_circleci_config_contracts.py
+++ b/tests/unit/test_circleci_config_contracts.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import base64
+import importlib.util
+import json
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +12,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CIRCLECI_CONFIG = REPO_ROOT / ".circleci" / "config.yml"
+CIRCLECI_OIDC_SCRIPT = REPO_ROOT / ".circleci" / "scripts" / "circleci_oidc_claims.py"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -69,3 +73,44 @@ def test_release_digest_extraction_avoids_circleci_heredoc_parsing() -> None:
     assert "python3 - \\<<'PY'" not in config_text
     assert "/tmp/image-metadata.json" in config_text
     assert "/tmp/pullbox-workspace/release-image-digest/digest.txt" in config_text
+
+
+def test_release_signing_uses_sigstore_audience_oidc_token() -> None:
+    config_text = CIRCLECI_CONFIG.read_text(encoding="utf-8")
+
+    assert 'circleci run oidc get --claims \'{"aud": "sigstore"}\'' in config_text
+    assert "export SIGSTORE_ID_TOKEN" in config_text
+    assert 'cosign sign --yes --identity-token "${SIGSTORE_ID_TOKEN}"' in config_text
+    assert 'cosign sign --yes --identity-token "${CIRCLE_OIDC_TOKEN_V2}"' not in config_text
+
+
+def test_circleci_oidc_claims_emit_fulcio_certificate_identity(
+    monkeypatch: Any, capsys: Any
+) -> None:
+    payload = {
+        "iss": "https://oidc.circleci.com/org/org-123",
+        "oidc.circleci.com/project-id": "project-456",
+        "oidc.circleci.com/pipeline-definition-id": "definition-789",
+        "oidc.circleci.com/vcs-origin": "https://github.com/pullboxapp/pullbox",
+        "oidc.circleci.com/vcs-ref": "refs/tags/v0.9.11-rc3",
+    }
+    encoded_payload = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    token = f"header.{encoded_payload.rstrip('=')}.signature"
+    spec = importlib.util.spec_from_file_location("circleci_oidc_claims", CIRCLECI_OIDC_SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setenv("SIGSTORE_ID_TOKEN", token)
+
+    assert module.main() == 0
+    output = capsys.readouterr().out
+
+    assert "export COSIGN_CERTIFICATE_OIDC_ISSUER=https://oidc.circleci.com/org/org-123" in output
+    assert (
+        "export COSIGN_CERTIFICATE_IDENTITY="
+        "https://circleci.com/api/v2/projects/project-456/"
+        "pipeline-definitions/definition-789"
+    ) in output
+    assert "export CIRCLECI_OIDC_PIPELINE_DEFINITION_ID=definition-789" in output


### PR DESCRIPTION
## Summary
- Prepares v0.9.11-rc3 after v0.9.11-rc2 published images but failed during keyless signing.
- Requests a Sigstore-audience CircleCI OIDC token for Cosign instead of using the default audience token.
- Verifies release image signatures against CircleCI's pipeline-definition certificate identity.

## Validation
- circleci config validate .circleci/config.yml
- .venv/bin/pytest tests/unit/test_circleci_config_contracts.py -q
- make release-changelog-check VERSION=0.9.11-rc3
- .venv/bin/python -c 'from pullbox import __version__; print(__version__)'
- .venv/bin/ruff check .circleci/scripts/circleci_oidc_claims.py tests/unit/test_circleci_config_contracts.py
- make typecheck
- make lint
- git diff --check