### PR TITLE
fix: evict platform image between release checks

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -692,6 +692,9 @@ jobs:
         run: |
           for platform in linux/amd64 linux/arm64; do
             echo "Verifying container security runtime for ${platform}"
+            # The classic Docker image store cannot retain two platform
+            # selections under the same multi-platform digest reference.
+            docker image rm --force "${GHCR_IMAGE}@${DIGEST}" > /dev/null 2>&1 || true
             docker run --rm --pull always --platform "${platform}" -i \
               --entrypoint python "${GHCR_IMAGE}@${DIGEST}" - \
               < scripts/verify_container_security_runtime.py

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -1045,6 +1045,9 @@ def test_docker_release_verifies_each_published_platform_runtime() -> None:
     verify_run = verify_step.get("run", "")
     assert "for platform in linux/amd64 linux/arm64" in verify_run
     assert '"${GHCR_IMAGE}@${DIGEST}"' in verify_run
+    digest_evict = 'docker image rm --force "${GHCR_IMAGE}@${DIGEST}"'
+    assert digest_evict in verify_run
+    assert verify_run.index(digest_evict) < verify_run.index("docker run --rm --pull always")
     assert "scripts/verify_container_security_runtime.py" in verify_run
     assert step_names.index("Validate pushed image metadata") < step_names.index(
         "Verify published platform security runtimes"


### PR DESCRIPTION
## Root cause
The first v1.0.3 Docker Release published and validated both multi-platform manifests, then failed before signing when the GitHub-hosted runner tried to pull ARM64 under the same digest reference already cached for AMD64:

`docker: cannot overwrite digest`

## Fix
- evict the digest-selected image before each platform runtime pull
- add a workflow contract requiring eviction before `docker run`

## Validation
- regression contract failed before the workflow change
- `.venv/bin/pytest tests/unit/test_github_actions_security_contracts.py -q` (40 passed)
- `make workflow-hygiene`
- pre-commit fast unit suite

After merge, the failed v1.0.3 tag will be replaced with a signed tag on the hotfixed commit and publication will be rerun.