### PR TITLE
Release v1.0.3

### DIFF
--- a/.github/workflows/docker-release-benchmark.yml
+++ b/.github/workflows/docker-release-benchmark.yml
@@ -1,0 +1,639 @@
+---
+# Pullbox Docker Release Benchmark
+# Measures a distributed multi-platform build without publishing release tags.
+# Each run uses an isolated GHCR package that is deleted after measurement.
+#
+# Security: manual dispatch only, explicit permissions, and full-SHA action pins.
+
+name: Docker Release Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      cache_generation:
+        description: "Cache generation; reuse for warm runs, change for cold runs"
+        required: true
+        default: "v1"
+        type: string
+      cleanup:
+        description: "Delete the temporary GHCR package after the benchmark"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  PYTHON_DEFAULT: "3.14"
+
+concurrency:
+  group: docker-release-benchmark
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare Benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      benchmark-started-at: ${{ steps.prepare.outputs.benchmark_started_at }}
+      build-date: ${{ steps.prepare.outputs.build_date }}
+      image-name: ${{ steps.prepare.outputs.image_name }}
+      package-name: ${{ steps.prepare.outputs.package_name }}
+      version: ${{ steps.prepare.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Prepare benchmark metadata
+        id: prepare
+        env:
+          CACHE_GENERATION: ${{ inputs.cache_generation }}
+        run: |
+          if ! [[ "${CACHE_GENERATION}" =~ ^[A-Za-z0-9._-]{1,40}$ ]]; then
+            echo "::error::cache_generation must use 1-40 letters, numbers, dots, underscores, or hyphens."
+            exit 1
+          fi
+
+          VERSION=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Unable to extract Pullbox version from src/pullbox/__init__.py"
+            exit 1
+          fi
+
+          REPOSITORY=$(printf '%s' "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          OWNER=${REPOSITORY%%/*}
+          PACKAGE_NAME="pullbox-benchmark-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          IMAGE_NAME="ghcr.io/${OWNER}/${PACKAGE_NAME}"
+
+          echo "benchmark_started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+          echo "image_name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Explain safety boundary
+        run: |
+          {
+            echo "## Docker Release Benchmark"
+            echo ""
+            echo "This run uses a temporary GHCR-only package and cannot publish release tags."
+            echo ""
+            echo "- Source: \`${GITHUB_SHA}\`"
+            echo "- Cache generation: \`${{ inputs.cache_generation }}\`"
+            echo "- Temporary package: \`${{ steps.prepare.outputs.image_name }}\`"
+            echo "- Cleanup requested: \`${{ inputs.cleanup }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-amd64:
+    name: Build AMD64
+    runs-on: [self-hosted, Linux, X64, docker]
+    needs: [prepare]
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      build-seconds: ${{ steps.build-elapsed.outputs.seconds }}
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Runner preflight
+        run: .github/scripts/preflight-runner.sh base docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Validate DHI authentication
+        env:
+          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
+          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+        run: |
+          if [ -z "${DHI_USERNAME}" ] || [ -z "${DHI_TOKEN}" ]; then
+            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required."
+            exit 1
+          fi
+
+      - name: Log in to DHI
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start build timer
+        id: build-timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push AMD64 by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          outputs: type=image,name=${{ needs.prepare.outputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.title=Pullbox
+            org.opencontainers.image.description=Pullbox Docker release benchmark image
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.licenses=GPL-3.0-or-later
+          build-args: |
+            BUILD_DATE=${{ needs.prepare.outputs.build-date }}
+            GIT_SHA=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            VERSION=${{ needs.prepare.outputs.version }}
+          cache-from: type=gha,scope=pullbox-benchmark-amd64-${{ inputs.cache_generation }}
+          cache-to: type=gha,mode=max,scope=pullbox-benchmark-amd64-${{ inputs.cache_generation }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Record build duration
+        id: build-elapsed
+        env:
+          STARTED_AT: ${{ steps.build-timer.outputs.started_at }}
+        run: echo "seconds=$(( $(date +%s) - STARTED_AT ))" >> "$GITHUB_OUTPUT"
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unexpected AMD64 digest: ${DIGEST}"
+            exit 1
+          fi
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload AMD64 digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-digest-amd64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-arm64:
+    name: Build ARM64
+    runs-on: [self-hosted, Linux, X64, docker]
+    needs: [prepare]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      build-seconds: ${{ steps.build-elapsed.outputs.seconds }}
+      digest: ${{ steps.build.outputs.digest }}
+      total-seconds: ${{ steps.total-elapsed.outputs.seconds }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Runner preflight
+        run: .github/scripts/preflight-runner.sh base docker
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Validate DHI authentication
+        env:
+          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
+          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+        run: |
+          if [ -z "${DHI_USERNAME}" ] || [ -z "${DHI_TOKEN}" ]; then
+            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required."
+            exit 1
+          fi
+
+      - name: Log in to DHI
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start job timer
+        id: total-timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Start build timer
+        id: build-timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ARM64 by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/arm64
+          outputs: type=image,name=${{ needs.prepare.outputs.image-name }},push-by-digest=true,name-canonical=true,push=true
+          labels: |
+            org.opencontainers.image.title=Pullbox
+            org.opencontainers.image.description=Pullbox Docker release benchmark image
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
+            org.opencontainers.image.licenses=GPL-3.0-or-later
+          build-args: |
+            BUILD_DATE=${{ needs.prepare.outputs.build-date }}
+            GIT_SHA=${{ github.sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            VERSION=${{ needs.prepare.outputs.version }}
+          cache-from: type=gha,scope=pullbox-benchmark-arm64-${{ inputs.cache_generation }}
+          cache-to: type=gha,mode=max,scope=pullbox-benchmark-arm64-${{ inputs.cache_generation }}
+          provenance: mode=max
+          sbom: true
+
+      - name: Record build duration
+        id: build-elapsed
+        env:
+          STARTED_AT: ${{ steps.build-timer.outputs.started_at }}
+        run: echo "seconds=$(( $(date +%s) - STARTED_AT ))" >> "$GITHUB_OUTPUT"
+
+      - name: Verify ARM64 container security runtime
+        env:
+          IMAGE_REF: ${{ needs.prepare.outputs.image-name }}@${{ steps.build.outputs.digest }}
+        run: |
+          docker run --rm --pull always --platform linux/arm64 -i \
+            --entrypoint python "${IMAGE_REF}" - \
+            < scripts/verify_container_security_runtime.py
+
+      - name: Record total ARM64 duration
+        id: total-elapsed
+        env:
+          STARTED_AT: ${{ steps.total-timer.outputs.started_at }}
+        run: echo "seconds=$(( $(date +%s) - STARTED_AT ))" >> "$GITHUB_OUTPUT"
+
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unexpected ARM64 digest: ${DIGEST}"
+            exit 1
+          fi
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload ARM64 digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-digest-arm64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  validate-amd64:
+    name: Validate AMD64
+    runs-on: [self-hosted, Linux, X64, docker]
+    needs: [prepare, build-amd64]
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      validation-seconds: ${{ steps.elapsed.outputs.seconds }}
+    env:
+      IMAGE_REF: ${{ needs.prepare.outputs.image-name }}@${{ needs.build-amd64.outputs.digest }}
+      LOCAL_IMAGE: pullbox:benchmark-amd64-${{ github.run_id }}
+      SMOKE_CONTAINER: pullbox-benchmark-smoke-${{ github.run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Start validation timer
+        id: timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Runner preflight
+        run: .github/scripts/preflight-runner.sh base docker
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull benchmark image
+        run: |
+          docker pull "${IMAGE_REF}"
+          docker tag "${IMAGE_REF}" "${LOCAL_IMAGE}"
+
+      - name: Verify container security runtime
+        run: |
+          docker run --rm -i --entrypoint python "${LOCAL_IMAGE}" - \
+            < scripts/verify_container_security_runtime.py
+
+      - name: Run Grype scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: ${{ env.LOCAL_IMAGE }}
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+          config: .grype.yaml
+
+      - name: Verify packaged static assets
+        run: |
+          docker run --rm --entrypoint python "${LOCAL_IMAGE}" -c '
+          import pullbox.app
+
+          assets = [
+              pullbox.app.STATIC_DIR / "css" / "tailwind.css",
+              pullbox.app.STATIC_DIR / "js" / "htmx.min.js",
+          ]
+          missing = [str(asset) for asset in assets if not asset.is_file()]
+          if missing:
+              raise SystemExit("Missing packaged static assets: " + ", ".join(missing))
+          print("Packaged static assets verified")
+          '
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name "${SMOKE_CONTAINER}" \
+            -p 127.0.0.1::8585 \
+            -e PULLBOX_SECRET_KEY=smoke-test-secret-key-for-docker-ci \
+            -e PULLBOX_LOG_LEVEL=WARNING \
+            "${LOCAL_IMAGE}"
+
+          smoke_port=$(docker port "${SMOKE_CONTAINER}" 8585/tcp | awk -F: 'NR == 1 { print $NF }')
+          if [ -z "${smoke_port}" ]; then
+            echo "::error::Could not determine Pullbox smoke-test port."
+            docker port "${SMOKE_CONTAINER}" || true
+            exit 1
+          fi
+          echo "PULLBOX_SMOKE_URL=http://127.0.0.1:${smoke_port}" >> "$GITHUB_ENV"
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf "${PULLBOX_SMOKE_URL}/ping" > /dev/null 2>&1; then
+              echo "Container healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Container failed to become healthy"
+          docker logs "${SMOKE_CONTAINER}"
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Setup runner-local test venv
+        run: .github/scripts/setup-runner-venv.sh "dev,e2e"
+
+      - name: Install Playwright browsers
+        run: playwright install chromium
+
+      - name: Python preflight
+        run: .github/scripts/preflight-runner.sh python
+
+      - name: Run smoke tests
+        env:
+          PULLBOX_SMOKE_TEST: "true"
+        run: |
+          pytest tests/e2e/test_smoke.py \
+            -v \
+            --base-url "${PULLBOX_SMOKE_URL}"
+
+      - name: Upload smoke traces
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: benchmark-smoke-test-traces
+          path: test-results/smoke/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Record validation duration
+        id: elapsed
+        if: always()
+        env:
+          STARTED_AT: ${{ steps.timer.outputs.started_at }}
+        run: echo "seconds=$(( $(date +%s) - STARTED_AT ))" >> "$GITHUB_OUTPUT"
+
+      - name: Container logs on failure
+        if: failure() || cancelled()
+        run: docker logs "${SMOKE_CONTAINER}"
+
+      - name: Cleanup local container and image
+        if: always()
+        run: |
+          docker rm -f "${SMOKE_CONTAINER}" || true
+          docker image rm "${LOCAL_IMAGE}" || true
+
+  manifest:
+    name: Merge Benchmark Manifest
+    runs-on: ubuntu-latest
+    needs: [prepare, build-amd64, build-arm64, validate-amd64]
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.inspect.outputs.digest }}
+      manifest-seconds: ${{ steps.elapsed.outputs.seconds }}
+      total-seconds: ${{ steps.elapsed.outputs.total_seconds }}
+    steps:
+      - name: Download platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: benchmark-digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start manifest timer
+        id: timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Create temporary multi-platform manifest
+        env:
+          IMAGE_NAME: ${{ needs.prepare.outputs.image-name }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          sources=()
+          for digest_file in *; do
+            sources+=("${IMAGE_NAME}@sha256:${digest_file}")
+          done
+
+          if [ "${#sources[@]}" -ne 2 ]; then
+            echo "::error::Expected two platform digests, found ${#sources[@]}."
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=Pullbox Docker release benchmark image" \
+            --tag "${IMAGE_NAME}:candidate" \
+            "${sources[@]}"
+
+      - name: Inspect temporary manifest
+        id: inspect
+        env:
+          IMAGE_NAME: ${{ needs.prepare.outputs.image-name }}
+        run: |
+          docker buildx imagetools inspect "${IMAGE_NAME}:candidate" > manifest-inspect.txt
+          docker buildx imagetools inspect "${IMAGE_NAME}:candidate" --raw > manifest-index.json
+          cat manifest-inspect.txt
+
+          DIGEST=$(awk '$1 == "Digest:" { print $2; exit }' manifest-inspect.txt)
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unexpected manifest digest: ${DIGEST}"
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+          python3 - <<'PY'
+          import json
+          import sys
+
+          with open("manifest-index.json", encoding="utf-8") as handle:
+              index = json.load(handle)
+
+          manifests = index.get("manifests") or []
+          platforms = {
+              f"{(manifest.get('platform') or {}).get('os')}/"
+              f"{(manifest.get('platform') or {}).get('architecture')}"
+              for manifest in manifests
+              if manifest.get("platform")
+          }
+          expected = {"linux/amd64", "linux/arm64"}
+          if not expected.issubset(platforms):
+              print(f"Missing expected platforms: {expected - platforms}", file=sys.stderr)
+              sys.exit(1)
+
+          attestations = sum(
+              1
+              for manifest in manifests
+              if (manifest.get("annotations") or {}).get("vnd.docker.reference.type")
+              == "attestation-manifest"
+          )
+          if attestations == 0:
+              print("Missing SBOM/provenance attestations.", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Record benchmark duration
+        id: elapsed
+        env:
+          BENCHMARK_STARTED_AT: ${{ needs.prepare.outputs.benchmark-started-at }}
+          MANIFEST_STARTED_AT: ${{ steps.timer.outputs.started_at }}
+        run: |
+          NOW=$(date +%s)
+          echo "seconds=$(( NOW - MANIFEST_STARTED_AT ))" >> "$GITHUB_OUTPUT"
+          echo "total_seconds=$(( NOW - BENCHMARK_STARTED_AT ))" >> "$GITHUB_OUTPUT"
+
+      - name: Write benchmark summary
+        run: |
+          {
+            echo "## Benchmark Result"
+            echo ""
+            echo "| Measurement | Seconds |"
+            echo "|---|---:|"
+            echo "| AMD64 build | ${{ needs.build-amd64.outputs.build-seconds }} |"
+            echo "| ARM64 build | ${{ needs.build-arm64.outputs.build-seconds }} |"
+            echo "| ARM64 build and runtime verification | ${{ needs.build-arm64.outputs.total-seconds }} |"
+            echo "| AMD64 scan and smoke validation | ${{ needs.validate-amd64.outputs.validation-seconds }} |"
+            echo "| Manifest merge and inspection | ${{ steps.elapsed.outputs.seconds }} |"
+            echo "| End-to-end after prepare started | ${{ steps.elapsed.outputs.total_seconds }} |"
+            echo ""
+            echo "Temporary manifest digest: \`${{ steps.inspect.outputs.digest }}\`"
+            echo ""
+            echo "Cleanup time is intentionally excluded from the benchmark total."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  cleanup:
+    name: Delete Benchmark Package
+    runs-on: ubuntu-latest
+    needs: [prepare, build-amd64, build-arm64, validate-amd64, manifest]
+    if: ${{ always() && inputs.cleanup }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete isolated GHCR package
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ needs.prepare.outputs.image-name }}
+          PACKAGE_NAME: ${{ needs.prepare.outputs.package-name }}
+        run: |
+          if [ -z "${IMAGE_NAME}" ] || [ -z "${PACKAGE_NAME}" ]; then
+            echo "::notice::No benchmark package was created."
+            exit 0
+          fi
+
+          OWNER_TYPE=$(jq -r '.repository.owner.type' "${GITHUB_EVENT_PATH}")
+          if ! [[ "${PACKAGE_NAME}" =~ ^[a-z0-9._-]+$ ]]; then
+            echo "::error::Refusing to delete unexpected package name: ${PACKAGE_NAME}"
+            exit 1
+          fi
+          if [[ "${PACKAGE_NAME}" != pullbox-benchmark-* ]]; then
+            echo "::error::Refusing to delete a non-benchmark package: ${PACKAGE_NAME}"
+            exit 1
+          fi
+
+          case "${OWNER_TYPE}" in
+            Organization)
+              ENDPOINT="/orgs/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}"
+              ;;
+            User)
+              ENDPOINT="/users/${GITHUB_REPOSITORY_OWNER}/packages/container/${PACKAGE_NAME}"
+              ;;
+            *)
+              echo "::error::Unexpected repository owner type: ${OWNER_TYPE}"
+              exit 1
+              ;;
+          esac
+
+          for attempt in $(seq 1 12); do
+            if gh api --method DELETE "${ENDPOINT}"; then
+              echo "Deleted temporary package ${IMAGE_NAME}."
+              exit 0
+            fi
+            echo "Package deletion not ready; retrying in 10 seconds (${attempt}/12)."
+            sleep 10
+          done
+
+          echo "::warning::Unable to delete ${IMAGE_NAME}; remove this isolated benchmark package manually."

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,30 +1,12 @@
 ---
 # Pullbox Docker Release Pipeline
-# Builds images, scans with Grype, runs smoke tests, publishes registry images,
-# signs them with Cosign, and verifies signatures only for release tags or
-# explicit release dispatches.
+# Builds AMD64 and ARM64 images concurrently, validates the AMD64 candidate,
+# publishes multi-platform manifests to GHCR and Docker Hub, signs both
+# registries with Cosign, and verifies the published release.
 #
-# Registries: GHCR and Docker Hub.
-#
-# Security: All actions pinned to full SHA. Container scanned before push.
-# See: docs/development/INFRASTRUCTURE.md
-#
-# Trigger rules:
-#   v* tag push  → release image build/publish/sign/verify
-#   dispatch     → manual release image build from the selected ref
-# Trusted Docker publish stays on the self-hosted runner. This workflow is not
-# governed by the general checks-runner toggle.
-#
-# Tag strategy:
-#   final v* tag → 1.2.3, latest, sha-xxxxx
-#   pre-release  → 1.2.3-rc1, sha-xxxxx
-#   manual       → edge (or custom), sha-xxxxx
-#
-# Versioning:
-#   Version is read from pullbox/__init__.py (__version__).
-#   During development: "0.X.0-dev" (bumped per sprint milestone).
-#   At release: "1.0.0-rc1" → "1.0.0" (git tag triggers release workflow).
-#   See CICD_SPRINT_GUIDE.md for the full versioning plan.
+# Security: All actions pinned to full SHA. Release tags or explicit manual
+# dispatches are the only publishing triggers. Runnable tags are created only
+# after the candidate image passes Grype and smoke validation.
 
 name: Docker Release
 
@@ -52,23 +34,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ──────────────────────────────────────────────
-  # Job 0: Decide whether this invocation should build
-  # ──────────────────────────────────────────────
-  gate:
-    name: Resolve Docker Trigger
-    runs-on: [self-hosted, Linux, X64, docker]
+  # Resolve release metadata once without occupying a Docker runner.
+  build:
+    name: Prepare Docker Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     outputs:
-      should-run: ${{ steps.decide.outputs.should_run }}
+      image-tags: ${{ steps.meta.outputs.tags }}
+      image-labels: ${{ steps.meta.outputs.labels }}
+      image-annotations: ${{ steps.meta.outputs.annotations }}
+      image-version: ${{ steps.version.outputs.version }}
+      build-date: ${{ steps.release-metadata.outputs.build_date }}
       build-sha: ${{ steps.resolve-sha.outputs.sha }}
-      release-tag: ${{ steps.resolve-sha.outputs.release_tag }}
+      release-tag: ${{ steps.resolve-tag.outputs.tag }}
+      is-release: ${{ steps.resolve-tag.outputs.is_release }}
+      is-prerelease: ${{ steps.resolve-tag.outputs.is_prerelease }}
     steps:
       - name: Resolve correct SHA
         id: resolve-sha
         run: |
-          echo "sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           if [ "${GITHUB_REF_TYPE}" = "tag" ] && [[ "${GITHUB_REF_NAME}" == v* ]]; then
             echo "release_tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           else
@@ -82,82 +69,36 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Decide whether to run Docker jobs
-        id: decide
-        run: |
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
-          echo "Release tag/manual trigger; running Docker release workflow."
-
-  # ──────────────────────────────────────────────
-  # Job 1: Build multi-arch image
-  # ──────────────────────────────────────────────
-  build:
-    name: Build Multi-Arch Image
-    runs-on: [self-hosted, Linux, X64, docker]
-    needs: [gate]
-    timeout-minutes: 45
-    if: needs.gate.outputs.should-run == 'true'
-    permissions:
-      contents: read
-    outputs:
-      image-tags: ${{ steps.meta.outputs.tags }}
-      image-labels: ${{ steps.meta.outputs.labels }}
-      image-version: ${{ steps.version.outputs.version }}
-      build-sha: ${{ needs.gate.outputs.build-sha }}
-      release-tag: ${{ steps.resolve-tag.outputs.tag }}
-      is-release: ${{ steps.resolve-tag.outputs.is_release }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ needs.gate.outputs.build-sha }}
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Resolve tag from trigger
         id: resolve-tag
         run: |
-          TAG="${{ needs.gate.outputs.release-tag }}"
+          TAG="${{ steps.resolve-sha.outputs.release_tag }}"
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          if [ -n "$TAG" ]; then
+          if [ -n "${TAG}" ]; then
             echo "is_release=true" >> "$GITHUB_OUTPUT"
-            if [[ "$TAG" == *-* ]]; then
+            if [[ "${TAG}" == *-* ]]; then
               echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
             else
               echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
             fi
-            echo "Found tag: $TAG"
           else
             echo "is_release=false" >> "$GITHUB_OUTPUT"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-            echo "No release tag for this trigger"
           fi
 
-      - name: Runner preflight
-        run: .github/scripts/preflight-runner.sh base docker
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      - name: Validate DHI authentication
-        env:
-          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
-          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+      - name: Extract version
+        id: version
         run: |
-          if [ -z "${DHI_USERNAME}" ] || [ -z "${DHI_TOKEN}" ]; then
-            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required to build Docker Hardened Images in CI."
+          VERSION=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)
+          if [ -z "${VERSION}" ]; then
+            echo "::error::Unable to extract Pullbox version from src/pullbox/__init__.py"
             exit 1
           fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to DHI
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: dhi.io
-          username: ${{ secrets.DHI_USERNAME }}
-          password: ${{ secrets.DHI_TOKEN }}
+      - name: Capture release metadata
+        id: release-metadata
+        run: echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
 
       - name: Docker metadata
         id: meta
@@ -178,250 +119,33 @@ jobs:
             org.opencontainers.image.description=Modern comic book management and acquisition platform
             org.opencontainers.image.url=https://github.com/${{ github.repository }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.gate.outputs.build-sha }}
+            org.opencontainers.image.revision=${{ steps.resolve-sha.outputs.sha }}
             org.opencontainers.image.licenses=GPL-3.0-or-later
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
           annotations: |
             org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments
 
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)
-          if [ -z "$VERSION" ]; then
-            echo "::error::Unable to extract Pullbox version from src/pullbox/__init__.py"
-            exit 1
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      # Build for amd64 only and export to local Docker for scanning + smoke tests.
-      # Multi-arch push happens in the push job after validation.
-      - name: Build amd64 image (for scan + smoke)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: linux/amd64
-          load: true
-          tags: pullbox:ci-scan
-          build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
-            GIT_SHA=${{ needs.gate.outputs.build-sha }}
-            GIT_BRANCH=${{ github.ref_name }}
-            VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Save image for downstream jobs
-        run: docker save pullbox:ci-scan | gzip > "${{ runner.temp }}/pullbox-image.tar.gz"
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: docker-image
-          path: ${{ runner.temp }}/pullbox-image.tar.gz
-          retention-days: 1
-
-  # ──────────────────────────────────────────────
-  # Job 2: Grype vulnerability scan
-  # ──────────────────────────────────────────────
-  scan:
-    name: Container Scan (Grype)
+  # Build each platform on a separate Docker runner. Digests are pushed without
+  # runnable tags so failed validation cannot publish a release.
+  build-amd64:
+    name: Build AMD64
     runs-on: [self-hosted, Linux, X64, docker]
     needs: [build]
-    timeout-minutes: 20
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: docker-image
-          path: ${{ runner.temp }}/docker-image-scan
-
-      - name: Load image
-        run: docker load < "${{ runner.temp }}/docker-image-scan/pullbox-image.tar.gz"
-
-      - name: Runner preflight
-        run: .github/scripts/preflight-runner.sh docker
-
-      - name: Verify container security runtime
-        run: |
-          docker run --rm -i --entrypoint python pullbox:ci-scan - \
-            < scripts/verify_container_security_runtime.py
-
-      - name: Run Grype scan
-        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
-        id: scan
-        with:
-          image: pullbox:ci-scan
-          fail-build: true
-          severity-cutoff: high
-          output-format: sarif
-          config: .grype.yaml
-
-      - name: Upload SARIF to GitHub Security
-        if: always()
-        continue-on-error: true  # SARIF upload requires GitHub Advanced Security (paid for private repos)
-        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
-        with:
-          sarif_file: ${{ steps.scan.outputs.sarif }}
-          category: container-scan
-
-  # ──────────────────────────────────────────────
-  # Job 3: Smoke test against Docker image
-  # ──────────────────────────────────────────────
-  smoke-test:
-    name: Docker Smoke Test
-    runs-on: [self-hosted, Linux, X64, docker]
-    needs: [build]
-    timeout-minutes: 25
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: docker-image
-          path: ${{ runner.temp }}/docker-image-smoke
-
-      - name: Load image
-        run: docker load < "${{ runner.temp }}/docker-image-smoke/pullbox-image.tar.gz"
-
-      - name: Runner preflight
-        run: .github/scripts/preflight-runner.sh docker
-
-      - name: Verify packaged static assets
-        run: |
-          docker run --rm --entrypoint python pullbox:ci-scan -c '
-          import pullbox.app
-
-          assets = [
-              pullbox.app.STATIC_DIR / "css" / "tailwind.css",
-              pullbox.app.STATIC_DIR / "js" / "htmx.min.js",
-          ]
-          missing = [str(asset) for asset in assets if not asset.is_file()]
-          if missing:
-              raise SystemExit("Missing packaged static assets: " + ", ".join(missing))
-          print("Packaged static assets verified")
-          '
-
-      - name: Start container
-        run: |
-          docker run -d \
-            --name pullbox-smoke \
-            -p 127.0.0.1::8585 \
-            -e PULLBOX_SECRET_KEY=smoke-test-secret-key-for-docker-ci \
-            -e PULLBOX_LOG_LEVEL=WARNING \
-            pullbox:ci-scan
-          smoke_port="$(docker port pullbox-smoke 8585/tcp | awk -F: 'NR == 1 { print $NF }')"
-          if [ -z "${smoke_port}" ]; then
-            echo "::error::Could not determine Pullbox smoke-test port."
-            docker port pullbox-smoke || true
-            exit 1
-          fi
-          echo "PULLBOX_SMOKE_URL=http://127.0.0.1:${smoke_port}" >> "$GITHUB_ENV"
-          echo "Container listening on http://127.0.0.1:${smoke_port}"
-
-      - name: Wait for healthy
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf "${PULLBOX_SMOKE_URL}/ping" > /dev/null 2>&1; then
-              echo "✅ Container healthy after ${i}s"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "❌ Container failed to become healthy"
-          docker logs pullbox-smoke
-          exit 1
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: ${{ env.PYTHON_DEFAULT }}
-
-      - name: Setup runner-local test venv
-        run: .github/scripts/setup-runner-venv.sh "dev,e2e"
-
-      - name: Install Playwright browsers
-        run: playwright install chromium
-
-      - name: Python preflight
-        run: .github/scripts/preflight-runner.sh python
-
-      - name: Run smoke tests
-        run: |
-          pytest tests/e2e/test_smoke.py \
-            -v \
-            --base-url "${PULLBOX_SMOKE_URL}"
-        env:
-          PULLBOX_SMOKE_TEST: "true"
-
-      - name: Upload smoke traces
-        if: failure() || cancelled()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: smoke-test-traces
-          path: test-results/smoke/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Container logs on failure
-        if: failure() || cancelled()
-        run: docker logs pullbox-smoke
-
-      - name: Cleanup
-        if: always()
-        run: docker rm -f pullbox-smoke || true
-
-  # ──────────────────────────────────────────────
-  # Job 4: Push to registries (after scan + smoke)
-  # ──────────────────────────────────────────────
-  push:
-    name: Push to Registries
-    runs-on: [self-hosted, Linux, X64, docker]
-    needs: [build, scan, smoke-test]
     if: needs.build.outputs.is-release == 'true' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 60
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
     outputs:
-      image-digest: ${{ steps.push-image.outputs.digest }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.build.outputs.build-sha }}
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Resolve tag from trigger
-        id: resolve-tag
-        run: |
-          TAG="${{ needs.build.outputs.release-tag }}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          if [ -n "$TAG" ]; then
-            echo "is_release=true" >> "$GITHUB_OUTPUT"
-            if [[ "$TAG" == *-* ]]; then
-              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Runner preflight
         run: .github/scripts/preflight-runner.sh base docker
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -432,7 +156,7 @@ jobs:
           DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
         run: |
           if [ -z "${DHI_USERNAME}" ] || [ -z "${DHI_TOKEN}" ]; then
-            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required to build Docker Hardened Images in CI."
+            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required."
             exit 1
           fi
 
@@ -456,7 +180,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
-            echo "::error::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets are required to publish release images to Docker Hub."
+            echo "::error::Docker Hub credentials are required to publish release images."
             exit 1
           fi
 
@@ -466,118 +190,505 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
-        with:
-          images: |
-            ${{ env.GHCR_IMAGE }}
-            ${{ env.DOCKERHUB_IMAGE }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ steps.resolve-tag.outputs.tag }},enable=${{ steps.resolve-tag.outputs.is_release }}
-            type=raw,value=latest,enable=${{ steps.resolve-tag.outputs.is_release == 'true' && steps.resolve-tag.outputs.is_prerelease != 'true' }}
-            type=raw,value=${{ inputs.tag_override || 'edge' }},enable=${{ github.event_name == 'workflow_dispatch' }}
-            type=sha,format=short,prefix=sha-
-          labels: |
-            org.opencontainers.image.title=Pullbox
-            org.opencontainers.image.description=Modern comic book management and acquisition platform
-            org.opencontainers.image.url=https://github.com/${{ github.repository }}
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.revision=${{ needs.build.outputs.build-sha }}
-            org.opencontainers.image.licenses=GPL-3.0-or-later
-            org.opencontainers.image.version=${{ needs.build.outputs.image-version }}
-          annotations: |
-            org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments
-
-      - name: Extract version
-        id: version
-        run: |
-          VERSION=$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' src/pullbox/__init__.py | head -1)
-          if [ -z "$VERSION" ]; then
-            echo "::error::Unable to extract Pullbox version from src/pullbox/__init__.py"
-            exit 1
-          fi
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push multi-arch
-        id: push-image
+      - name: Build and push AMD64 by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          platforms: linux/amd64
+          outputs: >-
+            type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ needs.build.outputs.image-labels }}
+          annotations: ${{ needs.build.outputs.image-annotations }}
           build-args: |
-            BUILD_DATE=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            BUILD_DATE=${{ needs.build.outputs.build-date }}
             GIT_SHA=${{ needs.build.outputs.build-sha }}
             GIT_BRANCH=${{ github.ref_name }}
-            VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            VERSION=${{ needs.build.outputs.image-version }}
+          cache-from: type=gha,scope=pullbox-release-amd64-v1
+          cache-to: type=gha,mode=max,scope=pullbox-release-amd64-v1
           provenance: mode=max
           sbom: true
 
-      - name: Validate pushed image digest
+      - name: Validate AMD64 digest in both registries
         env:
-          DIGEST: ${{ steps.push-image.outputs.digest }}
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
-            echo "::error::Unexpected pushed image digest format: ${DIGEST}"
+            echo "::error::Unexpected AMD64 digest: ${DIGEST}"
+            exit 1
+          fi
+          docker buildx imagetools inspect "${GHCR_IMAGE}@${DIGEST}" > /dev/null
+          docker buildx imagetools inspect "${DOCKERHUB_IMAGE}@${DIGEST}" > /dev/null
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload AMD64 digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digest-amd64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-arm64:
+    name: Build ARM64
+    runs-on: [self-hosted, Linux, X64, docker]
+    needs: [build]
+    if: needs.build.outputs.is-release == 'true' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.build-sha }}
+
+      - name: Runner preflight
+        run: .github/scripts/preflight-runner.sh base docker
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Validate DHI authentication
+        env:
+          DHI_USERNAME: ${{ secrets.DHI_USERNAME }}
+          DHI_TOKEN: ${{ secrets.DHI_TOKEN }}
+        run: |
+          if [ -z "${DHI_USERNAME}" ] || [ -z "${DHI_TOKEN}" ]; then
+            echo "::error::DHI_USERNAME and DHI_TOKEN repository secrets are required."
             exit 1
           fi
 
