### PR TITLE
Gate full CircleCI checks on develop PRs

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -29,8 +29,13 @@ signing, and GitHub Release gates.
 
 ## Trigger Policy
 
-- Open pull requests run the full CI/security/workflow-hygiene gate.
-- Pushes to open PR branches rerun that gate.
+- Open pull requests run the cheap `pr-preflight-checks` workflow by default.
+- Full PR CI/security/workflow-hygiene checks run only when a maintainer opts in
+  with the `ci:full` label. The GitHub `CircleCI Full CI Trigger` workflow
+  dispatches CircleCI with `run_full_ci=true` for same-repository PRs carrying
+  that label.
+- Pushes to PR branches with `ci:full` rerun the full gate. Remove the label
+  while iterating if the PR should return to preflight-only runs.
 - Direct pushes to `develop`, `main`, or unreviewed feature branches do not run
   the expensive PR workflow.
 - Version tags matching `v*` run the Docker release/sign/GitHub Release
@@ -51,6 +56,10 @@ Create restricted project environment variables or contexts for:
 - `GITHUB_RELEASE_TOKEN` with contents write access
 - `GITHUB_CODEQL_TOKEN` with `security_events` write access
 - `GITHUB_TOKEN` or `GH_TOKEN` with pull request read access for release-sync base detection
+
+Create the GitHub repository secret `CIRCLECI_TOKEN` with permission to trigger
+CircleCI pipelines. The lightweight GitHub label bridge uses it to start the
+full PR gate after `ci:full` is applied.
 
 Cosign uses CircleCI OIDC through `CIRCLE_OIDC_TOKEN_V2`. The signing job derives
 the certificate issuer and identity from the token used to sign, verifies both

--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -34,6 +34,8 @@ signing, and GitHub Release gates.
   with the `ci:full` label. The GitHub `CircleCI Full CI Trigger` workflow
   dispatches CircleCI with `run_full_ci=true` for same-repository PRs carrying
   that label.
+- Dependabot PRs never use the `ci:full` label bridge, even when they originate
+  from same-repository branches. Keep them on the reduced untrusted path.
 - Pushes to PR branches with `ci:full` rerun the full gate. Remove the label
   while iterating if the PR should return to preflight-only runs.
 - Direct pushes to `develop`, `main`, or unreviewed feature branches do not run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,18 @@ parameters:
   tag_override:
     type: string
     default: edge
+  run_pr_preflight:
+    type: boolean
+    default: true
+  run_full_ci:
+    type: boolean
+    default: false
+  pr_number:
+    type: string
+    default: ""
+  pr_base_branch:
+    type: string
+    default: ""
   python_test_parallelism:
     type: integer
     default: 6
@@ -181,6 +193,9 @@ jobs:
   release-sync-check:
     executor: python314
     resource_class: small
+    environment:
+      PULLBOX_PR_NUMBER: << pipeline.parameters.pr_number >>
+      PULLBOX_BASE_BRANCH: << pipeline.parameters.pr_base_branch >>
     steps:
       - checkout
       - run:
@@ -606,8 +621,11 @@ jobs:
             # shellcheck disable=SC1090
             . "${BASH_ENV}"
             : "${GITHUB_CODEQL_TOKEN:?GITHUB_CODEQL_TOKEN with security_events write access is required}"
+            PIPELINE_PR_NUMBER="<< pipeline.parameters.pr_number >>"
             if [ -n "${CIRCLE_TAG:-}" ]; then
               CODEQL_REF="refs/tags/${CIRCLE_TAG}"
+            elif [ -n "${PIPELINE_PR_NUMBER}" ]; then
+              CODEQL_REF="refs/pull/${PIPELINE_PR_NUMBER}/head"
             elif [ -n "${CIRCLE_PULL_REQUEST:-}" ]; then
               PR_NUMBER="${CIRCLE_PULL_REQUEST##*/}"
               if [[ "${PR_NUMBER}" =~ ^[0-9]+$ ]]; then
@@ -1045,7 +1063,8 @@ jobs:
               --changelog curated_changelog.md
 
 workflows:
-  pr-and-merge-checks:
+  pr-preflight-checks:
+    when: << pipeline.parameters.run_pr_preflight >>
     jobs:
       - release-sync-check:
           filters: &pr_checks_filters
@@ -1055,6 +1074,17 @@ workflows:
                 - develop
             tags:
               ignore: /.*/
+      - quality-gate:
+          name: pr-preflight
+          requires:
+            - release-sync-check
+          filters: *pr_checks_filters
+
+  pr-and-merge-checks:
+    when: << pipeline.parameters.run_full_ci >>
+    jobs:
+      - release-sync-check:
+          filters: *pr_checks_filters
       - quality-gate:
           requires:
             - release-sync-check

--- a/.circleci/scripts/release_sync_check.py
+++ b/.circleci/scripts/release_sync_check.py
@@ -84,17 +84,24 @@ def _github_api_json(url: str) -> dict[str, object] | None:
         return None
 
 
+def _pull_request_number() -> str:
+    pull_request_url = _env("CIRCLE_PULL_REQUEST")
+    if pull_request_url:
+        pr_number = pull_request_url.rstrip("/").split("/")[-1]
+        if pr_number.isdigit():
+            return pr_number
+
+    pr_number = _env("PULLBOX_PR_NUMBER")
+    return pr_number if pr_number.isdigit() else ""
+
+
 def _pull_request_base_branch(repository: str) -> str:
     for key in ("CIRCLE_PR_BASE_BRANCH", "GITHUB_BASE_REF", "PULLBOX_BASE_BRANCH"):
         if _env(key):
             return _env(key)
 
-    pull_request_url = _env("CIRCLE_PULL_REQUEST")
-    if not pull_request_url or not repository:
-        return ""
-
-    pr_number = pull_request_url.rstrip("/").split("/")[-1]
-    if not pr_number.isdigit():
+    pr_number = _pull_request_number()
+    if not pr_number or not repository:
         return ""
 
     data = _github_api_json(f"https://api.github.com/repos/{repository}/pulls/{pr_number}")
@@ -150,8 +157,8 @@ def version_bump_is_release_sync(main_text: str, head_text: str) -> ValidationRe
 
 
 def validate(cwd: Path) -> ValidationResult:
-    pull_request_url = _env("CIRCLE_PULL_REQUEST")
-    if not pull_request_url:
+    pr_number = _pull_request_number()
+    if not pr_number:
         return ValidationResult(False, "not a pull request")
 
     repository = f"{_env('CIRCLE_PROJECT_USERNAME')}/{_env('CIRCLE_PROJECT_REPONAME')}".strip("/")

--- a/.github/workflows/circleci-full-ci.yml
+++ b/.github/workflows/circleci-full-ci.yml
@@ -1,0 +1,65 @@
+---
+# Pullbox CircleCI Full CI Trigger
+# Triggers the expensive CircleCI PR gate only after maintainers opt in with
+# the ci:full label. Same-repository PRs only.
+
+name: CircleCI Full CI Trigger
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: circleci-full-ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  trigger-circleci-full-ci:
+    name: Trigger CircleCI Full CI
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'ci:full') &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Trigger CircleCI pipeline
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+          CIRCLECI_PROJECT_SLUG: gh/${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          : "${CIRCLECI_TOKEN:?CIRCLECI_TOKEN repository secret is required}"
+
+          payload="$(jq -n \
+            --arg branch "${HEAD_BRANCH}" \
+            --arg pr_number "${PR_NUMBER}" \
+            --arg pr_base_branch "${PR_BASE_BRANCH}" \
+            '{
+              branch: $branch,
+              parameters: {
+                run_pr_preflight: false,
+                run_full_ci: true,
+                pr_number: $pr_number,
+                pr_base_branch: $pr_base_branch
+              }
+            }')"
+
+          curl -fsS \
+            -X POST \
+            -H "Circle-Token: ${CIRCLECI_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "${payload}" \
+            "https://circleci.com/api/v2/project/${CIRCLECI_PROJECT_SLUG}/pipeline"

--- a/.github/workflows/circleci-full-ci.yml
+++ b/.github/workflows/circleci-full-ci.yml
@@ -1,7 +1,7 @@
 ---
 # Pullbox CircleCI Full CI Trigger
 # Triggers the expensive CircleCI PR gate only after maintainers opt in with
