### PR TITLE
ci: separate lightweight checks from test runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,5 @@
 self-hosted-runner:
   labels:
+    - checks
     - ci
     - docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ on:
       - labeled
       - unlabeled
   workflow_dispatch:
+    inputs:
+      e2e_diagnostics:
+        description: Retain E2E failure video and traces
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -32,6 +38,8 @@ concurrency:
 
 env:
   E2E_WORKERS: "3"
+  E2E_VIDEO_MODE: "${{ github.event_name == 'workflow_dispatch' && inputs.e2e_diagnostics && 'retain-on-failure' || 'off' }}"
+  PULLBOX_E2E_TRACE: "${{ github.event_name == 'workflow_dispatch' && inputs.e2e_diagnostics && 'true' || 'false' }}"
   PYTHON_DEFAULT: "3.14"
   PYTEST_WORKERS: "5"
 
@@ -316,7 +324,7 @@ jobs:
             -v \
             -m accessibility \
             --browser chromium \
-            --video retain-on-failure \
+            --video "${E2E_VIDEO_MODE}" \
             --screenshot only-on-failure \
             --full-page-screenshot \
             --output=test-results/e2e \
@@ -399,7 +407,7 @@ jobs:
             --dist=worksteal \
             --browser ${{ matrix.browser }} \
             ${{ matrix.pytest_extra_args }} \
-            --video retain-on-failure \
+            --video "${E2E_VIDEO_MODE}" \
             --screenshot only-on-failure \
             --full-page-screenshot \
             --output=test-results/e2e \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
+  E2E_WORKERS: "2"
   PYTHON_DEFAULT: "3.14"
   PYTEST_WORKERS: "5"
 
@@ -394,6 +395,8 @@ jobs:
           pytest tests/e2e/ \
             -v \
             -m "not accessibility" \
+            -n "${E2E_WORKERS}" \
+            --dist=worksteal \
             --browser ${{ matrix.browser }} \
             ${{ matrix.pytest_extra_args }} \
             --video retain-on-failure \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
           pytest tests/ \
             --ignore=tests/e2e \
             -n "${PYTEST_WORKERS}" \
+            --dist=worksteal \
             --cov=pullbox \
             --cov-report=xml \
             --cov-report=term-missing \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ concurrency:
 
 env:
   PYTHON_DEFAULT: "3.14"
-  PYTEST_WORKERS: "4"
+  PYTEST_WORKERS: "5"
 
 jobs:
   release_sync_check:
