### PR TITLE
fix: preserve venv interpreter in DHI runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,8 +36,8 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN python -m venv "${VIRTUAL_ENV}" \
-    && python -m pip install --upgrade pip wheel \
-    && python -m pip install --no-cache-dir --no-compile ".[prod]" \
+    && "${VIRTUAL_ENV}/bin/python" -m pip install --upgrade pip wheel \
+    && "${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir --no-compile ".[prod]" \
     && find "${VIRTUAL_ENV}" -type d -name __pycache__ -prune -exec rm -rf {} +
 
 RUN set -eu; \
@@ -83,7 +83,8 @@ RUN set -eu; \
 FROM dhi.io/python:3.14-debian13 AS runtime
 
 ENV VIRTUAL_ENV=/opt/venv \
-    PATH="/opt/venv/bin:/opt/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    PATH="/opt/python/bin:/usr/bin:/opt/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/bin" \
+    PYTHONPATH="/opt/venv/lib/python3.14/site-packages" \
     PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PULLBOX_DB_URL="sqlite+aiosqlite:////data/pullbox.db"

--- a/src/pullbox/docker_entrypoint.py
+++ b/src/pullbox/docker_entrypoint.py
@@ -91,7 +91,9 @@ def _install_startup_log_mirror(startup_log: Path) -> StartupLogMirror:
 def _run_migrations() -> None:
     """Run database migrations before application launch."""
     print(render_migration_start(), flush=True)
-    exit_code = _run_process(["alembic", "-c", "alembic/alembic.ini", "upgrade", "head"])
+    exit_code = _run_process(
+        [sys.executable, "-m", "alembic", "-c", "alembic/alembic.ini", "upgrade", "head"]
+    )
     if exit_code != 0:
         sys.exit(exit_code)
     print(render_migration_complete(), flush=True)

--- a/tests/unit/test_docker_entrypoint.py
+++ b/tests/unit/test_docker_entrypoint.py
@@ -146,11 +146,15 @@ def test_run_migrations_prints_completion_when_alembic_succeeds(
 ) -> None:
     import pullbox.docker_entrypoint as entrypoint
 
-    monkeypatch.setattr(entrypoint, "_run_process", lambda _command: 0)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(entrypoint, "_run_process", lambda command: commands.append(command) or 0)
 
     entrypoint._run_migrations()
 
     output = capsys.readouterr().out
+    assert commands == [
+        [sys.executable, "-m", "alembic", "-c", "alembic/alembic.ini", "upgrade", "head"]
+    ]
     assert "Running database migrations" in output
     assert "Database migrations complete" in output
 
@@ -309,6 +313,6 @@ def test_module_entrypoint_runs_default_command_without_real_processes(
 
     assert exc_info.value.code == 0
     assert commands == [
-        ["alembic", "-c", "alembic/alembic.ini", "upgrade", "head"],
+        [sys.executable, "-m", "alembic", "-c", "alembic/alembic.ini", "upgrade", "head"],
         ["python", "-m", "pullbox"],
     ]

--- a/tests/unit/test_docker_security_contracts.py
+++ b/tests/unit/test_docker_security_contracts.py
@@ -142,6 +142,22 @@ def test_runtime_state_paths_are_created_with_non_root_ownership() -> None:
     assert "COPY --from=builder --chown=65532:65532 /opt/venv /opt/venv" in text
 
 
+def test_runtime_python_loads_copied_packages_across_dhi_layouts() -> None:
+    """Runtime Python must load packages without relying on the builder's symlinks."""
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    pip_upgrade = '"${VIRTUAL_ENV}/bin/python" -m pip install --upgrade pip wheel'
+    runtime_path = (
+        'PATH="/opt/python/bin:/usr/bin:/opt/venv/bin:/usr/local/sbin:'
+        '/usr/local/bin:/usr/sbin:/sbin:/bin"'
+    )
+
+    assert pip_upgrade in text
+    assert '"${VIRTUAL_ENV}/bin/python" -m pip install --no-cache-dir' in text
+    assert runtime_path in text
+    assert 'PYTHONPATH="/opt/venv/lib/python3.14/site-packages"' in text
+    assert 'ln -sfn /opt/python/bin/python "${VIRTUAL_ENV}/bin/python"' not in text
+
+
 def test_compose_files_mount_canonical_media_paths() -> None:
     """Compose examples should expose the documented app-side media roots."""
     expected_mounts = {"/comics", "/downloads", "/imports"}


### PR DESCRIPTION
## Summary
- install dependencies through the builder-valid virtual environment interpreter
- normalize copied venv Python links to the shell-free DHI runtime path
- add a static Docker contract preventing the builder/runtime path mismatch from returning

## Root cause
The refreshed DHI builder creates `/opt/venv/bin/python` as a link to `/usr/bin/python`, while the runtime image exposes Python at `/opt/python/bin/python`. Copying the venv preserved a broken link, causing the runtime to fall back to the base interpreter without Pullbox installed.

## Validation
- regression test failed before implementation
- Docker security contracts: 13 passed
- ARM64 production image built from refreshed DHI bases
- container became healthy
- Docker smoke tests: 7 passed
- pre-commit hooks passed