-# the ci:full label. Same-repository PRs only.
+# the ci:full label. Same-repository non-Dependabot PRs only.
 
 name: CircleCI Full CI Trigger
 
@@ -25,6 +25,8 @@ jobs:
     name: Trigger CircleCI Full CI
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      !startsWith(github.event.pull_request.head.ref, 'dependabot/') &&
       contains(github.event.pull_request.labels.*.name, 'ci:full') &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -346,6 +346,11 @@ Main local validation commands:
   `Security Required`, and `Workflow Hygiene Required`.
 - Do not make path-filtered workflows, such as Docker PR validation, required
   branch checks unless they emit an always-present aggregate status.
+- PR pushes run only the cheap CircleCI preflight until a maintainer applies the
+  `ci:full` label. Apply `ci:full` after automated review comments have landed
+  and the PR is ready for the full required gate.
+- If a PR with `ci:full` needs more iteration, remove the label while working or
+  expect every subsequent push to rerun the full CircleCI gate.
 - Prefer squash or merge commits based on what preserves useful history for the
   branch.
 

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -22,6 +22,8 @@ requirements.
 - CircleCI runs lint, format, typecheck, tests, migration checks,
   accessibility checks, E2E, security scans, Docker validation, and release
   automation.
+- Pull request pushes run a cheap CircleCI preflight by default. Full PR
+  CI/security/workflow-hygiene checks run after maintainers apply `ci:full`.
 - CI tests Python 3.12, 3.13, and 3.14.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
@@ -174,7 +176,8 @@ manual/reference fallback.
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `pr-and-merge-checks` | Open PR source branches and explicit manual pipelines | Lint, format, typecheck, tests, migration check, accessibility, E2E, Docker validation, security, workflow hygiene, and aggregate required checks |
+| `pr-preflight-checks` | Open PR source branches | Cheap lint/format/CSS preflight while review is still in progress |
+| `pr-and-merge-checks` | `ci:full` label dispatch or explicit manual pipeline parameter | Full lint, typecheck, tests, migration check, accessibility, E2E, Docker validation, security, workflow hygiene, and aggregate required checks |
 | `docker-release` | Version tag push | Release image build, Grype scan, smoke test, GHCR/Docker Hub publish, Cosign signing, signature verification, and GitHub Release creation |
 | `manual-docker-release` | Manual CircleCI pipeline parameter | Explicit release-image build/publish path for controlled operator use |
 
@@ -194,6 +197,12 @@ manual/reference fallback.
 
 - PR checks are the authoritative correctness gate. Ordinary `develop` and
   `main` merges should not rerun full CI or publish container images.
+- The default PR push path intentionally runs only preflight so automated review
+  feedback can land before spending full matrix, E2E, Docker, and security
+  credits. Add `ci:full` when the PR is ready for the required aggregate
+  checks.
+- `ci:full` applies to PRs targeting both `develop` and `main`. Release tags do
+  not use this gate and continue to publish automatically.
 - Post-release `main` to `develop` sync PRs may use the release-sync fast path
   only when they are same-repository, version-only `feature/sync-develop-*`
   PRs that carry `origin/main` forward and bump `src/pullbox/__init__.py` from

--- a/src/pullbox/ui/static/js/pullbox.js
+++ b/src/pullbox/ui/static/js/pullbox.js
@@ -8107,6 +8107,12 @@ function libraryBrowserPage(config) {
       }
     },
 
