### PR TITLE
fix: harden container validation and enum migrations

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -575,6 +575,17 @@ jobs:
               sys.exit(1)
           PY
 
+      - name: Verify published platform security runtimes
+        env:
+          DIGEST: ${{ steps.push-image.outputs.digest }}
+        run: |
+          for platform in linux/amd64 linux/arm64; do
+            echo "Verifying container security runtime for ${platform}"
+            docker run --rm --pull always --platform "${platform}" -i \
+              --entrypoint python "${GHCR_IMAGE}@${DIGEST}" - \
+              < scripts/verify_container_security_runtime.py
+          done
+
       - name: Summary
         run: |
           {

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -247,6 +247,11 @@ jobs:
       - name: Runner preflight
         run: .github/scripts/preflight-runner.sh docker
 
+      - name: Verify container security runtime
+        run: |
+          docker run --rm -i --entrypoint python pullbox:ci-scan - \
+            < scripts/verify_container_security_runtime.py
+
       - name: Run Grype scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: scan

--- a/.github/workflows/docker-validate.yml
+++ b/.github/workflows/docker-validate.yml
@@ -162,6 +162,11 @@ jobs:
       - name: Inspect built production image
         run: docker image inspect pullbox:validate >/dev/null
 
+      - name: Verify container security runtime
+        run: |
+          docker run --rm -i --entrypoint python pullbox:validate - \
+            < scripts/verify_container_security_runtime.py
+
       - name: Run Grype scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         with:

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -8,7 +8,7 @@
 # Python package vulnerabilities are not suppressed here; pip-audit covers
 # those separately in the security workflow.
 #
-# Reviewed against pullbox:ci-scan on 2026-06-17 using the local Grype DB.
+# Reviewed against pullbox:validate on 2026-07-12 using the local Grype DB.
 # Re-audit after each DHI base-image refresh and remove entries when fixed
 # stable Python 3.14 or Debian 13 packages become available upstream.
 
@@ -76,73 +76,147 @@ ignore:
       version: 3.14.6
       type: binary
 
+  # The application XML path uses Python's bundled Expat, which the container
+  # runtime check requires to be 2.8.1 or newer. The Debian 13 libexpat copy is
+  # retained only as the Fontconfig dependency used by Poppler PDF tools.
+  - vulnerability: CVE-2025-59375
+    package:
+      name: libexpat1
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2025-59375
+    package:
+      name: libexpat1-dev
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-45186
+    package:
+      name: libexpat1
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-45186
+    package:
+      name: libexpat1-dev
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-41080
+    package:
+      name: libexpat1
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-41080
+    package:
+      name: libexpat1-dev
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-25210
+    package:
+      name: libexpat1
+      version: 2.7.1-2+dhi5
+      type: deb
+  - vulnerability: CVE-2026-25210
+    package:
+      name: libexpat1-dev
+      version: 2.7.1-2+dhi5
+      type: deb
+
   # Debian 13 runtime packages. These are currently reported by Grype as
   # negligible/medium, no-fix, or won't-fix findings in the DHI Debian 13 base.
   - vulnerability: CVE-2010-4756
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2018-20796
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2019-1010022
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2019-1010023
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2019-1010024
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2019-1010025
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2019-9192
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2026-6238
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2026-5435
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5435
+    package:
+      name: libc-dev-bin
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5435
+    package:
+      name: libc6-dev
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2026-5450
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5450
+    package:
+      name: libc-dev-bin
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5450
+    package:
+      name: libc6-dev
+      version: 2.41-12+deb13u3+dhi1
       type: deb
   - vulnerability: CVE-2026-5928
     package:
       name: libc6
-      version: 2.41-12+deb13u3
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5928
+    package:
+      name: libc-dev-bin
+      version: 2.41-12+deb13u3+dhi1
+      type: deb
+  - vulnerability: CVE-2026-5928
+    package:
+      name: libc6-dev
+      version: 2.41-12+deb13u3+dhi1
       type: deb
 
   - vulnerability: CVE-2021-45346
     package:
       name: libsqlite3-0
-      version: 3.46.1-7+deb13u1
+      version: 3.46.1-7+deb13u1+dhi2
       type: deb
   - vulnerability: CVE-2025-70873
     package:
       name: libsqlite3-0
-      version: 3.46.1-7+deb13u1
+      version: 3.46.1-7+deb13u1+dhi2
       type: deb
 
   # Debian trixie marks these SQLite FTS5 findings as no-dsa/minor while the
@@ -150,80 +224,80 @@ ignore:
   - vulnerability: CVE-2026-11822
     package:
       name: libsqlite3-0
-      version: 3.46.1-7+deb13u1
+      version: 3.46.1-7+deb13u1+dhi2
       type: deb
   - vulnerability: CVE-2026-11824
     package:
       name: libsqlite3-0
-      version: 3.46.1-7+deb13u1
+      version: 3.46.1-7+deb13u1+dhi2
       type: deb
 
   - vulnerability: CVE-2022-0563
     package:
       name: libuuid1
-      version: 2.41-5
+      version: 2.41-5+dhi3
       type: deb
   - vulnerability: CVE-2025-14104
     package:
       name: libuuid1
-      version: 2.41-5
+      version: 2.41-5+dhi3
       type: deb
   - vulnerability: CVE-2026-27456
     package:
       name: libuuid1
-      version: 2.41-5
+      version: 2.41-5+dhi3
       type: deb
   - vulnerability: CVE-2026-3184
     package:
       name: libuuid1
-      version: 2.41-5
+      version: 2.41-5+dhi3
       type: deb
 
   - vulnerability: CVE-2025-6141
     package:
       name: libncursesw6
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-6141
     package:
       name: libtinfo6
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-6141
     package:
       name: ncurses-base
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-6141
     package:
       name: ncurses-bin
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-69720
     package:
       name: libncursesw6
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-69720
     package:
       name: libtinfo6
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-69720
     package:
       name: ncurses-base
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
   - vulnerability: CVE-2025-69720
     package:
       name: ncurses-bin
-      version: 6.5+20250216-2
+      version: 6.5+20250216-2+dhi4
       type: deb
 
   - vulnerability: CVE-2026-27171
     package:
       name: zlib1g
-      version: 1:1.3.dfsg+really1.3.1-1+b1
+      version: 1:1.3.dfsg+really1.3.1-1+dhi2
       type: deb
   - vulnerability: CVE-2026-34743
     package:
@@ -233,5 +307,5 @@ ignore:
   - vulnerability: CVE-2026-42250
     package:
       name: libbz2-1.0
-      version: 1.0.8-6
+      version: 1.0.8-6+dhi2
       type: deb

--- a/alembic/versions/c8e1f4a7b902_add_paused_import_job_status.py
+++ b/alembic/versions/c8e1f4a7b902_add_paused_import_job_status.py
@@ -1,0 +1,34 @@
+"""Add the paused import job status.
+
+Revision ID: c8e1f4a7b902
+Revises: a5d6e7f8g901
+Create Date: 2026-07-12
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "c8e1f4a7b902"
+down_revision: str | Sequence[str] | None = "a5d6e7f8g901"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the PostgreSQL enum value used by paused import jobs."""
+    bind = op.get_bind()
+    if bind.dialect.name == "postgresql":
+        op.execute("ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS 'PAUSED'")
+
+
+def downgrade() -> None:
+    """Leave the PostgreSQL enum value in place."""
+    # PostgreSQL enum value removal is intentionally omitted.
+    pass

--- a/docs/development/SECURITY_STANDARDS.md
+++ b/docs/development/SECURITY_STANDARDS.md
@@ -1,8 +1,8 @@
 # Pullbox Security Standards
 
 **Author:** Adam Hernandez
-**Version:** 1.1
-**Last Modified:** 2026-05-16
+**Version:** 1.2
+**Last Modified:** 2026-07-12
 
 ## Purpose
 
@@ -743,6 +743,10 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
   without publishing.
 - `.github/workflows/docker-release.yml` runs Grype container scanning before
   release image publication.
+- Docker validation and release scanning verify that Python's bundled Expat is
+  at least 2.8.1 before accepting the image.
+- `.grype.yaml` limits reviewed container exceptions to exact package versions;
+  the Grype High-severity gate remains blocking.
 - GitHub Actions are SHA-pinned with version comments.
 - Workflows define explicit default permissions and per-job permissions.
 - `.github/dependabot.yml` covers `pip`, `github-actions`, `docker`, and `npm`.
@@ -767,6 +771,8 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
   scripts from the checkout.
 - Dependency scanning remains active in CI.
 - Container scanning remains active for Docker artifacts.
+- Container exceptions must identify the vulnerability, package, version, and
+  reviewed exposure. Re-review them after each DHI base-image refresh.
 - CodeQL must run on GitHub-hosted runners only.
 - CodeQL should only become merge-blocking after an explicit policy change and
   backlog triage.
@@ -792,6 +798,8 @@ default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; 
 - [ ] Workflows and jobs declare explicit permissions.
 - [ ] `pip-audit` remains active in CI.
 - [ ] Grype remains active for container images.
+- [ ] Container exceptions remain version-pinned and documented.
+- [ ] The container Expat runtime assertion remains active before Grype.
 - [ ] Dependabot covers primary dependency surfaces.
 - [ ] CodeQL status is documented accurately.
 - [ ] Required branch checks use stable aggregate jobs.

--- a/scripts/verify_container_security_runtime.py
+++ b/scripts/verify_container_security_runtime.py
@@ -1,0 +1,25 @@
+"""Verify security-sensitive libraries embedded in the production runtime."""
+
+from __future__ import annotations
+
+import pyexpat
+
+MINIMUM_EXPAT_VERSION = (2, 8, 1)
+
+
+def verify_expat_version(version: tuple[int, int, int]) -> None:
+    """Reject runtimes whose Python XML parser lacks reviewed Expat fixes."""
+    if version < MINIMUM_EXPAT_VERSION:
+        actual = ".".join(str(part) for part in version)
+        required = ".".join(str(part) for part in MINIMUM_EXPAT_VERSION)
+        raise SystemExit(f"Expat {required} or newer is required; found {actual}")
+
+
+def main() -> None:
+    """Run all container runtime security assertions."""
+    verify_expat_version(pyexpat.version_info)
+    print(f"Container Expat runtime verified: {pyexpat.EXPAT_VERSION}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_database_model_contracts.py
+++ b/tests/unit/test_database_model_contracts.py
@@ -102,23 +102,22 @@ def test_runtime_enum_columns_use_python_enum_classes() -> None:
 
 def test_import_job_status_enum_values_are_covered_by_migrations() -> None:
     """PostgreSQL native enum migrations must include every ImportJobStatus member."""
-    migration_text = "\n".join(
-        path.read_text(encoding="utf-8") for path in MIGRATION_DIR.glob("*.py")
-    )
     created_statuses = set()
-    for enum_definition in re.findall(
-        r"sa\.Enum\((.*?)name=\"importjobstatus\"",
-        migration_text,
-        flags=re.DOTALL,
-    ):
-        created_statuses.update(re.findall(r'"([A-Z_]+)"', enum_definition))
-
-    added_statuses = set(
-        re.findall(
-            r"ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS '([^']+)'",
+    added_statuses = set()
+    for path in sorted(MIGRATION_DIR.glob("*.py")):
+        migration_text = path.read_text(encoding="utf-8")
+        for enum_definition in re.findall(
+            r"sa\.Enum\((.*?)name=\"importjobstatus\"",
             migration_text,
+            flags=re.DOTALL,
+        ):
+            created_statuses.update(re.findall(r'"([A-Z_]+)"', enum_definition))
+        added_statuses.update(
+            re.findall(
+                r"ALTER TYPE importjobstatus ADD VALUE IF NOT EXISTS '([^']+)'",
+                migration_text,
+            )
         )
-    )
 
     migration_statuses = created_statuses | added_statuses
     missing_statuses = {member.name for member in ImportJobStatus} - migration_statuses

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -758,6 +758,28 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
     assert "--certificate-oidc-issuer" in docker_workflow
 
 
+def test_docker_release_verifies_each_published_platform_runtime() -> None:
+    data = _load_yaml(WORKFLOW_DIR / "docker-release.yml")
+    push_job = data["jobs"]["push"]
+    steps = push_job["steps"]
+    step_names = [step.get("name") for step in steps if isinstance(step, dict)]
+
+    assert "Verify published platform security runtimes" in step_names
+    verify_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Verify published platform security runtimes"
+    )
+    verify_run = verify_step.get("run", "")
+    assert "for platform in linux/amd64 linux/arm64" in verify_run
+    assert '"${GHCR_IMAGE}@${DIGEST}"' in verify_run
+    assert "scripts/verify_container_security_runtime.py" in verify_run
+    assert step_names.index("Build and push multi-arch") < step_names.index(
+        "Verify published platform security runtimes"
+    )
+
+
 def test_release_notes_include_image_signature_verification() -> None:
     release_workflow_path = WORKFLOW_DIR / "release.yml"
     release_workflow = release_workflow_path.read_text(encoding="utf-8")

--- a/tests/unit/test_verify_container_security_runtime.py
+++ b/tests/unit/test_verify_container_security_runtime.py
@@ -1,0 +1,16 @@
+"""Tests for container runtime security assertions."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.verify_container_security_runtime import verify_expat_version
+
+
+def test_verify_expat_version_accepts_reviewed_minimum() -> None:
+    verify_expat_version((2, 8, 1))
+
+
+def test_verify_expat_version_rejects_older_runtime() -> None:
+    with pytest.raises(SystemExit, match=r"Expat 2\.8\.1 or newer is required"):
+        verify_expat_version((2, 7, 1))


### PR DESCRIPTION
## Summary

- assert Python bundled Expat 2.8.1 or newer in validation and release images
- verify both published amd64 and arm64 runtimes from the pushed digest before signing
- refresh reviewed Grype exceptions to exact current DHI package versions while retaining the blocking High gate
- add a forward PostgreSQL migration for `ImportJobStatus.PAUSED`
- make the enum migration contract test deterministic
- document the container exception and re-review policy

## Root causes

The current DHI package suffixes no longer matched the reviewed Grype exceptions, while new Debian findings required exposure review. Separately, `ImportJobStatus.PAUSED` existed without a PostgreSQL enum migration, and filesystem-dependent migration concatenation could mask that gap.

## Validation

- trusted Docker Validate passed on `pullbox-home-docker` with the High Grype gate unchanged
- container runtime assertion verified Expat 2.8.1
- workflow security contracts: 33 passed
- model contracts: 7 passed
- empty SQLite schema upgraded through the new Alembic head
- `make validate`: 6,957 passed, 3 skipped, 1 xfailed

The current push runs the combined candidate on the home CI runners for the final performance and correctness benchmark.