@@ -272,7 +272,7 @@ jobs:
   # ──────────────────────────────────────────────
   accessibility:
     name: Accessibility Checks
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     needs: [release_sync_check, full_ci_check, quality-gate, typecheck, alembic-check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  E2E_WORKERS: "2"
+  E2E_WORKERS: "3"
   PYTHON_DEFAULT: "3.14"
   PYTEST_WORKERS: "5"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,7 +95,7 @@ jobs:
     name: Gitleaks
     needs: [release_sync_check, full_ci_check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     timeout-minutes: 20
     permissions:
       contents: read
@@ -184,7 +184,7 @@ jobs:
     name: pip-audit
     needs: [release_sync_check, full_ci_check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -223,7 +223,7 @@ jobs:
     name: Safety Check
     needs: [release_sync_check, full_ci_check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     timeout-minutes: 15
     permissions:
       contents: read
@@ -260,7 +260,7 @@ jobs:
     name: Bandit
     needs: [release_sync_check, full_ci_check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/workflow-hygiene.yml
+++ b/.github/workflows/workflow-hygiene.yml
@@ -84,7 +84,7 @@ jobs:
     name: actionlint
     needs: [release_sync_check, full_ci_check]
     if: needs.release_sync_check.outputs.is_sync != 'true' && needs.full_ci_check.outputs.run_full == 'true'
-    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","ci"]') }}
+    runs-on: ${{ fromJSON(((github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')) || vars.PULLBOX_CHECKS_RUNNER == 'github-hosted') && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","checks"]') }}
     timeout-minutes: 15
     permissions:
       contents: read

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -26,7 +26,7 @@ requirements.
   CI/security/workflow-hygiene checks run after maintainers apply `ci:full`.
 - CI tests Python 3.12, 3.13, and 3.14.
 - Self-hosted Python matrix jobs use five pytest workers per Python version.
-- Self-hosted functional E2E jobs use two isolated pytest workers per browser.
+- Self-hosted functional E2E jobs use three isolated pytest workers per browser.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
 - The runtime image is non-root and intentionally minimal.

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -27,6 +27,8 @@ requirements.
 - CI tests Python 3.12, 3.13, and 3.14.
 - Self-hosted Python matrix jobs use five pytest workers per Python version.
 - Self-hosted functional E2E jobs use three isolated pytest workers per browser.
+- Normal PR E2E runs disable video encoding; manual CI dispatches can enable
+  retained failure video and tracing with the `e2e_diagnostics` input.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
 - The runtime image is non-root and intentionally minimal.

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -25,6 +25,7 @@ requirements.
 - Pull request pushes run a cheap GitHub Actions preflight by default. Full PR
   CI/security/workflow-hygiene checks run after maintainers apply `ci:full`.
 - CI tests Python 3.12, 3.13, and 3.14.
+- Self-hosted Python matrix jobs use five pytest workers per Python version.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
 - The runtime image is non-root and intentionally minimal.
@@ -222,8 +223,11 @@ tracked in the active CI/CD path.
   - `github-hosted` moves trusted checks to `ubuntu-latest`
 - Fork and Dependabot pull requests always run ordinary checks on
   `ubuntu-latest`, regardless of `PULLBOX_CHECKS_RUNNER`.
-- Trusted ordinary jobs use the explicit self-hosted `ci` runner label when
-  `PULLBOX_CHECKS_RUNNER` is not `github-hosted`.
+- Trusted compute-intensive test and E2E jobs use the explicit self-hosted `ci`
+  runner label when `PULLBOX_CHECKS_RUNNER` is not `github-hosted`.
+- Trusted accessibility, dependency-audit, static-analysis, secret-scan, and
+  workflow-hygiene jobs use the explicit self-hosted `checks` runner label so
+  they cannot occupy a matrix-test runner slot.
 - Trusted Docker validation and Docker release jobs use the explicit
   self-hosted `docker` runner label by design. They are not governed by
   `PULLBOX_CHECKS_RUNNER`.

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -26,6 +26,7 @@ requirements.
   CI/security/workflow-hygiene checks run after maintainers apply `ci:full`.
 - CI tests Python 3.12, 3.13, and 3.14.
 - Self-hosted Python matrix jobs use five pytest workers per Python version.
+- Self-hosted functional E2E jobs use two isolated pytest workers per browser.
 - Python 3.14 is the production container runtime.
 - The production Docker image uses Docker Hardened Images.
 - The runtime image is non-root and intentionally minimal.
@@ -95,6 +96,8 @@ tests/e2e/
 - Tests outside `tests/unit/` are treated as slower coverage.
 - E2E tests run a live app and seed through API-style setup rather than relying
   on broad seed scripts.
+- Each parallel E2E worker creates its own temporary database, data directories,
+  uvicorn server, browser session, and local port.
 - Search and parser tests should use real fixture data when release-title edge
   cases matter.
 - Coverage percentage is useful, but contract coverage matters more.

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -459,6 +459,40 @@ def test_trusted_jobs_use_explicit_self_hosted_runner_labels() -> None:
     assert failures == []
 
 
+def test_self_hosted_jobs_separate_heavy_ci_from_lightweight_checks() -> None:
+    """Keep matrix tests off runners used by accessibility and security checks."""
+    expected_labels = {
+        "ci.yml": {
+            "ci": ["quality-gate", "typecheck", "test", "alembic-check", "e2e"],
+            "checks": ["accessibility"],
+        },
+        "security.yml": {
+            "checks": ["gitleaks", "dependency-audit", "safety-check", "bandit"],
+        },
+        "workflow-hygiene.yml": {"checks": ["actionlint"]},
+    }
+
+    for workflow_name, labels in expected_labels.items():
+        jobs = _load_yaml(WORKFLOW_DIR / workflow_name).get("jobs")
+        assert isinstance(jobs, dict)
+        for label, job_names in labels.items():
+            selector = f'["self-hosted","Linux","X64","{label}"]'
+            for job_name in job_names:
+                job = jobs.get(job_name)
+                assert isinstance(job, dict)
+                runs_on = job.get("runs-on")
+                assert isinstance(runs_on, str)
+                assert "ubuntu-latest" in runs_on
+                assert selector in runs_on
+
+
+def test_ci_python_matrix_uses_five_parallel_workers() -> None:
+    workflow = _load_yaml(WORKFLOW_DIR / "ci.yml")
+    env = workflow.get("env")
+    assert isinstance(env, dict)
+    assert env.get("PYTEST_WORKERS") == "5"
+
+
 def test_browser_smoke_and_accessibility_artifacts_survive_failures_and_cancels() -> None:
     ci_workflow = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
     docker_validate = (WORKFLOW_DIR / "docker-validate.yml").read_text(encoding="utf-8")

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -527,6 +527,45 @@ def test_e2e_matrix_shards_each_browser_across_three_workers() -> None:
     assert "--dist=worksteal" in command
 
 
+def test_ci_video_and_trace_capture_are_manual_diagnostics_only() -> None:
+    workflow = _load_yaml(WORKFLOW_DIR / "ci.yml")
+    triggers = workflow.get(True, workflow.get("on"))
+    assert isinstance(triggers, dict)
+    dispatch = triggers.get("workflow_dispatch")
+    assert isinstance(dispatch, dict)
+    diagnostic_input = dispatch.get("inputs", {}).get("e2e_diagnostics")
+    assert diagnostic_input == {
+        "description": "Retain E2E failure video and traces",
+        "required": False,
+        "type": "boolean",
+        "default": False,
+    }
+
+    env = workflow.get("env")
+    assert isinstance(env, dict)
+    assert env.get("E2E_VIDEO_MODE") == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.e2e_diagnostics "
+        "&& 'retain-on-failure' || 'off' }}"
+    )
+    assert env.get("PULLBOX_E2E_TRACE") == (
+        "${{ github.event_name == 'workflow_dispatch' && inputs.e2e_diagnostics "
+        "&& 'true' || 'false' }}"
+    )
+
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    for job_name, step_name in [
+        ("accessibility", "Run accessibility browser tests"),
+        ("e2e", "Run E2E tests"),
+    ]:
+        job = jobs.get(job_name)
+        assert isinstance(job, dict)
+        step = next(step for step in job.get("steps", []) if step.get("name") == step_name)
+        command = step.get("run", "")
+        assert '--video "${E2E_VIDEO_MODE}"' in command
+        assert "--video retain-on-failure" not in command
+
+
 def test_browser_smoke_and_accessibility_artifacts_survive_failures_and_cancels() -> None:
     ci_workflow = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
     docker_validate = (WORKFLOW_DIR / "docker-validate.yml").read_text(encoding="utf-8")

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -18,6 +18,7 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 DEPENDABOT_CONFIG = REPO_ROOT / ".github" / "dependabot.yml"
 CODEQL_CONFIG = REPO_ROOT / ".github" / "codeql" / "codeql-config.yml"
 GRYPE_CONFIG = REPO_ROOT / ".grype.yaml"
+ACTIONLINT_CONFIG = REPO_ROOT / ".github" / "actionlint.yaml"
 RELEASE_SYNC_SCRIPT = REPO_ROOT / ".github" / "scripts" / "validate-release-sync-pr.py"
 
 ACTION_REF_RE = re.compile(
@@ -457,6 +458,12 @@ def test_trusted_jobs_use_explicit_self_hosted_runner_labels() -> None:
             if runs_on == "self-hosted":
                 failures.append(f"{workflow.name}:{job_name}")
     assert failures == []
+
+
+def test_actionlint_allowlist_declares_every_custom_runner_label() -> None:
+    config = _load_yaml(ACTIONLINT_CONFIG)
+    labels = config.get("self-hosted-runner", {}).get("labels")
+    assert set(labels) == {"checks", "ci", "docker"}
 
 
 def test_self_hosted_jobs_separate_heavy_ci_from_lightweight_checks() -> None:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -509,11 +509,11 @@ def test_ci_python_matrix_uses_five_parallel_workers() -> None:
     assert "--dist=worksteal" in test_step.get("run", "")
 
 
-def test_e2e_matrix_shards_each_browser_across_two_workers() -> None:
+def test_e2e_matrix_shards_each_browser_across_three_workers() -> None:
     workflow = _load_yaml(WORKFLOW_DIR / "ci.yml")
     env = workflow.get("env")
     assert isinstance(env, dict)
-    assert env.get("E2E_WORKERS") == "2"
+    assert env.get("E2E_WORKERS") == "3"
 
     jobs = workflow.get("jobs")
     assert isinstance(jobs, dict)

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -509,6 +509,24 @@ def test_ci_python_matrix_uses_five_parallel_workers() -> None:
     assert "--dist=worksteal" in test_step.get("run", "")
 
 
+def test_e2e_matrix_shards_each_browser_across_two_workers() -> None:
+    workflow = _load_yaml(WORKFLOW_DIR / "ci.yml")
+    env = workflow.get("env")
+    assert isinstance(env, dict)
+    assert env.get("E2E_WORKERS") == "2"
+
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    e2e_job = jobs.get("e2e")
+    assert isinstance(e2e_job, dict)
+    e2e_step = next(
+        step for step in e2e_job.get("steps", []) if step.get("name") == "Run E2E tests"
+    )
+    command = e2e_step.get("run", "")
+    assert '-n "${E2E_WORKERS}"' in command
+    assert "--dist=worksteal" in command
+
+
 def test_browser_smoke_and_accessibility_artifacts_survive_failures_and_cancels() -> None:
     ci_workflow = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")
     docker_validate = (WORKFLOW_DIR / "docker-validate.yml").read_text(encoding="utf-8")

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -499,6 +499,15 @@ def test_ci_python_matrix_uses_five_parallel_workers() -> None:
     assert isinstance(env, dict)
     assert env.get("PYTEST_WORKERS") == "5"
 
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict)
+    test_job = jobs.get("test")
+    assert isinstance(test_job, dict)
+    test_step = next(
+        step for step in test_job.get("steps", []) if step.get("name") == "Run tests with coverage"
+    )
+    assert "--dist=worksteal" in test_step.get("run", "")
+
 
 def test_browser_smoke_and_accessibility_artifacts_survive_failures_and_cancels() -> None:
     ci_workflow = (WORKFLOW_DIR / "ci.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- route accessibility, security scans, and workflow hygiene to a dedicated `checks` runner
- raise Python matrix parallelism from four to five workers and use xdist work stealing
- run three isolated E2E workers per browser
- disable E2E video encoding for normal runs while preserving opt-in failure video and tracing through manual dispatch
- document and test the self-hosted runner placement and parallelism contracts

## Validation
- workflow contract tests: 38 passed
- `make validate`: 6960 passed, 3 skipped, 1 xfailed
- local three-worker Chromium: 455 passed, 2 skipped in 2m14s
- local three-worker Firefox: 455 passed, 2 skipped in 2m46s
- normal and diagnostic video-mode smoke tests passed
- live normal-run process check: no FFmpeg processes
- all required GitHub checks green

## Benchmark
- GitHub-hosted baseline: 24m08s
- initial self-hosted realistic run: 13m53s
- five workers plus work stealing: 10m19s
- two E2E workers per browser: 7m18s
- three E2E workers per browser: 6m21s
- three E2E workers with normal-run video disabled: 6m15s
- latest Chromium E2E job: 1m58s
- latest Firefox E2E job: 2m28s