+    queueToastForNextPage: function (message, level) {
+      if (typeof queueToastForNextPage === "function") {
+        queueToastForNextPage({ message: message, level: level || "info" });
+      }
+    },
+
     requestJson: async function (url, options) {
       var response = await fetch(url, options || {});
       var data = null;
@@ -8683,6 +8689,7 @@ function libraryBrowserPage(config) {
           result.source_path || this.modalEntry.path,
           result.target_path || this.renameTargetPreviewPath()
         );
+        this.queueToastForNextPage("Rename completed.", "success");
         this.dispatchToast("Rename completed.", "success");
         this.closeModal();
         window.setTimeout(function () {
@@ -8717,6 +8724,7 @@ function libraryBrowserPage(config) {
           result.source_path || this.modalEntry.path,
           result.target_path || this.modalEntry.path
         );
+        this.queueToastForNextPage("Rename completed.", "success");
         this.dispatchToast("Rename completed.", "success");
         this.closeModal();
         window.setTimeout(function () {
@@ -8746,6 +8754,7 @@ function libraryBrowserPage(config) {
         });
         var targetPath = result.target_path || this.modalEntry.path;
         var refreshPath = this.currentPath || parentDirectory(targetPath) || this.rootPath || "";
+        this.queueToastForNextPage("Conversion completed.", "success");
         this.dispatchToast("Conversion completed.", "success");
         this.closeModal();
         window.setTimeout(function () {
@@ -8813,6 +8822,7 @@ function libraryBrowserPage(config) {
             delete_folder: this.deleteFolder,
           }),
         });
+        this.queueToastForNextPage("Delete completed.", "success");
         this.dispatchToast("Delete completed.", "success");
         var refreshUrl = this.refreshUrlAfterDelete(this.modalEntry.path);
         this.closeModal();
@@ -15307,6 +15317,55 @@ function _handleAuthExpiryResponse(response) {
   window.__pbAuthExpiryFetchWrapped = true;
 })();
 
+const PULLBOX_QUEUED_TOAST_KEY = "pullbox:queued-toast";
+const PULLBOX_QUEUED_TOAST_TTL_MS = 30000;
+
+function queueToastForNextPage(detail) {
+  if (!detail || !detail.message) return;
+
+  try {
+    window.sessionStorage.setItem(
+      PULLBOX_QUEUED_TOAST_KEY,
+      JSON.stringify({
+        message: String(detail.message),
+        level: detail.level || "info",
+        id: detail.id || "",
+        persistent: !!detail.persistent,
+        createdAt: Date.now(),
+      })
+    );
+  } catch (_) {
+    // Storage can be unavailable in private browsing or locked-down webviews.
+  }
+}
+
+function replayQueuedToast() {
+  try {
+    var raw = window.sessionStorage.getItem(PULLBOX_QUEUED_TOAST_KEY);
+    if (!raw) return;
+
+    window.sessionStorage.removeItem(PULLBOX_QUEUED_TOAST_KEY);
+    var detail = JSON.parse(raw);
+    if (!detail || !detail.message) return;
+
+    var createdAt = Number(detail.createdAt || 0);
+    if (createdAt && Date.now() - createdAt > PULLBOX_QUEUED_TOAST_TTL_MS) return;
+
+    showToast({
+      message: detail.message,
+      level: detail.level || "info",
+      id: detail.id || undefined,
+      persistent: !!detail.persistent,
+    });
+  } catch (_) {
+    try {
+      window.sessionStorage.removeItem(PULLBOX_QUEUED_TOAST_KEY);
+    } catch (__) {
+      // Ignore storage cleanup failures.
+    }
+  }
+}
+
 /**
  * Show a toast notification.
  * @param {object} detail - { message: string, level: "success"|"error"|"warning"|"info", id?: string, persistent?: boolean, spinner?: boolean }
@@ -15447,6 +15506,12 @@ function dismissToast(el) {
   el.addEventListener("animationend", function () {
     el.remove();
   });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", replayQueuedToast, { once: true });
+} else {
+  replayQueuedToast();
 }
 
 /**

--- a/tests/e2e/test_library_page.py
+++ b/tests/e2e/test_library_page.py
@@ -301,6 +301,7 @@ class TestLibraryPage:
         library.rename_modal.wait_for(state="hidden", timeout=5000)
         assert payload["path"].endswith("/pullbox-e2e-library/01-batman/Batman 001 (2016).cbz")
         assert payload["proposed_name"] == "Batman cover.cbz"
+        authed_page.wait_for_url("**/library?path=*pullbox-e2e-library%2F01-batman", timeout=5000)
         expect(authed_page.get_by_text("Rename completed.", exact=True)).to_be_visible()
 
     def test_library_folder_rename_submits_on_enter(
@@ -341,6 +342,7 @@ class TestLibraryPage:
         library.rename_modal.wait_for(state="hidden", timeout=5000)
         assert payload["path"].endswith("/pullbox-e2e-library/01-batman")
         assert payload["proposed_name"] == "01-batman deluxe"
+        authed_page.wait_for_url("**/library?path=*pullbox-e2e-library", timeout=5000)
         expect(authed_page.get_by_text("Rename completed.", exact=True)).to_be_visible()
 
     def test_library_rename_blocked_modal_uses_structured_contract(

--- a/tests/unit/test_circleci_config_contracts.py
+++ b/tests/unit/test_circleci_config_contracts.py
@@ -119,6 +119,8 @@ def test_ci_full_label_bridge_dispatches_circleci_without_privileged_pr_target()
     assert "pull_request_target" not in workflow_text
     assert "contains(github.event.pull_request.labels.*.name, 'ci:full')" in workflow_text
     assert "github.event.pull_request.head.repo.full_name == github.repository" in workflow_text
+    assert "github.event.pull_request.user.login != 'dependabot[bot]'" in workflow_text
+    assert "!startsWith(github.event.pull_request.head.ref, 'dependabot/')" in workflow_text
     assert "CIRCLECI_TOKEN repository secret is required" in workflow_text
     assert "run_pr_preflight: false" in workflow_text
     assert "run_full_ci: true" in workflow_text

--- a/tests/unit/test_circleci_config_contracts.py
+++ b/tests/unit/test_circleci_config_contracts.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib.util
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +11,8 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CIRCLECI_CONFIG = REPO_ROOT / ".circleci" / "config.yml"
+CIRCLECI_RELEASE_SYNC_SCRIPT = REPO_ROOT / ".circleci" / "scripts" / "release_sync_check.py"
+CIRCLECI_FULL_CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "circleci-full-ci.yml"
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -32,19 +36,92 @@ def _workflow_job_configs(workflow: dict[str, Any]) -> list[dict[str, Any]]:
     return job_configs
 
 
+def _workflow_job_names(workflow: dict[str, Any]) -> list[str]:
+    job_names: list[str] = []
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, list)
+
+    for entry in jobs:
+        assert isinstance(entry, dict)
+        assert len(entry) == 1
+        job_key, config = next(iter(entry.items()))
+        assert isinstance(config, dict)
+        configured_name = config.get("name")
+        job_names.append(configured_name if isinstance(configured_name, str) else job_key)
+
+    return job_names
+
+
 def test_pr_workflow_ignores_merge_pushes_and_tags() -> None:
-    """Expensive checks should run for PR branches, not protected-branch pushes."""
+    """PR checks should run for PR branches, not protected-branch pushes."""
     data = _load_yaml(CIRCLECI_CONFIG)
     workflows = data.get("workflows")
     assert isinstance(workflows, dict)
-    pr_workflow = workflows.get("pr-and-merge-checks")
-    assert isinstance(pr_workflow, dict)
 
-    for config in _workflow_job_configs(pr_workflow):
-        filters = config.get("filters")
-        assert isinstance(filters, dict)
-        assert filters.get("branches") == {"ignore": ["main", "develop"]}
-        assert filters.get("tags") == {"ignore": "/.*/"}
+    for workflow_name in ("pr-preflight-checks", "pr-and-merge-checks"):
+        pr_workflow = workflows.get(workflow_name)
+        assert isinstance(pr_workflow, dict)
+
+        for config in _workflow_job_configs(pr_workflow):
+            filters = config.get("filters")
+            assert isinstance(filters, dict)
+            assert filters.get("branches") == {"ignore": ["main", "develop"]}
+            assert filters.get("tags") == {"ignore": "/.*/"}
+
+
+def test_pr_full_ci_is_explicitly_gated_after_preflight() -> None:
+    """Default PR pushes should stay cheap until maintainers opt in to full CI."""
+    data = _load_yaml(CIRCLECI_CONFIG)
+    parameters = data.get("parameters")
+    workflows = data.get("workflows")
+    assert isinstance(parameters, dict)
+    assert isinstance(workflows, dict)
+
+    run_preflight = parameters.get("run_pr_preflight")
+    run_full_ci = parameters.get("run_full_ci")
+    assert run_preflight == {"type": "boolean", "default": True}
+    assert run_full_ci == {"type": "boolean", "default": False}
+
+    preflight = workflows.get("pr-preflight-checks")
+    full_ci = workflows.get("pr-and-merge-checks")
+    assert isinstance(preflight, dict)
+    assert isinstance(full_ci, dict)
+    assert preflight.get("when") == "<< pipeline.parameters.run_pr_preflight >>"
+    assert full_ci.get("when") == "<< pipeline.parameters.run_full_ci >>"
+
+    preflight_jobs = _workflow_job_names(preflight)
+    full_ci_jobs = _workflow_job_names(full_ci)
+
+    assert preflight_jobs == ["release-sync-check", "pr-preflight"]
+    assert {"test-python-3.12", "test-python-3.13", "test-python-3.14"}.isdisjoint(preflight_jobs)
+    assert {"accessibility", "e2e-chromium", "e2e-firefox", "docker-validate"}.isdisjoint(
+        preflight_jobs
+    )
+    assert {"ci-required", "security-required", "workflow-hygiene-required"} <= set(full_ci_jobs)
+
+
+def test_ci_full_label_bridge_dispatches_circleci_without_privileged_pr_target() -> None:
+    """The GitHub bridge should only dispatch full CircleCI for explicit PR opt-in."""
+    data = _load_yaml(CIRCLECI_FULL_CI_WORKFLOW)
+    workflow_text = CIRCLECI_FULL_CI_WORKFLOW.read_text(encoding="utf-8")
+
+    triggers = data.get(True, data.get("on"))
+    assert isinstance(triggers, dict)
+    pull_request = triggers.get("pull_request")
+    assert isinstance(pull_request, dict)
+    assert set(pull_request.get("types", [])) == {
+        "labeled",
+        "synchronize",
+        "reopened",
+        "ready_for_review",
+    }
+
+    assert "pull_request_target" not in workflow_text
+    assert "contains(github.event.pull_request.labels.*.name, 'ci:full')" in workflow_text
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in workflow_text
+    assert "CIRCLECI_TOKEN repository secret is required" in workflow_text
+    assert "run_pr_preflight: false" in workflow_text
+    assert "run_full_ci: true" in workflow_text
 
 
 def test_weekly_clean_room_schedule_is_disabled() -> None:
@@ -69,3 +146,22 @@ def test_release_digest_extraction_avoids_circleci_heredoc_parsing() -> None:
     assert "python3 - \\<<'PY'" not in config_text
     assert "/tmp/image-metadata.json" in config_text
     assert "/tmp/pullbox-workspace/release-image-digest/digest.txt" in config_text
+
+
+def test_release_sync_check_accepts_pipeline_pr_context(monkeypatch: Any) -> None:
+    """API-triggered full-CI pipelines should still be recognized as PR pipelines."""
+    spec = importlib.util.spec_from_file_location(
+        "circleci_release_sync_check", CIRCLECI_RELEASE_SYNC_SCRIPT
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    monkeypatch.delenv("CIRCLE_PULL_REQUEST", raising=False)
+    monkeypatch.setenv("PULLBOX_PR_NUMBER", "48")
+    monkeypatch.setenv("PULLBOX_BASE_BRANCH", "main")
+
+    assert module._pull_request_number() == "48"
+    assert module._pull_request_base_branch("pullboxapp/pullbox") == "main"


### PR DESCRIPTION
## Summary
- add the lightweight PR preflight workflow and require the ci:full label for full CircleCI runs
- add the GitHub label bridge for same-repo non-Dependabot PRs
- document the trigger policy and cover it with CircleCI config contract tests

## Validation
- circleci config validate .circleci/config.yml
- make workflow-hygiene
- ./.venv/bin/ruff check .circleci/scripts/release_sync_check.py tests/unit/test_circleci_config_contracts.py
- ./.venv/bin/ruff format --check .circleci/scripts/release_sync_check.py tests/unit/test_circleci_config_contracts.py
- ./.venv/bin/pytest tests/unit/test_circleci_config_contracts.py -q