-      - name: Validate pushed image metadata
+      - name: Log in to DHI
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DHI_USERNAME }}
+          password: ${{ secrets.DHI_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate Docker Hub authentication
         env:
-          DIGEST: ${{ steps.push-image.outputs.digest }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          docker buildx imagetools inspect "${GHCR_IMAGE}@${DIGEST}" --raw > image-index.json
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "::error::Docker Hub credentials are required to publish release images."
+            exit 1
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push ARM64 by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/arm64
+          outputs: >-
+            type=image,"name=${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+          labels: ${{ needs.build.outputs.image-labels }}
+          annotations: ${{ needs.build.outputs.image-annotations }}
+          build-args: |
+            BUILD_DATE=${{ needs.build.outputs.build-date }}
+            GIT_SHA=${{ needs.build.outputs.build-sha }}
+            GIT_BRANCH=${{ github.ref_name }}
+            VERSION=${{ needs.build.outputs.image-version }}
+          cache-from: type=gha,scope=pullbox-release-arm64-v1
+          cache-to: type=gha,mode=max,scope=pullbox-release-arm64-v1
+          provenance: mode=max
+          sbom: true
+
+      - name: Validate ARM64 digest in both registries
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          if ! [[ "${DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unexpected ARM64 digest: ${DIGEST}"
+            exit 1
+          fi
+          docker buildx imagetools inspect "${GHCR_IMAGE}@${DIGEST}" > /dev/null
+          docker buildx imagetools inspect "${DOCKERHUB_IMAGE}@${DIGEST}" > /dev/null
+
+      - name: Verify ARM64 container security runtime
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          docker run --rm --pull always --platform linux/arm64 -i \
+            --entrypoint python "${GHCR_IMAGE}@${DIGEST}" - \
+            < scripts/verify_container_security_runtime.py
+
+      - name: Export ARM64 digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - name: Upload ARM64 digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-digest-arm64
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Scan and smoke-test the AMD64 digest as soon as it is available. This runs
+  # concurrently with the longer QEMU-backed ARM64 build.
+  validate-amd64:
+    name: Validate AMD64 Candidate
+    runs-on: [self-hosted, Linux, X64, docker]
+    needs: [build, build-amd64]
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    env:
+      IMAGE_REF: ghcr.io/${{ github.repository }}@${{ needs.build-amd64.outputs.digest }}
+      LOCAL_IMAGE: pullbox:release-amd64-${{ github.run_id }}
+      SMOKE_CONTAINER: pullbox-release-smoke-${{ github.run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.build-sha }}
+
+      - name: Runner preflight
+        run: .github/scripts/preflight-runner.sh base docker
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull candidate image
+        run: |
+          docker pull "${IMAGE_REF}"
+          docker tag "${IMAGE_REF}" "${LOCAL_IMAGE}"
+
+      - name: Verify container security runtime
+        run: |
+          docker run --rm -i --entrypoint python "${LOCAL_IMAGE}" - \
+            < scripts/verify_container_security_runtime.py
+
+      - name: Run Grype scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        id: scan
+        with:
+          image: ${{ env.LOCAL_IMAGE }}
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+          config: .grype.yaml
+
+      - name: Upload SARIF to GitHub Security
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+          category: container-scan
+
+      - name: Verify packaged static assets
+        run: |
+          docker run --rm --entrypoint python "${LOCAL_IMAGE}" -c '
+          import pullbox.app
+
+          assets = [
+              pullbox.app.STATIC_DIR / "css" / "tailwind.css",
+              pullbox.app.STATIC_DIR / "js" / "htmx.min.js",
+          ]
+          missing = [str(asset) for asset in assets if not asset.is_file()]
+          if missing:
+              raise SystemExit("Missing packaged static assets: " + ", ".join(missing))
+          print("Packaged static assets verified")
+          '
+
+      - name: Start container
+        run: |
+          docker run -d \
+            --name "${SMOKE_CONTAINER}" \
+            -p 127.0.0.1::8585 \
+            -e PULLBOX_SECRET_KEY=smoke-test-secret-key-for-docker-ci \
+            -e PULLBOX_LOG_LEVEL=WARNING \
+            "${LOCAL_IMAGE}"
+          smoke_port=$(docker port "${SMOKE_CONTAINER}" 8585/tcp | awk -F: 'NR == 1 { print $NF }')
+          if [ -z "${smoke_port}" ]; then
+            echo "::error::Could not determine Pullbox smoke-test port."
+            docker port "${SMOKE_CONTAINER}" || true
+            exit 1
+          fi
+          echo "PULLBOX_SMOKE_URL=http://127.0.0.1:${smoke_port}" >> "$GITHUB_ENV"
+
+      - name: Wait for healthy
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf "${PULLBOX_SMOKE_URL}/ping" > /dev/null 2>&1; then
+              echo "Container healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Container failed to become healthy"
+          docker logs "${SMOKE_CONTAINER}"
+          exit 1
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ env.PYTHON_DEFAULT }}
+
+      - name: Setup runner-local test venv
+        run: .github/scripts/setup-runner-venv.sh "dev,e2e"
+
+      - name: Install Playwright browsers
+        run: playwright install chromium
+
+      - name: Python preflight
+        run: .github/scripts/preflight-runner.sh python
+
+      - name: Run smoke tests
+        env:
+          PULLBOX_SMOKE_TEST: "true"
+        run: |
+          pytest tests/e2e/test_smoke.py \
+            -v \
+            --base-url "${PULLBOX_SMOKE_URL}"
+
+      - name: Upload smoke traces
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: smoke-test-traces
+          path: test-results/smoke/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Container logs on failure
+        if: failure() || cancelled()
+        run: docker logs "${SMOKE_CONTAINER}"
+
+      - name: Cleanup local container and image
+        if: always()
+        run: |
+          docker rm -f "${SMOKE_CONTAINER}" || true
+          docker image rm "${LOCAL_IMAGE}" || true
+
+  # Assemble and tag the already-built platform digests only after validation.
+  push:
+    name: Publish Multi-Arch Manifests
+    runs-on: ubuntu-latest
+    needs: [build, build-amd64, build-arm64, validate-amd64]
+    if: needs.build.outputs.is-release == 'true' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image-digest: ${{ steps.inspect.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.build.outputs.build-sha }}
+
+      - name: Download platform digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: release-digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+        with:
+          platforms: arm64
+
+      - name: Log in to GHCR
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate Docker Hub authentication
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+            echo "::error::Docker Hub credentials are required to publish release images."
+            exit 1
+          fi
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish GHCR multi-platform manifest
+        env:
+          TAGS: ${{ needs.build.outputs.image-tags }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          sources=()
+          for digest_file in *; do
+            sources+=("${GHCR_IMAGE}@sha256:${digest_file}")
+          done
+          if [ "${#sources[@]}" -ne 2 ]; then
+            echo "::error::Expected two platform digests, found ${#sources[@]}."
+            exit 1
+          fi
+
+          tag_args=()
+          while IFS= read -r tag; do
+            if [[ "${tag}" == "${GHCR_IMAGE}:"* ]]; then
+              tag_args+=(--tag "${tag}")
+            fi
+          done <<< "${TAGS}"
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "::error::No GHCR release tags were generated."
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments" \
+            "${tag_args[@]}" \
+            "${sources[@]}"
+
+      - name: Publish Docker Hub multi-platform manifest
+        env:
+          TAGS: ${{ needs.build.outputs.image-tags }}
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          sources=()
+          for digest_file in *; do
+            sources+=("${DOCKERHUB_IMAGE}@sha256:${digest_file}")
+          done
+
+          tag_args=()
+          while IFS= read -r tag; do
+            if [[ "${tag}" == "${DOCKERHUB_IMAGE}:"* ]]; then
+              tag_args+=(--tag "${tag}")
+            fi
+          done <<< "${TAGS}"
+          if [ "${#tag_args[@]}" -eq 0 ]; then
+            echo "::error::No Docker Hub release tags were generated."
+            exit 1
+          fi
+
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=Modern comic book management and acquisition platform for self-hosted environments" \
+            "${tag_args[@]}" \
+            "${sources[@]}"
+
+      - name: Validate pushed image metadata
+        id: inspect
+        env:
+          TAGS: ${{ needs.build.outputs.image-tags }}
+        run: |
+          GHCR_TAG=$(printf '%s\n' "${TAGS}" | awk -v prefix="${GHCR_IMAGE}:" 'index($0, prefix) == 1 { print; exit }')
+          if [ -z "${GHCR_TAG}" ]; then
+            echo "::error::Unable to resolve a published GHCR tag."
+            exit 1
+          fi
+          TAG_SUFFIX=${GHCR_TAG#${GHCR_IMAGE}:}
+          DOCKERHUB_TAG="${DOCKERHUB_IMAGE}:${TAG_SUFFIX}"
+
+          docker buildx imagetools inspect "${GHCR_TAG}" > ghcr-inspect.txt
+          docker buildx imagetools inspect "${DOCKERHUB_TAG}" > dockerhub-inspect.txt
+          docker buildx imagetools inspect "${GHCR_TAG}" --raw > ghcr-index.json
+          docker buildx imagetools inspect "${DOCKERHUB_TAG}" --raw > dockerhub-index.json
+
+          GHCR_DIGEST=$(awk '$1 == "Digest:" { print $2; exit }' ghcr-inspect.txt)
+          DOCKERHUB_DIGEST=$(awk '$1 == "Digest:" { print $2; exit }' dockerhub-inspect.txt)
+          if ! [[ "${GHCR_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+            echo "::error::Unexpected GHCR manifest digest: ${GHCR_DIGEST}"
+            exit 1
+          fi
+          if [ "${GHCR_DIGEST}" != "${DOCKERHUB_DIGEST}" ]; then
+            echo "::error::Published registry digests differ: GHCR=${GHCR_DIGEST} DockerHub=${DOCKERHUB_DIGEST}"
+            exit 1
+          fi
+          echo "digest=${GHCR_DIGEST}" >> "$GITHUB_OUTPUT"
+
           python3 - <<'PY'
           import json
           import sys
 
-          with open("image-index.json", encoding="utf-8") as handle:
-              index = json.load(handle)
-
-          annotations = index.get("annotations") or {}
           expected_description = (
               "Modern comic book management and acquisition platform for "
               "self-hosted environments"
           )
-          if annotations.get("org.opencontainers.image.description") != expected_description:
-              print("Missing OCI index description annotation.", file=sys.stderr)
-              sys.exit(1)
-
-          manifests = index.get("manifests") or []
-          platforms = {
-              f"{(manifest.get('platform') or {}).get('os')}/"
-              f"{(manifest.get('platform') or {}).get('architecture')}"
-              for manifest in manifests
-              if manifest.get("platform")
-          }
           expected_platforms = {"linux/amd64", "linux/arm64"}
-          if not expected_platforms.issubset(platforms):
-              print(f"Missing expected runnable platforms: {expected_platforms - platforms}", file=sys.stderr)
-              sys.exit(1)
 
-          attestation_count = sum(
-              1
-              for manifest in manifests
-              if (manifest.get("annotations") or {}).get("vnd.docker.reference.type")
-              == "attestation-manifest"
-          )
-          if attestation_count == 0:
-              print("Missing SBOM/provenance attestation manifests.", file=sys.stderr)
-              sys.exit(1)
+          for registry, path in [
+              ("GHCR", "ghcr-index.json"),
+              ("Docker Hub", "dockerhub-index.json"),
+          ]:
+              with open(path, encoding="utf-8") as handle:
+                  index = json.load(handle)
+
+              annotations = index.get("annotations") or {}
+              if annotations.get("org.opencontainers.image.description") != expected_description:
+                  print(f"{registry}: missing OCI index description annotation.", file=sys.stderr)
+                  sys.exit(1)
+
+              manifests = index.get("manifests") or []
+              platforms = {
+                  f"{(manifest.get('platform') or {}).get('os')}/"
+                  f"{(manifest.get('platform') or {}).get('architecture')}"
+                  for manifest in manifests
+                  if manifest.get("platform")
+              }
+              if not expected_platforms.issubset(platforms):
+                  missing = expected_platforms - platforms
+                  print(f"{registry}: missing runnable platforms: {missing}", file=sys.stderr)
+                  sys.exit(1)
+
+              attestations = sum(
+                  1
+                  for manifest in manifests
+                  if (manifest.get("annotations") or {}).get("vnd.docker.reference.type")
+                  == "attestation-manifest"
+              )
+              if attestations == 0:
+                  print(f"{registry}: missing SBOM/provenance attestations.", file=sys.stderr)
+                  sys.exit(1)
           PY
 
       - name: Verify published platform security runtimes
         env:
-          DIGEST: ${{ steps.push-image.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
         run: |
           for platform in linux/amd64 linux/arm64; do
             echo "Verifying container security runtime for ${platform}"
@@ -591,17 +702,14 @@ jobs:
           {
             echo "## Docker Images Published"
             echo ""
-            echo "**Digest:** \`${{ steps.push-image.outputs.digest }}\`"
+            echo "**Digest:** \`${{ steps.inspect.outputs.digest }}\`"
             echo ""
             echo "**Tags:**"
             echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "${{ needs.build.outputs.image-tags }}"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # ──────────────────────────────────────────────
-  # Job 5: Sign published image digests
-  # ──────────────────────────────────────────────
   sign:
     name: Sign Published Images
     runs-on: ubuntu-latest
@@ -626,7 +734,7 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
-            echo "::error::DOCKERHUB_USERNAME and DOCKERHUB_TOKEN repository secrets are required to sign release images on Docker Hub."
+            echo "::error::Docker Hub credentials are required to sign release images."
             exit 1
           fi
 
@@ -647,7 +755,6 @@ jobs:
             echo "::error::Push job did not return a digest to sign."
             exit 1
           fi
-
           cosign sign --yes "${GHCR_IMAGE}@${DIGEST}"
           cosign sign --yes "${DOCKERHUB_IMAGE}@${DIGEST}"
 
@@ -670,12 +777,10 @@ jobs:
                 "${image_ref}"; then
                 return 0
               fi
-
               if [ "${attempt}" -eq "${max_attempts}" ]; then
                 echo "::error::Signature for ${label} was not discoverable after ${max_attempts} attempts."
                 return 1
               fi
-
               echo "::notice::Signature for ${label} was not discoverable yet; retrying in 10 seconds (${attempt}/${max_attempts})."
               sleep 10
             done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Raised the Pillow dependency floor to 12.3.0 to include upstream fixes for
-  crafted font/image memory exhaustion and Windows viewer command injection.
-
 ### Performance
 
 ### Testing
@@ -24,10 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### CI / Build
 
+### Internal
+
+## [1.0.3] - 2026-07-13
+
+Maintenance release focused on faster multi-architecture image publication and
+dependency security while preserving the existing release gates.
+
+### Fixed
+
+- Raised the Pillow dependency floor to 12.3.0 to include upstream fixes for
+  crafted font/image memory exhaustion and Windows viewer command injection.
+
+### CI / Build
+
 - Parallelized AMD64 and ARM64 release builds across two Docker runners while
   preserving Grype, smoke-test, dual-registry, attestation, and signing gates.
-
-### Internal
 
 ## [1.0.2] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Raised the Pillow dependency floor to 12.3.0 to include upstream fixes for
+  crafted font/image memory exhaustion and Windows viewer command injection.
+
 ### Performance
 
 ### Testing
@@ -20,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 ### CI / Build
+
+- Parallelized AMD64 and ARM64 release builds across two Docker runners while
+  preserving Grype, smoke-test, dual-registry, attestation, and signing gates.
 
 ### Internal
 

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -245,9 +245,10 @@ tracked in the active CI/CD path.
 - Trusted Docker validation and Docker release jobs use the explicit
   self-hosted `docker` runner label by design. They are not governed by
   `PULLBOX_CHECKS_RUNNER`.
-- Two isolated-VM runners carry the `docker` label so benchmark platform builds
-  can run concurrently. Production release behavior remains unchanged until a
-  benchmarked design is adopted explicitly.
+- Two isolated-VM runners carry the `docker` label so benchmark and production
+  AMD64/ARM64 platform builds can run concurrently. Production releases use
+  architecture-specific GitHub Actions cache scopes and merge the platform
+  digests only after validation succeeds.
 - Untrusted Docker PRs run a reduced public sanity check (`Dockerfile.dev`
   build) instead of the full DHI-backed production build.
 - `Docker Validate Required` is the stable aggregate check for Docker
@@ -608,7 +609,9 @@ Development dependency categories:
 ### 8.1 Current Pullbox implementation
 
 - Version tags trigger GitHub Actions release and Docker automation.
-- GitHub Actions `Docker Release` builds, scans, smoke-tests, publishes, signs, and
+- GitHub Actions `Docker Release` builds AMD64 and ARM64 concurrently on the two
+  Docker runners, scans and smoke-tests the AMD64 candidate while ARM64
+  continues, publishes the validated multi-platform manifests, signs them, and
   verifies release images only for version tags or explicit release dispatches.
 - GitHub Actions `Docker Validate` validates Docker-sensitive PR changes without
   publishing.
@@ -622,6 +625,11 @@ Development dependency categories:
 - The root `CHANGELOG.md` is curated manually during release prep.
 - Release tags are expected to be signed.
 - GHCR and Docker Hub are the current image registries.
+- Platform jobs stage immutable, untagged digests in both registries. Version,
+  `latest`, `edge`, and SHA tags are created only after Grype and smoke
+  validation succeeds.
+- GHCR and Docker Hub final manifests must resolve to the same digest and expose
+  both runnable architectures plus SBOM/provenance attestations.
 - GHCR may display SBOM/provenance attestation manifests as `unknown/unknown`.
   Those entries are expected supply-chain metadata, not runnable Pullbox images.
 
@@ -635,7 +643,8 @@ Development dependency categories:
   is pushed.
 - Docker publication should happen only from trusted refs and should not publish
   ordinary untagged `main` merges.
-- Release images should pass Grype and smoke tests before publication.
+- Release images should pass Grype and smoke tests before runnable registry tags
+  are published.
 - Release images should publish SBOM/provenance attestations and pass Cosign
   digest signature verification before Docker Release succeeds.
 - GHCR and Docker Hub tags should be reviewed after release.
@@ -648,6 +657,9 @@ Development dependency categories:
 - Pre-release tags can exercise the full pipeline before a stable release.
 - Pre-release tags must not update `latest`; only final release tags should move
   that alias.
+- The AMD64 and ARM64 builders use separate stable cache scopes. Changing a
+  scope generation intentionally creates a cold build; routine releases should
+  reuse the existing generation.
 - If Docker publish succeeds but registry tags look wrong, treat that as release
   hygiene work before moving on.
 
@@ -661,6 +673,7 @@ Development dependency categories:
       annotations.
 - [ ] Multi-arch manifests include `linux/amd64`, `linux/arm64`, and
       SBOM/provenance attestation manifests.
+- [ ] GHCR and Docker Hub publish the same final multi-platform digest.
 - [ ] GHCR and Docker Hub release image signatures verify with Cosign by digest.
 - [ ] Unwanted GHCR and Docker Hub aliases are reviewed and cleaned up.
 

--- a/docs/development/INFRASTRUCTURE.md
+++ b/docs/development/INFRASTRUCTURE.md
@@ -185,6 +185,7 @@ tracked in the active CI/CD path.
 | `Security` | Pull requests and manual dispatch | gitleaks, dependency audits, Bandit, CodeQL, and aggregate security gate after `ci:full` |
 | `Workflow Hygiene` | Pull requests and manual dispatch | actionlint and aggregate workflow gate after `ci:full` |
 | `Docker Validate` | Pull requests and manual dispatch | Trusted DHI production image validation or reduced public sanity validation |
+| `Docker Release Benchmark` | Manual dispatch | GHCR-only distributed AMD64/ARM64 build timing with temporary package cleanup |
 | `Docker Release` | Version tag push and manual dispatch | Release image build, Grype scan, smoke test, GHCR/Docker Hub publish, Cosign signing, and signature verification |
 | `Release` | Successful `Docker Release` workflow run | GitHub Release creation with curated changelog, generated commit details, Docker pull commands, signature verification, and full changelog link |
 
@@ -217,6 +218,14 @@ tracked in the active CI/CD path.
   the released version to the next patch `-dev` version.
 - Docker validation is a PR/manual GitHub Actions workflow. It never logs in to
   publish registries and never pushes images.
+- Docker release benchmarking is manual-only. It builds AMD64 and ARM64 by
+  digest on separate `docker` runners, validates the AMD64 image while ARM64
+  continues, creates a temporary multi-platform manifest in an isolated GHCR
+  package, and deletes that package after timing. It never publishes to Docker
+  Hub or writes version, `latest`, or `edge` tags.
+- Reuse the same Docker benchmark `cache_generation` for warm-cache comparisons.
+  Change it for a cold-cache comparison. Benchmark summaries exclude cleanup
+  time from the measured critical path.
 - Docker publication depends on trusted refs and release tags.
 - DHI credentials are required for Docker builds that pull `dhi.io` base images.
 - Forked or Dependabot PRs may not have repository secrets. PR workflows should
@@ -236,6 +245,9 @@ tracked in the active CI/CD path.
 - Trusted Docker validation and Docker release jobs use the explicit
   self-hosted `docker` runner label by design. They are not governed by
   `PULLBOX_CHECKS_RUNNER`.
+- Two isolated-VM runners carry the `docker` label so benchmark platform builds
+  can run concurrently. Production release behavior remains unchanged until a
+  benchmarked design is adopted explicitly.
 - Untrusted Docker PRs run a reduced public sanity check (`Dockerfile.dev`
   build) instead of the full DHI-backed production build.
 - `Docker Validate Required` is the stable aggregate check for Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "structlog>=25.5,<27.0",
     "rarfile~=4.2",
     "py7zr>=1.1.3,<2.0",
-    "pillow~=12.1",
+    "pillow~=12.3",
     "pdf2image~=1.17",
     "tzlocal~=5.3",
 ]

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.3-dev"
+__version__ = "1.0.3"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.2"
+__version__ = "1.0.3-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -654,7 +654,7 @@ def test_docker_smoke_workflows_use_ephemeral_host_ports() -> None:
         },
         {
             "workflow": "docker-release.yml",
-            "container": "pullbox-smoke",
+            "container": '"${SMOKE_CONTAINER}"',
             "url_env": "PULLBOX_SMOKE_URL",
         },
     ]
@@ -702,11 +702,121 @@ def test_docker_release_workflow_is_tag_or_manual_only_and_scans_before_publish(
     assert isinstance(jobs, dict)
     push_job = jobs.get("push")
     assert isinstance(push_job, dict)
+    validate_job = jobs.get("validate-amd64")
+    assert isinstance(validate_job, dict)
 
     assert "anchore/scan-action@" in docker_workflow
     assert "config: .grype.yaml" in docker_workflow
-    assert push_job.get("needs") == ["build", "scan", "smoke-test"]
-    assert push_job.get("runs-on") == ["self-hosted", "Linux", "X64", "docker"]
+    assert validate_job.get("needs") == ["build", "build-amd64"]
+    assert push_job.get("needs") == [
+        "build",
+        "build-amd64",
+        "build-arm64",
+        "validate-amd64",
+    ]
+    assert push_job.get("runs-on") == "ubuntu-latest"
+
+
+def test_docker_release_distributes_platform_builds_before_manifest_publish() -> None:
+    """Release platforms should build concurrently and publish tags only after validation."""
+    workflow_path = WORKFLOW_DIR / "docker-release.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    data = _load_yaml(workflow_path)
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict)
+
+    prepare = jobs.get("build")
+    amd64 = jobs.get("build-amd64")
+    arm64 = jobs.get("build-arm64")
+    validate = jobs.get("validate-amd64")
+    push = jobs.get("push")
+    for job in [prepare, amd64, arm64, validate, push]:
+        assert isinstance(job, dict)
+
+    assert prepare.get("runs-on") == "ubuntu-latest"
+    assert prepare.get("outputs", {}).get("image-tags") == "${{ steps.meta.outputs.tags }}"
+    assert prepare.get("outputs", {}).get("build-date") == (
+        "${{ steps.release-metadata.outputs.build_date }}"
+    )
+
+    expected_runner = ["self-hosted", "Linux", "X64", "docker"]
+    for platform_job, platform, cache_scope in [
+        (amd64, "linux/amd64", "pullbox-release-amd64-v1"),
+        (arm64, "linux/arm64", "pullbox-release-arm64-v1"),
+    ]:
+        assert platform_job.get("runs-on") == expected_runner
+        assert platform_job.get("needs") == ["build"]
+        assert platform_job.get("permissions", {}).get("packages") == "write"
+        build_step = next(
+            step
+            for step in platform_job.get("steps", [])
+            if isinstance(step, dict) and step.get("name", "").startswith("Build and push")
+        )
+        build_with = build_step.get("with")
+        assert isinstance(build_with, dict)
+        assert build_with.get("platforms") == platform
+        assert "push-by-digest=true" in build_with.get("outputs", "")
+        assert "${{ env.GHCR_IMAGE }},${{ env.DOCKERHUB_IMAGE }}" in build_with.get("outputs", "")
+        assert build_with.get("cache-from") == f"type=gha,scope={cache_scope}"
+        assert build_with.get("cache-to") == f"type=gha,mode=max,scope={cache_scope}"
+        assert build_with.get("provenance") == "mode=max"
+        assert build_with.get("sbom") is True
+
+    assert "Set up QEMU" not in {
+        step.get("name") for step in amd64.get("steps", []) if isinstance(step, dict)
+    }
+    assert "Set up QEMU" in {
+        step.get("name") for step in arm64.get("steps", []) if isinstance(step, dict)
+    }
+    assert "Verify ARM64 container security runtime" in {
+        step.get("name") for step in arm64.get("steps", []) if isinstance(step, dict)
+    }
+
+    assert validate.get("needs") == ["build", "build-amd64"]
+    assert validate.get("runs-on") == expected_runner
+    validate_names = {
+        step.get("name") for step in validate.get("steps", []) if isinstance(step, dict)
+    }
+    assert {
+        "Run Grype scan",
+        "Verify packaged static assets",
+        "Run smoke tests",
+    } <= validate_names
+
+    assert push.get("needs") == [
+        "build",
+        "build-amd64",
+        "build-arm64",
+        "validate-amd64",
+    ]
+    assert push.get("runs-on") == "ubuntu-latest"
+    push_names = {step.get("name") for step in push.get("steps", []) if isinstance(step, dict)}
+    assert {
+        "Checkout",
+        "Download platform digests",
+        "Set up QEMU",
+        "Publish GHCR multi-platform manifest",
+        "Publish Docker Hub multi-platform manifest",
+        "Validate pushed image metadata",
+        "Verify published platform security runtimes",
+    } <= push_names
+    push_steps = [step for step in push.get("steps", []) if isinstance(step, dict)]
+    checkout_step = next(step for step in push_steps if step.get("name") == "Checkout")
+    assert checkout_step.get("with", {}).get("ref") == "${{ needs.build.outputs.build-sha }}"
+    assert next(
+        index for index, step in enumerate(push_steps) if step.get("name") == "Checkout"
+    ) < next(
+        index
+        for index, step in enumerate(push_steps)
+        if step.get("name") == "Verify published platform security runtimes"
+    )
+    assert "Build and push multi-arch" not in push_names
+    assert "pattern: release-digest-*" in workflow
+    assert "merge-multiple: true" in workflow
+    assert "docker buildx imagetools create" in workflow
+    assert "GHCR_DIGEST" in workflow
+    assert "DOCKERHUB_DIGEST" in workflow
+    assert "Published registry digests differ" in workflow
 
 
 def test_docker_release_benchmark_is_manual_isolated_and_non_release() -> None:
@@ -778,20 +888,14 @@ def test_docker_release_uses_trigger_tag_without_sha_rediscovery() -> None:
     jobs = data.get("jobs")
     assert isinstance(jobs, dict)
 
-    gate = jobs.get("gate")
-    assert isinstance(gate, dict)
-    assert gate.get("outputs", {}).get("release-tag") == (
-        "${{ steps.resolve-sha.outputs.release_tag }}"
-    )
-
     build = jobs.get("build")
     assert isinstance(build, dict)
     assert build.get("outputs", {}).get("release-tag") == "${{ steps.resolve-tag.outputs.tag }}"
+    assert build.get("outputs", {}).get("build-sha") == "${{ steps.resolve-sha.outputs.sha }}"
 
     assert "GITHUB_REF_NAME" in docker_workflow
     assert "GITHUB_REF_TYPE" in docker_workflow
-    assert 'TAG="${{ needs.gate.outputs.release-tag }}"' in docker_workflow
-    assert 'TAG="${{ needs.build.outputs.release-tag }}"' in docker_workflow
+    assert 'TAG="${{ steps.resolve-sha.outputs.release_tag }}"' in docker_workflow
     assert "git tag --points-at" not in docker_workflow
     assert "tag.txt" in docker_workflow
 
@@ -806,7 +910,7 @@ def test_docker_release_prerelease_tags_do_not_update_latest() -> None:
         "type=raw,value=latest,enable=${{ steps.resolve-tag.outputs.is_release == 'true' && "
         "steps.resolve-tag.outputs.is_prerelease != 'true' }}"
     )
-    assert docker_workflow.count(latest_guard) == 2
+    assert docker_workflow.count(latest_guard) == 1
     assert (
         "type=raw,value=latest,enable=${{ steps.resolve-tag.outputs.is_release }}"
         not in docker_workflow
@@ -848,26 +952,24 @@ def test_docker_workflow_signs_and_verifies_published_images() -> None:
 
     push_outputs = push_job.get("outputs")
     assert isinstance(push_outputs, dict)
-    assert push_outputs.get("image-digest") == "${{ steps.push-image.outputs.digest }}"
+    assert push_outputs.get("image-digest") == "${{ steps.inspect.outputs.digest }}"
 
     steps = push_job.get("steps")
     assert isinstance(steps, list)
-    build_steps = [
-        step
-        for step in steps
-        if isinstance(step, dict) and step.get("name") == "Build and push multi-arch"
+    assert push_job.get("runs-on") == "ubuntu-latest"
+    assert push_job.get("needs") == [
+        "build",
+        "build-amd64",
+        "build-arm64",
+        "validate-amd64",
     ]
-    assert len(build_steps) == 1
-    build_step = build_steps[0]
-    assert build_step.get("id") == "push-image"
-    build_with = build_step.get("with")
-    assert isinstance(build_with, dict)
-    assert build_with.get("provenance") == "mode=max"
-    assert build_with.get("sbom") is True
-    assert build_with.get("annotations") == "${{ steps.meta.outputs.annotations }}"
 
+    build_job = jobs.get("build")
+    assert isinstance(build_job, dict)
     metadata_steps = [
-        step for step in steps if isinstance(step, dict) and step.get("name") == "Docker metadata"
+        step
+        for step in build_job.get("steps", [])
+        if isinstance(step, dict) and step.get("name") == "Docker metadata"
     ]
     assert len(metadata_steps) == 1
     metadata_env = metadata_steps[0].get("env")
@@ -944,7 +1046,7 @@ def test_docker_release_verifies_each_published_platform_runtime() -> None:
     assert "for platform in linux/amd64 linux/arm64" in verify_run
     assert '"${GHCR_IMAGE}@${DIGEST}"' in verify_run
     assert "scripts/verify_container_security_runtime.py" in verify_run
-    assert step_names.index("Build and push multi-arch") < step_names.index(
+    assert step_names.index("Validate pushed image metadata") < step_names.index(
         "Verify published platform security runtimes"
     )
 

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -709,6 +709,68 @@ def test_docker_release_workflow_is_tag_or_manual_only_and_scans_before_publish(
     assert push_job.get("runs-on") == ["self-hosted", "Linux", "X64", "docker"]
 
 
+def test_docker_release_benchmark_is_manual_isolated_and_non_release() -> None:
+    """Benchmark runs must not mutate either production registry namespace."""
+    workflow_path = WORKFLOW_DIR / "docker-release-benchmark.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+    data = _load_yaml(workflow_path)
+    triggers = data.get(True, data.get("on"))
+    assert triggers == {
+        "workflow_dispatch": {
+            "inputs": {
+                "cache_generation": {
+                    "description": ("Cache generation; reuse for warm runs, change for cold runs"),
+                    "required": True,
+                    "default": "v1",
+                    "type": "string",
+                },
+                "cleanup": {
+                    "description": ("Delete the temporary GHCR package after the benchmark"),
+                    "required": True,
+                    "default": True,
+                    "type": "boolean",
+                },
+            }
+        }
+    }
+
+    jobs = data.get("jobs")
+    assert isinstance(jobs, dict)
+    assert jobs["build-amd64"].get("runs-on") == [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "docker",
+    ]
+    assert jobs["build-arm64"].get("runs-on") == [
+        "self-hosted",
+        "Linux",
+        "X64",
+        "docker",
+    ]
+    assert jobs["validate-amd64"].get("needs") == ["prepare", "build-amd64"]
+    assert jobs["manifest"].get("needs") == [
+        "prepare",
+        "build-amd64",
+        "build-arm64",
+        "validate-amd64",
+    ]
+
+    assert "REPOSITORY=$(printf '%s' \"${GITHUB_REPOSITORY}\"" in workflow
+    assert 'PACKAGE_NAME="pullbox-benchmark-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"' in workflow
+    assert "push-by-digest=true" in workflow
+    assert "pullbox-benchmark-amd64-${{ inputs.cache_generation }}" in workflow
+    assert "pullbox-benchmark-arm64-${{ inputs.cache_generation }}" in workflow
+    assert "Delete isolated GHCR package" in workflow
+    assert "if: ${{ always() && inputs.cleanup }}" in workflow
+    assert "docker.io/pullbox/pullbox" not in workflow
+    assert "DOCKERHUB" not in workflow
+    assert "cosign" not in workflow.lower()
+    assert "type=raw,value=latest" not in workflow
+    assert "type=raw,value=edge" not in workflow
+    assert "release-image-digest" not in workflow
+
+
 def test_docker_release_uses_trigger_tag_without_sha_rediscovery() -> None:
     docker_workflow_path = WORKFLOW_DIR / "docker-release.yml"
     docker_workflow = docker_workflow_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Release
- publish Pullbox 1.0.3
- parallelize AMD64 and ARM64 Docker release builds on the two existing runners
- preserve Grype, smoke, platform, attestation, dual-registry digest, and Cosign gates
- require Pillow 12.3.0 for the current upstream security fixes

## Validation
- optimization PR #79 passed all required CI, Docker, security, and workflow-hygiene checks
- local `make ci-full` passed
- `make release-changelog-check VERSION=1.0.3` passed

After merge, a signed `v1.0.3` tag will trigger publication and verification.