### PR TITLE
fix: migrate paused import job status

### DIFF
--- a/alembic/versions/c8e1f4a7b902_add_paused_import_job_status.py
+++ b/alembic/versions/c8e1f4a7b902_add_paused_import_job_status.py
@@ -1,0 +1,34 @@
+"""Add the paused import job status.
+
+Revision ID: c8e1f4a7b902
+Revises: a5d6e7f8g901
+Create Date: 2026-07-12
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "c8e1f4a7b902"
+down_revision: str | Sequence[str] | None = "a5d6e7f8g901"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the PostgreSQL enum value used by paused import jobs."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS 'PAUSED'")
+
+
+def downgrade() -> None:
+    """Leave the PostgreSQL enum value in place."""
+    # PostgreSQL enum value removal is intentionally omitted.
+    pass

--- a/tests/unit/test_database_model_contracts.py
+++ b/tests/unit/test_database_model_contracts.py
@@ -102,23 +102,22 @@ def test_runtime_enum_columns_use_python_enum_classes() -> None:
 
 def test_import_job_status_enum_values_are_covered_by_migrations() -> None:
     """PostgreSQL native enum migrations must include every ImportJobStatus member."""
-    migration_text = "\n".join(
-        path.read_text(encoding="utf-8") for path in MIGRATION_DIR.glob("*.py")
-    )
     created_statuses = set()
-    for enum_definition in re.findall(
-        r"sa\.Enum\((.*?)name=\"importjobstatus\"",
-        migration_text,
-        flags=re.DOTALL,
-    ):
-        created_statuses.update(re.findall(r'"([A-Z_]+)"', enum_definition))
-
-    added_statuses = set(
-        re.findall(
-            r"ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS '([^']+)'",
+    added_statuses = set()
+    for path in sorted(MIGRATION_DIR.glob("*.py")):
+        migration_text = path.read_text(encoding="utf-8")
+        for enum_definition in re.findall(
+            r"sa\.Enum\((.*?)name=\"importjobstatus\"",
             migration_text,
+            flags=re.DOTALL,
+        ):
+            created_statuses.update(re.findall(r'"([A-Z_]+)"', enum_definition))
+        added_statuses.update(
+            re.findall(
+                r"ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS '([^']+)'",
+                migration_text,
+            )
         )
-    )
 
     migration_statuses = created_statuses | added_statuses
     missing_statuses = {member.name for member in ImportJobStatus} - migration_statuses


### PR DESCRIPTION
## Summary

- add a forward PostgreSQL migration for the `PAUSED` import-job enum value
- make the enum migration contract test evaluate each migration independently

## Root cause

`ImportJobStatus.PAUSED` existed in the runtime model without a corresponding PostgreSQL enum migration. The guard test concatenated migration files in filesystem order, allowing an unrelated `PAUSED` enum value to satisfy the regex nondeterministically.

## Validation

- focused model-contract test failed before the migration and passed after it
- empty SQLite database upgraded through the new Alembic head
- `make validate`: 6,955 passed, 3 skipped, 1 xfailed