### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [1.0.4] - 2026-07-13
+
+Maintenance release focused on reliable multi-platform publication across
+Docker runtimes with classic image stores.
+
+### CI / Build
+
+- Evicted the digest-selected image between AMD64 and ARM64 runtime checks so
+  sequential verification cannot fail with Docker's `cannot overwrite digest`
+  error after manifests are published.
+
 ## [1.0.3] - 2026-07-13
 
 Maintenance release focused on faster multi-architecture image publication and

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.3"
+__version__ = "1.0.4-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.4-dev"
+__version__ = "1.0.4"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Release
- publish Pullbox 1.0.4 as a clean end-to-end release
- include the digest-cache eviction fix for sequential AMD64/ARM64 runtime verification
- retain the parallel platform builds, dual-registry digest checks, attestations, and Cosign signing gates

## Validation
- hotfix PR #81 passed all required CI, Docker, security, and workflow-hygiene checks
- recovered v1.0.3 publication verified the fixed runtime-check path and both registry signatures
- `make release-changelog-check VERSION=1.0.4` passed

The first v1.0.4 tag-triggered run must complete without manual registry or workflow recovery.