### PR TITLE
chore: sync develop after v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [1.0.2] - 2026-07-12
+
+Maintenance release focused on container runtime reliability, migration
+correctness, and faster self-hosted CI without weakening release gates.
+
+### Fixed
+
+- Added the missing PostgreSQL enum migration for paused import jobs so
+  PostgreSQL deployments upgrade cleanly.
+- Made shell-free production images resilient to Python path changes between
+  Docker Hardened Image builder and runtime releases.
+
+### CI / Build
+
+- Hardened release image validation with an Expat runtime floor, exact reviewed
+  Grype exceptions, and pre-signing checks for both AMD64 and ARM64 images.
+- Routed lightweight checks to a dedicated runner, increased Python test
+  parallelism, sharded browser tests, and disabled routine E2E video encoding
+  while retaining opt-in diagnostics.
+- Updated the pinned CodeQL actions to 4.37.0.
+
 ## [1.0.1] - 2026-07-07
 
 Patch maintenance release focused on dependency freshness and release-pipeline

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.2-dev"
+__version__ = "1.0.2"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.2"
+__version__ = "1.0.3-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary

- merge the released `main` history back toward `develop`
- advance the development version from `1.0.2` to `1.0.3-dev`

## Validation

- release-sync validator: `release_sync=true`
- repository pre-commit hooks, including mypy and fast unit tests