### PR TITLE
Sync develop after v1.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [1.0.4] - 2026-07-13
+
+Maintenance release focused on reliable multi-platform publication across
+Docker runtimes with classic image stores.
+
+### CI / Build
+
+- Evicted the digest-selected image between AMD64 and ARM64 runtime checks so
+  sequential verification cannot fail with Docker's `cannot overwrite digest`
+  error after manifests are published.
+
 ## [1.0.3] - 2026-07-13
 
 Maintenance release focused on faster multi-architecture image publication and

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.4"
+__version__ = "1.0.5-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.4-dev"
+__version__ = "1.0.4"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary

- merge the released v1.0.4 main history back into develop
- bump the development version to 1.0.5-dev

## Validation

- pre-commit hooks passed, including mypy and fast unit tests
- release sync validator: 1.0.4 -> 1.0.5-dev
- diff is limited to src/pullbox/__init__.py after main