### PR TITLE
fix: harden production reliability and live UI state

### DIFF
--- a/src/pullbox/api/v1/clients.py
+++ b/src/pullbox/api/v1/clients.py
@@ -1,15 +1,22 @@
 """Download client API routes — CRUD and test connection."""
 
+import asyncio
 from datetime import UTC, datetime
 
 import httpx
 import structlog
 from fastapi import APIRouter
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 
 from pullbox.api.deps import DbSession, InteractiveOperatorUser
 from pullbox.core.encryption import decrypt_secret, encrypt_secret
 from pullbox.core.exceptions import NotFoundError, ProviderError
+from pullbox.core.sqlite_lock import (
+    SQLITE_LOCK_RETRY_ATTEMPTS,
+    is_sqlite_locked_error,
+    sqlite_lock_retry_delay,
+)
 from pullbox.models.client import DownloadClientConfig
 from pullbox.schemas.client import ClientCreate, ClientResponse, ClientUpdate
 
@@ -62,6 +69,46 @@ def _redact_client(client: DownloadClientConfig) -> dict[str, object]:
         "created_at": client.created_at,
         "updated_at": client.updated_at,
     }
+
+
+async def _persist_client_test_status_with_retry(
+    session: DbSession,
+    client_id: int,
+    *,
+    healthy: bool,
+    message: str,
+    checked_at: datetime,
+) -> None:
+    """Persist client test status, retrying transient SQLite write locks."""
+    for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+        client = await session.get(DownloadClientConfig, client_id)
+        if not client:
+            raise NotFoundError("Download client", client_id)
+
+        client.last_test_message = message
+        if healthy:
+            client.last_success_at = checked_at
+            client.last_error = None
+        else:
+            client.last_failure_at = checked_at
+            client.last_error = message
+
+        try:
+            await session.flush()
+            return
+        except OperationalError as exc:
+            await session.rollback()
+            if not is_sqlite_locked_error(exc) or attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                raise
+            delay_seconds = sqlite_lock_retry_delay(attempt)
+            logger.warning(
+                "client_test_status_persist_retrying_after_sqlite_lock",
+                client_id=client_id,
+                attempt=attempt,
+                max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                delay_seconds=delay_seconds,
+            )
+            await asyncio.sleep(delay_seconds)
 
 
 def _decryption_failure_response() -> dict[str, object]:
@@ -389,10 +436,13 @@ async def test_client(
             raise ProviderError("download", f"Unknown client type: {client.client_type}")
     except ValueError as exc:
         message = str(_decryption_failure_response()["message"])
-        client.last_failure_at = datetime.now(UTC)
-        client.last_error = message
-        client.last_test_message = message
-        await session.flush()
+        await _persist_client_test_status_with_retry(
+            session,
+            client_id,
+            healthy=False,
+            message=message,
+            checked_at=datetime.now(UTC),
+        )
         logger.warning("client_test_decrypt_failed", client_id=client_id, error=str(exc))
         return _decryption_failure_response()
 
@@ -402,14 +452,13 @@ async def test_client(
 
     result = await dl_provider.test_connection()
     checked_at = datetime.now(UTC)
-    client.last_test_message = result.message
-    if result.healthy:
-        client.last_success_at = checked_at
-        client.last_error = None
-    else:
-        client.last_failure_at = checked_at
-        client.last_error = result.message
-    await session.flush()
+    await _persist_client_test_status_with_retry(
+        session,
+        client_id,
+        healthy=result.healthy,
+        message=result.message,
+        checked_at=checked_at,
+    )
 
     logger.info(
         "client_test_connection",

--- a/src/pullbox/api/v1/downloads.py
+++ b/src/pullbox/api/v1/downloads.py
@@ -10,6 +10,7 @@ from pullbox.core.exceptions import NotFoundError
 from pullbox.models.blocklist import BlocklistReason
 from pullbox.models.download import DownloadClientType, DownloadHistory, DownloadState
 from pullbox.models.issue import Issue, IssueStatus
+from pullbox.providers.download.qbittorrent import QBittorrentError
 from pullbox.schemas.blocklist import BlocklistEntryResponse
 from pullbox.schemas.download import DownloadHistoryItem, DownloadQueueItem
 from pullbox.schemas.pagination import PaginatedResponse
@@ -374,10 +375,21 @@ async def retry_download(
 
     # Re-send to client
     dl_type = DownloadClientType(str(download.download_client))
-    if dl_type.is_torrent:
-        external_id = await client.add_torrent(download.download_url, download.title)
-    else:
-        external_id = await client.add_nzb(download.download_url, download.title)
+    try:
+        if dl_type.is_torrent:
+            external_id = await client.add_torrent(download.download_url, download.title)
+        else:
+            external_id = await client.add_nzb(download.download_url, download.title)
+    except QBittorrentError as exc:
+        logger.warning(
+            "download_retry_client_rejected",
+            download_id=download.id,
+            issue_id=download.issue_id,
+            indexer_id=download.indexer_id,
+            client_type=dl_type.value,
+            error=str(exc),
+        )
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     download.external_id = external_id
     download.state = DownloadState.SENT

--- a/src/pullbox/api/v1/indexers.py
+++ b/src/pullbox/api/v1/indexers.py
@@ -1,14 +1,21 @@
 """Indexer API routes — CRUD, test connection, Prowlarr sync, and priority management."""
 
+import asyncio
 from datetime import UTC, datetime
 
 import structlog
 from fastapi import APIRouter
 from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
 
 from pullbox.api.deps import DbSession, InteractiveOperatorUser
 from pullbox.core.encryption import decrypt_secret, encrypt_secret
 from pullbox.core.exceptions import NotFoundError
+from pullbox.core.sqlite_lock import (
+    SQLITE_LOCK_RETRY_ATTEMPTS,
+    is_sqlite_locked_error,
+    sqlite_lock_retry_delay,
+)
 from pullbox.models.indexer import IndexerConfig
 from pullbox.schemas.indexer import (
     IndexerCreate,
@@ -50,6 +57,45 @@ def _redact_indexer(indexer: IndexerConfig) -> dict[str, object]:
         "created_at": indexer.created_at,
         "updated_at": indexer.updated_at,
     }
+
+
+async def _persist_indexer_test_status_with_retry(
+    session: DbSession,
+    indexer_id: int,
+    *,
+    healthy: bool,
+    message: str,
+    checked_at: datetime,
+) -> None:
+    """Persist indexer test status, retrying transient SQLite write locks."""
+    for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+        indexer = await session.get(IndexerConfig, indexer_id)
+        if not indexer:
+            raise NotFoundError("Indexer", indexer_id)
+
+        if healthy:
+            indexer.last_success_at = checked_at
+            indexer.last_error = None
+        else:
+            indexer.last_failure_at = checked_at
+            indexer.last_error = message
+
+        try:
+            await session.flush()
+            return
+        except OperationalError as exc:
+            await session.rollback()
+            if not is_sqlite_locked_error(exc) or attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                raise
+            delay_seconds = sqlite_lock_retry_delay(attempt)
+            logger.warning(
+                "indexer_test_status_persist_retrying_after_sqlite_lock",
+                indexer_id=indexer_id,
+                attempt=attempt,
+                max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                delay_seconds=delay_seconds,
+            )
+            await asyncio.sleep(delay_seconds)
 
 
 # ── List ─────────────────────────────────────────────────────────────
@@ -433,14 +479,13 @@ async def test_indexer(
 
     result = await provider.test_connection()
 
-    checked_at = datetime.now(UTC)
-    if result.healthy:
-        indexer.last_success_at = checked_at
-        indexer.last_error = None
-    else:
-        indexer.last_failure_at = checked_at
-        indexer.last_error = result.message
-    await session.flush()
+    await _persist_indexer_test_status_with_retry(
+        session,
+        indexer_id,
+        healthy=result.healthy,
+        message=result.message,
+        checked_at=datetime.now(UTC),
+    )
 
     logger.info(
         "indexer_test_connection",

--- a/src/pullbox/api/v1/series.py
+++ b/src/pullbox/api/v1/series.py
@@ -11,6 +11,7 @@ from sqlalchemy import case, func, inspect, select, update
 from sqlalchemy.orm import contains_eager
 
 from pullbox.api.deps import AuthenticatedUser, DbSession
+from pullbox.core.events import IssueWanted, get_event_bus
 from pullbox.core.exceptions import NotFoundError, ValidationError
 from pullbox.core.library_policy import load_search_on_add_default
 from pullbox.models.issue import Issue, IssueStatus
@@ -40,6 +41,7 @@ router = APIRouter(prefix="/series", tags=["series"])
 
 # Strong references to background tasks to prevent garbage collection
 _background_tasks: set[asyncio.Task[object]] = set()
+_BULK_UPDATE_CHUNK_SIZE = 500
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
@@ -249,14 +251,52 @@ async def bulk_update_series(
     _user: AuthenticatedUser,
     session: DbSession,
 ) -> dict[str, int]:
-    """Bulk-update monitored status for multiple series."""
+    """Bulk-update monitoring and reconcile the related issue states."""
     series_ids = list(dict.fromkeys(body.series_ids))
-    result = await session.execute(
-        update(Series).where(Series.id.in_(series_ids)).values(monitored=body.monitored)
-    )
-    updated = int(result.rowcount or 0)  # type: ignore[attr-defined]
+    updated = 0
+    issues_updated = 0
+    event_bus = get_event_bus()
+    for offset in range(0, len(series_ids), _BULK_UPDATE_CHUNK_SIZE):
+        chunk = series_ids[offset : offset + _BULK_UPDATE_CHUNK_SIZE]
+        result = await session.execute(
+            update(Series).where(Series.id.in_(chunk)).values(monitored=body.monitored)
+        )
+        updated += int(result.rowcount or 0)  # type: ignore[attr-defined]
+
+        if body.monitored:
+            issue_result = await session.execute(
+                update(Issue)
+                .where(
+                    Issue.series_id.in_(chunk),
+                    Issue.status == IssueStatus.SKIPPED,
+                    Issue.manual_skip.is_(False),
+                )
+                .values(status=IssueStatus.WANTED)
+                .returning(Issue.id, Issue.series_id)
+            )
+            wanted_issues = list(issue_result.all())
+            issues_updated += len(wanted_issues)
+            for issue_id, series_id in wanted_issues:
+                await event_bus.emit(IssueWanted(issue_id=issue_id, series_id=series_id))
+        else:
+            issue_result = await session.execute(
+                update(Issue)
+                .where(
+                    Issue.series_id.in_(chunk),
+                    Issue.status.in_([IssueStatus.WANTED, IssueStatus.DOWNLOADING]),
+                )
+                .values(status=IssueStatus.SKIPPED)
+            )
+            issues_updated += int(issue_result.rowcount or 0)  # type: ignore[attr-defined]
+
     skipped = len(series_ids) - updated
-    logger.info("bulk_update_series", updated=updated, skipped=skipped)
+    logger.info(
+        "bulk_update_series",
+        updated=updated,
+        skipped=skipped,
+        issues_updated=issues_updated,
+        monitored=body.monitored,
+    )
     return {"updated": updated, "skipped": skipped}
 
 

--- a/src/pullbox/providers/indexer/newznab.py
+++ b/src/pullbox/providers/indexer/newznab.py
@@ -152,11 +152,7 @@ class NewznabIndexer:
         if query.categories:
             params["cat"] = ",".join(query.categories)
 
-        try:
-            xml_text = await self._request(params)
-        except NewznabError:
-            log.exception("newznab_search_failed")
-            return []
+        xml_text = await self._request(params)
 
         results = self._parse_search_results(xml_text)
         log.debug("newznab_search_results", count=len(results))

--- a/src/pullbox/providers/indexer/prowlarr.py
+++ b/src/pullbox/providers/indexer/prowlarr.py
@@ -158,11 +158,7 @@ class ProwlarrIndexer:
         if self._indexer_ids:
             params["indexerIds"] = self._indexer_ids
 
-        try:
-            data = await self._api_request("/search", params, timeout=_SEARCH_TIMEOUT)
-        except ProwlarrError:
-            log.exception("prowlarr_search_failed")
-            return []
+        data = await self._api_request("/search", params, timeout=_SEARCH_TIMEOUT)
 
         results = self._parse_api_results(data)
         log.debug("prowlarr_search_results", count=len(results))

--- a/src/pullbox/providers/metadata/comicvine.py
+++ b/src/pullbox/providers/metadata/comicvine.py
@@ -229,8 +229,9 @@ def _extract_story_arcs(arc_credits: list[dict[str, Any]] | None) -> list[dict[s
 class ComicVineError(Exception):
     """Raised when the ComicVine API returns a non-OK status."""
 
-    def __init__(self, status_code: int, message: str) -> None:
+    def __init__(self, status_code: int, message: str, *, retryable: bool = False) -> None:
         self.status_code = status_code
+        self.retryable = retryable
         super().__init__(message)
 
 
@@ -303,16 +304,25 @@ class ComicVineProvider:
             response.raise_for_status()
         except httpx.TimeoutException:
             log.error("comicvine_timeout")
-            raise ComicVineError(0, f"Request timed out: {endpoint}") from None
+            raise ComicVineError(
+                0,
+                f"Request timed out: {endpoint}",
+                retryable=True,
+            ) from None
         except httpx.HTTPStatusError as exc:
-            if exc.response.status_code == 404:
+            http_status = exc.response.status_code
+            if http_status == 404:
                 log.warning("comicvine_not_found")
                 raise ComicVineError(_STATUS_NOT_FOUND, f"Resource not found: {endpoint}") from None
-            log.error("comicvine_http_error", status=exc.response.status_code)
-            raise ComicVineError(0, f"HTTP {exc.response.status_code}: {endpoint}") from None
+            log.error("comicvine_http_error", status=http_status)
+            raise ComicVineError(
+                http_status,
+                f"HTTP {http_status}: {endpoint}",
+                retryable=http_status in {408, 420, 429} or http_status >= 500,
+            ) from None
         except httpx.HTTPError as exc:
             log.error("comicvine_request_failed", error=str(exc))
-            raise ComicVineError(0, f"Request failed: {exc}") from None
+            raise ComicVineError(0, f"Request failed: {exc}", retryable=True) from None
 
         data: dict[str, Any] = response.json()
         status_code = data.get("status_code", 0)
@@ -325,7 +335,7 @@ class ComicVineProvider:
             raise ComicVineError(status_code, f"Resource not found: {endpoint}")
         if status_code == _STATUS_RATE_LIMITED:
             log.warning("comicvine_rate_limited")
-            raise ComicVineError(status_code, "Rate limit exceeded")
+            raise ComicVineError(status_code, "Rate limit exceeded", retryable=True)
         if status_code != _STATUS_OK:
             error_msg = data.get("error", "Unknown error")
             log.error("comicvine_api_error", status_code=status_code, error=error_msg)

--- a/src/pullbox/schemas/series.py
+++ b/src/pullbox/schemas/series.py
@@ -67,10 +67,18 @@ class SeriesResponse(BaseModel):
     updated_at: datetime
 
 
+SERIES_BULK_UPDATE_MAX_IDS = 10_000
+
+
 class SeriesBulkUpdate(BaseModel):
     """Request body for bulk-updating series monitored status."""
 
-    series_ids: list[int] = Field(..., min_length=1, max_length=100, description="IDs to update")
+    series_ids: list[int] = Field(
+        ...,
+        min_length=1,
+        max_length=SERIES_BULK_UPDATE_MAX_IDS,
+        description="IDs to update",
+    )
     monitored: bool = Field(..., description="New monitored status")
 
 

--- a/src/pullbox/services/blocklist_service.py
+++ b/src/pullbox/services/blocklist_service.py
@@ -327,12 +327,13 @@ class BlocklistService:
 
         from pullbox.core.release_parser import parse_release_title
 
-        # Load all blocked normalized titles in one query
-        bl_result = await session.execute(select(BlocklistEntry.release_title_normalized))
-        blocked_titles = {row[0] for row in bl_result.all()}
-
-        # Load blocked groups from config
-        blocked_groups = await BlocklistService.get_blocked_groups(session)
+        # Search fan-out updates indexer health in memory. These read-only lookups
+        # must not flush those writes and hold SQLite's writer lock while later
+        # network queries are still running.
+        with session.no_autoflush:
+            bl_result = await session.execute(select(BlocklistEntry.release_title_normalized))
+            blocked_titles = {row[0] for row in bl_result.all()}
+            blocked_groups = await BlocklistService.get_blocked_groups(session)
 
         kept: list[ReleaseResult] = []
         removed = 0

--- a/src/pullbox/services/import_comicinfo_enrichment.py
+++ b/src/pullbox/services/import_comicinfo_enrichment.py
@@ -5,14 +5,21 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import structlog
 from sqlalchemy import select as sa_select
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import joinedload
 
+from pullbox.core.sqlite_lock import (
+    SQLITE_LOCK_RETRY_ATTEMPTS,
+    is_sqlite_locked_error,
+    sqlite_lock_retry_delay,
+)
 from pullbox.models.import_job import ImportedFile, ImportedFileStatus, ImportJob, ImportJobStatus
 from pullbox.models.issue import Issue
 from pullbox.models.library import LibraryFile
@@ -32,6 +39,18 @@ ImportComicInfoLogEvent = Callable[..., Awaitable[None]]
 comicinfo_enrichment_tasks: set[asyncio.Task[None]] = set()
 _comicinfo_enrichment_semaphore: asyncio.Semaphore | None = None
 _comicinfo_enrichment_semaphore_loop: asyncio.AbstractEventLoop | None = None
+
+
+@dataclass(frozen=True)
+class PreparedComicInfoEnrichment:
+    """Database-independent inputs for one deferred archive rewrite."""
+
+    artifact_path: Path
+    payload: dict[str, Any]
+    library_file_id: int
+    library_file_name: str
+    issue_id: int
+    issue_cv_id: int | None
 
 
 def reset_comicinfo_enrichment_gate() -> None:
@@ -118,26 +137,34 @@ async def run_import_comicinfo_enrichment(
     """Refresh deferred ComicInfo metadata for imported files in one import job."""
     pending_ids = await _load_pending_imported_file_ids(session_factory, job_id=job_id)
     for imported_file_id in pending_ids:
-        async with session_factory() as session:
-            try:
-                await _process_pending_imported_file(
-                    session,
-                    job_id=job_id,
-                    imported_file_id=imported_file_id,
-                    build_comicinfo_payload=build_comicinfo_payload,
-                    apply_comicinfo=apply_comicinfo,
-                    log_event=log_event,
-                )
-                await session.commit()
-            except Exception as exc:
-                await session.rollback()
-                await _mark_pending_file_failed(
-                    session_factory,
-                    job_id=job_id,
-                    imported_file_id=imported_file_id,
-                    error=str(exc),
-                    log_event=log_event,
-                )
+        try:
+            prepared = await _prepare_pending_imported_file_with_retry(
+                session_factory,
+                imported_file_id=imported_file_id,
+                build_comicinfo_payload=build_comicinfo_payload,
+            )
+            if prepared is None:
+                continue
+
+            apply_result = apply_comicinfo(prepared.artifact_path, prepared.payload)
+            if inspect.isawaitable(apply_result):
+                await apply_result
+
+            await _mark_pending_file_complete_with_retry(
+                session_factory,
+                job_id=job_id,
+                imported_file_id=imported_file_id,
+                prepared=prepared,
+                log_event=log_event,
+            )
+        except Exception as exc:
+            await _mark_pending_file_failed(
+                session_factory,
+                job_id=job_id,
+                imported_file_id=imported_file_id,
+                error=str(exc),
+                log_event=log_event,
+            )
 
 
 async def _load_pending_imported_file_ids(
@@ -192,18 +219,58 @@ def _is_pending_comicinfo_enrichment_diagnostics(diagnostics: Any) -> bool:
     return isinstance(details, dict) and details.get("status") == "pending"
 
 
-async def _process_pending_imported_file(
-    session: AsyncSession,
+async def _prepare_pending_imported_file_with_retry(
+    session_factory: async_sessionmaker[AsyncSession],
     *,
-    job_id: int,
     imported_file_id: int,
     build_comicinfo_payload: ImportComicInfoBuildPayload,
-    apply_comicinfo: ImportComicInfoApply,
-    log_event: ImportComicInfoLogEvent,
-) -> None:
+) -> PreparedComicInfoEnrichment | None:
+    """Prepare metadata and commit it before any archive mutation begins."""
+    for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+        async with session_factory() as session:
+            try:
+                prepared = await _prepare_pending_imported_file(
+                    session,
+                    imported_file_id=imported_file_id,
+                    build_comicinfo_payload=build_comicinfo_payload,
+                )
+                await session.commit()
+                return prepared
+            except OperationalError as exc:
+                await session.rollback()
+                if not is_sqlite_locked_error(exc):
+                    raise
+                if attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                    logger.warning(
+                        "import_comicinfo_prepare_deferred_after_sqlite_lock",
+                        imported_file_id=imported_file_id,
+                        attempts=attempt,
+                    )
+                    return None
+                delay_seconds = sqlite_lock_retry_delay(attempt)
+                logger.warning(
+                    "import_comicinfo_prepare_retrying_after_sqlite_lock",
+                    imported_file_id=imported_file_id,
+                    attempt=attempt,
+                    max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                    delay_seconds=delay_seconds,
+                )
+            except Exception:
+                await session.rollback()
+                raise
+        await asyncio.sleep(delay_seconds)
+    return None
+
+
+async def _prepare_pending_imported_file(
+    session: AsyncSession,
+    *,
+    imported_file_id: int,
+    build_comicinfo_payload: ImportComicInfoBuildPayload,
+) -> PreparedComicInfoEnrichment | None:
     imported_file = await session.get(ImportedFile, imported_file_id)
     if not _is_pending_comicinfo_enrichment(imported_file):
-        return
+        return None
     assert imported_file is not None
 
     library_file_id = imported_file.library_file_id
@@ -238,32 +305,87 @@ async def _process_pending_imported_file(
         source_path=artifact_path,
         defer_issue_enrichment=False,
     )
-    apply_result = apply_comicinfo(artifact_path, payload)
-    if inspect.isawaitable(apply_result):
-        await apply_result
-
-    if artifact_path.exists():
-        library_file.file_size = artifact_path.stat().st_size
-        library_file.file_modified_at = datetime.fromtimestamp(
-            artifact_path.stat().st_mtime,
-            tz=UTC,
-        )
-    _set_comicinfo_enrichment_status(
-        imported_file,
-        status="complete",
-        completed_at=datetime.now(UTC).isoformat(),
-    )
-    await log_event(
-        session,
-        job_id,
-        "DEBUG",
-        "import_file_comicinfo_enrichment_completed",
-        message=f"Deferred ComicInfo metadata refreshed: {library_file.file_name}",
-        destination_path=library_file.file_path,
+    return PreparedComicInfoEnrichment(
+        artifact_path=artifact_path,
+        payload=payload,
         library_file_id=library_file.id,
+        library_file_name=library_file.file_name,
         issue_id=issue.id,
         issue_cv_id=issue.comicvine_id,
     )
+
+
+async def _mark_pending_file_complete_with_retry(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    job_id: int,
+    imported_file_id: int,
+    prepared: PreparedComicInfoEnrichment,
+    log_event: ImportComicInfoLogEvent,
+) -> bool:
+    """Persist archive completion in a short, retryable transaction."""
+    for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+        async with session_factory() as session:
+            try:
+                imported_file = await session.get(ImportedFile, imported_file_id)
+                if not _is_pending_comicinfo_enrichment(imported_file):
+                    return True
+                assert imported_file is not None
+
+                library_file = await session.get(LibraryFile, prepared.library_file_id)
+                if library_file is None:
+                    raise ValueError(f"Library file {prepared.library_file_id} no longer exists")
+                if prepared.artifact_path.exists():
+                    artifact_stat = prepared.artifact_path.stat()
+                    library_file.file_size = artifact_stat.st_size
+                    library_file.file_modified_at = datetime.fromtimestamp(
+                        artifact_stat.st_mtime,
+                        tz=UTC,
+                    )
+                _set_comicinfo_enrichment_status(
+                    imported_file,
+                    status="complete",
+                    completed_at=datetime.now(UTC).isoformat(),
+                )
+                await log_event(
+                    session,
+                    job_id,
+                    "DEBUG",
+                    "import_file_comicinfo_enrichment_completed",
+                    message=(
+                        f"Deferred ComicInfo metadata refreshed: {prepared.library_file_name}"
+                    ),
+                    destination_path=str(prepared.artifact_path),
+                    library_file_id=prepared.library_file_id,
+                    issue_id=prepared.issue_id,
+                    issue_cv_id=prepared.issue_cv_id,
+                )
+                await session.commit()
+                return True
+            except OperationalError as exc:
+                await session.rollback()
+                if not is_sqlite_locked_error(exc):
+                    raise
+                if attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                    logger.warning(
+                        "import_comicinfo_completion_deferred_after_sqlite_lock",
+                        imported_file_id=imported_file_id,
+                        attempts=attempt,
+                    )
+                    return False
+                delay_seconds = sqlite_lock_retry_delay(attempt)
+                logger.warning(
+                    "import_comicinfo_completion_retrying_after_sqlite_lock",
+                    imported_file_id=imported_file_id,
+                    attempt=attempt,
+                    max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                    delay_seconds=delay_seconds,
+                )
+            except Exception:
+                await session.rollback()
+                raise
+        await asyncio.sleep(delay_seconds)
+    return False
 
 
 async def _mark_pending_file_failed(
@@ -273,27 +395,57 @@ async def _mark_pending_file_failed(
     imported_file_id: int,
     error: str,
     log_event: ImportComicInfoLogEvent,
-) -> None:
-    async with session_factory() as session:
-        imported_file = await session.get(ImportedFile, imported_file_id)
-        if imported_file is None:
-            return
-        _set_comicinfo_enrichment_status(
-            imported_file,
-            status="failed",
-            error=error,
-            failed_at=datetime.now(UTC).isoformat(),
-        )
-        await log_event(
-            session,
-            job_id,
-            "WARNING",
-            "import_file_comicinfo_enrichment_failed",
-            message=f"Deferred ComicInfo metadata refresh failed: {imported_file.file_name}",
-            imported_file_id=imported_file.id,
-            error=error,
-        )
-        await session.commit()
+) -> bool:
+    """Record a non-transient failure without letting a lock abort the queue."""
+    for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+        async with session_factory() as session:
+            try:
+                imported_file = await session.get(ImportedFile, imported_file_id)
+                if imported_file is None:
+                    return True
+                _set_comicinfo_enrichment_status(
+                    imported_file,
+                    status="failed",
+                    error=error,
+                    failed_at=datetime.now(UTC).isoformat(),
+                )
+                await log_event(
+                    session,
+                    job_id,
+                    "WARNING",
+                    "import_file_comicinfo_enrichment_failed",
+                    message=(
+                        f"Deferred ComicInfo metadata refresh failed: {imported_file.file_name}"
+                    ),
+                    imported_file_id=imported_file.id,
+                    error=error,
+                )
+                await session.commit()
+                return True
+            except OperationalError as exc:
+                await session.rollback()
+                if not is_sqlite_locked_error(exc):
+                    raise
+                if attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                    logger.warning(
+                        "import_comicinfo_failure_status_deferred_after_sqlite_lock",
+                        imported_file_id=imported_file_id,
+                        attempts=attempt,
+                    )
+                    return False
+                delay_seconds = sqlite_lock_retry_delay(attempt)
+                logger.warning(
+                    "import_comicinfo_failure_status_retrying_after_sqlite_lock",
+                    imported_file_id=imported_file_id,
+                    attempt=attempt,
+                    max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                    delay_seconds=delay_seconds,
+                )
+            except Exception:
+                await session.rollback()
+                raise
+        await asyncio.sleep(delay_seconds)
+    return False
 
 
 def _set_comicinfo_enrichment_status(

--- a/src/pullbox/services/import_comicinfo_enrichment.py
+++ b/src/pullbox/services/import_comicinfo_enrichment.py
@@ -24,6 +24,7 @@ from pullbox.models.import_job import ImportedFile, ImportedFileStatus, ImportJo
 from pullbox.models.issue import Issue
 from pullbox.models.library import LibraryFile
 from pullbox.models.series import Series
+from pullbox.services.import_comicinfo_metadata import is_retryable_provider_error
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -158,6 +159,14 @@ async def run_import_comicinfo_enrichment(
                 log_event=log_event,
             )
         except Exception as exc:
+            if is_retryable_provider_error(exc):
+                logger.warning(
+                    "import_comicinfo_enrichment_deferred_for_provider",
+                    job_id=job_id,
+                    imported_file_id=imported_file_id,
+                    error=str(exc),
+                )
+                break
             await _mark_pending_file_failed(
                 session_factory,
                 job_id=job_id,
@@ -304,6 +313,7 @@ async def _prepare_pending_imported_file(
         issue,
         source_path=artifact_path,
         defer_issue_enrichment=False,
+        propagate_retryable_provider_errors=True,
     )
     return PreparedComicInfoEnrichment(
         artifact_path=artifact_path,

--- a/src/pullbox/services/import_comicinfo_metadata.py
+++ b/src/pullbox/services/import_comicinfo_metadata.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy import func as sa_func
 from sqlalchemy import select as sa_select
 
+from pullbox.core.exceptions import ProviderError, RateLimitError
 from pullbox.core.sqlite_lock import is_sqlite_locked_error
 from pullbox.models.creator import IssueCreator
 from pullbox.models.issue import Issue
@@ -19,6 +20,15 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = structlog.get_logger(__name__)
+
+
+def is_retryable_provider_error(exc: Exception) -> bool:
+    """Return whether deferred metadata work should remain pending."""
+    if isinstance(exc, RateLimitError):
+        return True
+    if not isinstance(exc, ProviderError) or not isinstance(exc.details, dict):
+        return False
+    return exc.details.get("retryable") is True
 
 
 async def issue_needs_comicinfo_enrichment(
@@ -47,6 +57,7 @@ async def enrich_issue_for_comicinfo(
     *,
     metadata_service: Any,
     defer_provider_fetch: bool = False,
+    propagate_retryable_provider_errors: bool = False,
     timing: dict[str, Any] | None = None,
     log_warning: Callable[..., Any] = logger.warning,
     time_monotonic: Callable[[], float] = time.monotonic,
@@ -91,7 +102,9 @@ async def enrich_issue_for_comicinfo(
             comicvine_issue_id=issue.comicvine_id,
             error=str(exc),
         )
-        if is_sqlite_locked_error(exc):
+        if is_sqlite_locked_error(exc) or (
+            propagate_retryable_provider_errors and is_retryable_provider_error(exc)
+        ):
             raise
         return issue
 

--- a/src/pullbox/services/import_comicinfo_metadata.py
+++ b/src/pullbox/services/import_comicinfo_metadata.py
@@ -9,6 +9,7 @@ import structlog
 from sqlalchemy import func as sa_func
 from sqlalchemy import select as sa_select
 
+from pullbox.core.sqlite_lock import is_sqlite_locked_error
 from pullbox.models.creator import IssueCreator
 from pullbox.models.issue import Issue
 
@@ -90,6 +91,8 @@ async def enrich_issue_for_comicinfo(
             comicvine_issue_id=issue.comicvine_id,
             error=str(exc),
         )
+        if is_sqlite_locked_error(exc):
+            raise
         return issue
 
     if timing is not None:

--- a/src/pullbox/services/import_service_file_operations.py
+++ b/src/pullbox/services/import_service_file_operations.py
@@ -275,12 +275,6 @@ class ImportServiceFileOperationsMixin:
         timing: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Build authoritative ComicInfo.xml fields for a chosen issue."""
-        enriched_issue = await self._enrich_issue_for_comicinfo(
-            session,
-            issue,
-            defer_provider_fetch=defer_issue_enrichment,
-            timing=timing,
-        )
         page_count = None
         if source_path is not None:
             page_count_started_at = time.monotonic()
@@ -299,6 +293,12 @@ class ImportServiceFileOperationsMixin:
                         else None,
                     }
                 )
+        enriched_issue = await self._enrich_issue_for_comicinfo(
+            session,
+            issue,
+            defer_provider_fetch=defer_issue_enrichment,
+            timing=timing,
+        )
         return await build_comicinfo_payload_for_issue(
             session,
             enriched_issue,

--- a/src/pullbox/services/import_service_file_operations.py
+++ b/src/pullbox/services/import_service_file_operations.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
             issue: Issue,
             *,
             defer_provider_fetch: bool = False,
+            propagate_retryable_provider_errors: bool = False,
             timing: dict[str, Any] | None = None,
         ) -> Issue: ...
 
@@ -102,6 +103,7 @@ if TYPE_CHECKING:
             *,
             source_path: Path | None = None,
             defer_issue_enrichment: bool = False,
+            propagate_retryable_provider_errors: bool = False,
             timing: dict[str, Any] | None = None,
         ) -> dict[str, Any]: ...
 
@@ -272,6 +274,7 @@ class ImportServiceFileOperationsMixin:
         *,
         source_path: Path | None = None,
         defer_issue_enrichment: bool = False,
+        propagate_retryable_provider_errors: bool = False,
         timing: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Build authoritative ComicInfo.xml fields for a chosen issue."""
@@ -297,6 +300,7 @@ class ImportServiceFileOperationsMixin:
             session,
             issue,
             defer_provider_fetch=defer_issue_enrichment,
+            propagate_retryable_provider_errors=propagate_retryable_provider_errors,
             timing=timing,
         )
         return await build_comicinfo_payload_for_issue(
@@ -351,6 +355,7 @@ class ImportServiceFileOperationsMixin:
         issue: Issue,
         *,
         defer_provider_fetch: bool = False,
+        propagate_retryable_provider_errors: bool = False,
         timing: dict[str, Any] | None = None,
     ) -> Issue:
         """Fetch full issue metadata once when ComicInfo needs authoritative fields."""
@@ -359,6 +364,7 @@ class ImportServiceFileOperationsMixin:
             issue,
             metadata_service=self._metadata_service,
             defer_provider_fetch=defer_provider_fetch,
+            propagate_retryable_provider_errors=propagate_retryable_provider_errors,
             timing=timing,
             log_warning=logger.warning,
         )

--- a/src/pullbox/services/metadata_service.py
+++ b/src/pullbox/services/metadata_service.py
@@ -36,6 +36,16 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+
+def _provider_error_from_comicvine(exc: ComicVineError) -> ProviderError:
+    """Preserve provider failure classification across the service boundary."""
+    return ProviderError(
+        "comicvine",
+        str(exc),
+        details={"status_code": exc.status_code, "retryable": exc.retryable},
+    )
+
+
 # Mapping from IssueType → SeriesType for propagating detected issue types
 # to the parent series when all issues share a single non-standard type.
 _ISSUE_TO_SERIES_TYPE: dict[IssueType, SeriesType] = {
@@ -194,7 +204,7 @@ class MetadataService:
         try:
             return await self._provider.get_series(str(comicvine_id))
         except ComicVineError as exc:
-            raise ProviderError("comicvine", str(exc)) from exc
+            raise _provider_error_from_comicvine(exc) from exc
 
     async def get_issue_summaries_for_series(
         self,
@@ -207,7 +217,7 @@ class MetadataService:
         try:
             return await self._provider.get_issues_for_series(str(comicvine_id))
         except ComicVineError as exc:
-            raise ProviderError("comicvine", str(exc)) from exc
+            raise _provider_error_from_comicvine(exc) from exc
 
     async def get_recent_issue_summaries_for_series(
         self,
@@ -225,7 +235,7 @@ class MetadataService:
                 limit=limit,
             )
         except ComicVineError as exc:
-            raise ProviderError("comicvine", str(exc)) from exc
+            raise _provider_error_from_comicvine(exc) from exc
 
     async def classify_and_link_series(
         self,
@@ -335,7 +345,7 @@ class MetadataService:
         try:
             meta = await self._provider.get_issue(str(comicvine_id))
         except ComicVineError as exc:
-            raise ProviderError("comicvine", str(exc)) from exc
+            raise _provider_error_from_comicvine(exc) from exc
 
         existing = (
             await session.execute(select(Issue).where(Issue.comicvine_id == comicvine_id))

--- a/src/pullbox/services/search_indexers.py
+++ b/src/pullbox/services/search_indexers.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -30,8 +31,17 @@ INDEXER_BACKOFF_SECONDS = [900, 3600, 21600, 86400]  # 15min, 1hr, 6hr, 24hr
 
 SearchSingleIndexerFunc = Callable[
     ["Indexer", SearchQuery, "IndexerConfig | None", int],
-    Awaitable[list[ReleaseResult]],
+    Awaitable["IndexerSearchAttempt"],
 ]
+
+
+@dataclass(frozen=True)
+class IndexerSearchAttempt:
+    """Results and health status for one isolated indexer request."""
+
+    results: list[ReleaseResult]
+    status: str = "completed"
+    error: str | None = None
 
 
 def calculate_backoff(
@@ -114,11 +124,11 @@ async def search_indexers(
         indexer: Indexer,
         indexer_query: SearchQuery,
         cfg: IndexerConfig | None,
-    ) -> tuple[Indexer, SearchQuery, list[ReleaseResult], int]:
+    ) -> tuple[Indexer, SearchQuery, IndexerSearchAttempt, int]:
         started_at = time.monotonic()
-        results = await search_single(indexer, indexer_query, cfg, failure_threshold)
+        attempt = await search_single(indexer, indexer_query, cfg, failure_threshold)
         elapsed_ms = int((time.monotonic() - started_at) * 1000)
-        return indexer, indexer_query, results, elapsed_ms
+        return indexer, indexer_query, attempt, elapsed_ms
 
     raw_results = await asyncio.gather(
         *[
@@ -128,7 +138,8 @@ async def search_indexers(
     )
 
     all_results: list[ReleaseResult] = []
-    for indexer, indexer_query, results, elapsed_ms in raw_results:
+    for indexer, indexer_query, attempt, elapsed_ms in raw_results:
+        results = attempt.results
         if results:
             active_logger.debug(
                 "search_indexer_raw_results",
@@ -144,18 +155,19 @@ async def search_indexers(
         filtered_results = [result for result in results if _is_comic_category(result.category)]
         filtered = before - len(filtered_results)
         if timing_collector is not None:
-            timing_collector.append(
-                {
-                    "query": indexer_query.series_title,
-                    "indexer": indexer.name,
-                    "status": "completed",
-                    "elapsed_ms": elapsed_ms,
-                    "raw_count": before,
-                    "result_count": len(filtered_results),
-                    "filtered_count": filtered,
-                    "categories": indexer_query.categories,
-                }
-            )
+            timing: dict[str, object] = {
+                "query": indexer_query.series_title,
+                "indexer": indexer.name,
+                "status": attempt.status,
+                "elapsed_ms": elapsed_ms,
+                "raw_count": before,
+                "result_count": len(filtered_results),
+                "filtered_count": filtered,
+                "categories": indexer_query.categories,
+            }
+            if attempt.error is not None:
+                timing["error"] = attempt.error
+            timing_collector.append(timing)
         if filtered:
             active_logger.debug(
                 "search_category_filtered",
@@ -174,7 +186,7 @@ async def search_single_indexer(
     query: SearchQuery,
     cfg: IndexerConfig | None = None,
     failure_threshold: int = DEFAULT_INDEXER_FAILURE_THRESHOLD,
-) -> list[ReleaseResult]:
+) -> IndexerSearchAttempt:
     """Search a single indexer, handling errors and health tracking."""
     log = logger.bind(indexer=indexer.name, query=query.series_title)
     log.debug(
@@ -195,10 +207,10 @@ async def search_single_indexer(
             cfg.disabled_until = None
             cfg.last_success_at = datetime.now(UTC)
 
-        return results
-    except Exception:
+        return IndexerSearchAttempt(results=results)
+    except Exception as exc:
         elapsed_ms = int((time.monotonic() - started_at) * 1000)
-        log.exception("search_indexer_error", elapsed_ms=elapsed_ms)
+        log.warning("search_indexer_error", elapsed_ms=elapsed_ms, error=str(exc))
 
         if cfg is not None:
             cfg.failure_count += 1
@@ -215,4 +227,4 @@ async def search_single_indexer(
                     backoff_seconds=backoff,
                 )
 
-        return []
+        return IndexerSearchAttempt(results=[], status="failed", error=str(exc))

--- a/src/pullbox/services/search_service.py
+++ b/src/pullbox/services/search_service.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from pullbox.models.indexer import IndexerConfig
     from pullbox.providers.base import Indexer, ProviderRegistry
+    from pullbox.services.search_indexers import IndexerSearchAttempt
     from pullbox.services.search_types import SearchEvalKwargs, ValidatorKwargs
 
 logger = structlog.get_logger(__name__)
@@ -814,7 +815,7 @@ class SearchService:
         query: SearchQuery,
         cfg: IndexerConfig | None = None,
         failure_threshold: int = DEFAULT_INDEXER_FAILURE_THRESHOLD,
-    ) -> list[ReleaseResult]:
+    ) -> IndexerSearchAttempt:
         """Compatibility facade for a single indexer search attempt."""
         return await _search_indexers.search_single_indexer(
             indexer,

--- a/src/pullbox/tasks/search_task.py
+++ b/src/pullbox/tasks/search_task.py
@@ -507,13 +507,6 @@ async def search_series_issues(
                 return {"wanted": 0, "sent": 0, "queued": 0}
 
             preload_ms = int((time.monotonic() - preload_started_at) * 1000)
-            search_svc = SearchService(
-                runtime.registry,
-                failure_threshold=runtime.failure_threshold,
-            )
-            download_svc = _build_download_service(runtime.registry)
-            intervention_svc = InterventionService(download_svc)
-
             log.info(
                 "search_series_issues_config",
                 series=str(series.title),
@@ -525,52 +518,85 @@ async def search_series_issues(
             )
 
             search_started_at = time.monotonic()
-            if _is_mocked_search_service(search_svc):
-                two_pass_enabled = await _load_mocked_two_pass_enabled(session, runtime)
-                pass1_outcomes = [
-                    await _build_mocked_issue_outcome(
-                        session,
-                        search_svc,
-                        target,
-                        runtime,
+            pass1_outcomes: list[IssueSearchOutcome] = []
+            pass2_outcomes: list[IssueSearchOutcome] = []
+            for attempt in range(1, SQLITE_LOCK_RETRY_ATTEMPTS + 1):
+                try:
+                    if attempt > 1:
+                        retry_runtime = await _build_task_search_runtime(
+                            session,
+                            include_download_clients=True,
+                        )
+                        if retry_runtime is None:
+                            msg = "Search runtime became unavailable during lock retry"
+                            raise RuntimeError(msg)
+                        runtime = retry_runtime
+
+                    search_svc = SearchService(
+                        runtime.registry,
+                        failure_threshold=runtime.failure_threshold,
                     )
-                    for target in targets
-                ]
-                pass2_targets = [
-                    outcome.target
-                    for outcome in pass1_outcomes
-                    if outcome.best_validation is None
-                    and outcome.target.issue_type.value in _TYPE_QUERY_KEYWORDS
-                    and two_pass_enabled
-                ]
-                pass2_outcomes = [
-                    await _build_mocked_issue_outcome(
-                        session,
-                        search_svc,
-                        target,
-                        runtime,
-                        force_generic=True,
+                    if _is_mocked_search_service(search_svc):
+                        two_pass_enabled = await _load_mocked_two_pass_enabled(session, runtime)
+                        pass1_outcomes = [
+                            await _build_mocked_issue_outcome(
+                                session,
+                                search_svc,
+                                target,
+                                runtime,
+                            )
+                            for target in targets
+                        ]
+                        pass2_targets = [
+                            outcome.target
+                            for outcome in pass1_outcomes
+                            if outcome.best_validation is None
+                            and outcome.target.issue_type.value in _TYPE_QUERY_KEYWORDS
+                            and two_pass_enabled
+                        ]
+                        pass2_outcomes = [
+                            await _build_mocked_issue_outcome(
+                                session,
+                                search_svc,
+                                target,
+                                runtime,
+                                force_generic=True,
+                            )
+                            for target in pass2_targets
+                        ]
+                    else:
+                        pass1_outcomes = await search_svc.search_targets_quick_first(
+                            session,
+                            targets,
+                            indexer_configs=runtime.indexer_configs,
+                            eval_kwargs=runtime.eval_kwargs,
+                            validator_kwargs=runtime.validator_kwargs,
+                            source_priority=runtime.source_priority,
+                            enable_deep_fallback=runtime.two_pass_enabled,
+                            concurrency=DEFAULT_WANTED_SEARCH_CONCURRENCY,
+                        )
+                        pass2_outcomes = []
+
+                    # Persist indexer health immediately after network fan-out.
+                    await session.commit()
+                    break
+                except OperationalError as exc:
+                    await session.rollback()
+                    if not is_sqlite_locked_error(exc) or attempt == SQLITE_LOCK_RETRY_ATTEMPTS:
+                        raise
+                    delay_seconds = sqlite_lock_retry_delay(attempt)
+                    log.warning(
+                        "search_series_retrying_after_sqlite_lock",
+                        attempt=attempt,
+                        max_attempts=SQLITE_LOCK_RETRY_ATTEMPTS,
+                        delay_seconds=delay_seconds,
+                        stage="search_fanout_persist",
                     )
-                    for target in pass2_targets
-                ]
-            else:
-                pass1_outcomes = await search_svc.search_targets_quick_first(
-                    session,
-                    targets,
-                    indexer_configs=runtime.indexer_configs,
-                    eval_kwargs=runtime.eval_kwargs,
-                    validator_kwargs=runtime.validator_kwargs,
-                    source_priority=runtime.source_priority,
-                    enable_deep_fallback=runtime.two_pass_enabled,
-                    concurrency=DEFAULT_WANTED_SEARCH_CONCURRENCY,
-                )
-                pass2_outcomes = []
+                    await asyncio.sleep(delay_seconds)
             search_fanout_ms = int((time.monotonic() - search_started_at) * 1000)
 
-            # Persist indexer health immediately after network fan-out. The
-            # routing phase performs additional client I/O and must not inherit
-            # a pending writer transaction from health tracking.
-            await session.commit()
+            download_svc = _build_download_service(runtime.registry)
+            intervention_svc = InterventionService(download_svc)
 
             sent = 0
             queued = 0

--- a/src/pullbox/tasks/search_task.py
+++ b/src/pullbox/tasks/search_task.py
@@ -567,6 +567,11 @@ async def search_series_issues(
                 pass2_outcomes = []
             search_fanout_ms = int((time.monotonic() - search_started_at) * 1000)
 
+            # Persist indexer health immediately after network fan-out. The
+            # routing phase performs additional client I/O and must not inherit
+            # a pending writer transaction from health tracking.
+            await session.commit()
+
             sent = 0
             queued = 0
             pass2_by_issue = {outcome.target.issue_id: outcome for outcome in pass2_outcomes}

--- a/src/pullbox/ui/series_routes.py
+++ b/src/pullbox/ui/series_routes.py
@@ -10,7 +10,7 @@ import structlog
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import ColumnElement, case, func, select
+from sqlalchemy import ColumnElement, String, case, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import contains_eager
 from starlette.responses import Response
@@ -126,6 +126,11 @@ def series_type_code(series_type_value: str) -> str:
     return type_codes.get(series_type_value, series_type_value[:3].upper())
 
 
+def _lower_enum_sort(column: Any) -> ColumnElement[str]:
+    """Return a portable case-insensitive sort for native enum columns."""
+    return func.lower(cast(column, String))
+
+
 def build_series_filters(
     q: str | None,
     status: str | None,
@@ -208,14 +213,16 @@ async def series_list(
         .subquery()
     )
 
+    status_sort = _lower_enum_sort(Series.status)
+    series_type_sort = _lower_enum_sort(Series.series_type)
     sort_map = {
         "title": func.lower(Series.sort_title),
         "year": Series.year_start,
         "date_added": Series.created_at,
         "publisher": func.lower(Publisher.name),
-        "status": func.lower(Series.status),
+        "status": status_sort,
         "issues": func.coalesce(issue_counts.c.owned_count, 0),
-        "series_type": func.lower(Series.series_type),
+        "series_type": series_type_sort,
     }
     sort_col = sort_map.get(sort_field, func.lower(Series.sort_title))
     order_clause = sort_col.desc() if sort_desc else sort_col.asc()
@@ -227,7 +234,7 @@ async def series_list(
         order_clauses.extend(
             [
                 Series.year_start.desc().nullslast(),
-                func.lower(Series.series_type).asc(),
+                series_type_sort.asc(),
             ]
         )
     else:

--- a/src/pullbox/ui/series_routes.py
+++ b/src/pullbox/ui/series_routes.py
@@ -209,16 +209,35 @@ async def series_list(
     )
 
     sort_map = {
-        "title": Series.sort_title,
+        "title": func.lower(Series.sort_title),
         "year": Series.year_start,
         "date_added": Series.created_at,
-        "publisher": Publisher.name,
-        "status": Series.status,
+        "publisher": func.lower(Publisher.name),
+        "status": func.lower(Series.status),
         "issues": func.coalesce(issue_counts.c.owned_count, 0),
-        "series_type": Series.series_type,
+        "series_type": func.lower(Series.series_type),
     }
-    sort_col = sort_map.get(sort_field, Series.sort_title)
+    sort_col = sort_map.get(sort_field, func.lower(Series.sort_title))
     order_clause = sort_col.desc() if sort_desc else sort_col.asc()
+    if sort_field in {"year", "publisher"}:
+        order_clause = order_clause.nullslast()
+
+    order_clauses = [order_clause]
+    if sort_field == "title":
+        order_clauses.extend(
+            [
+                Series.year_start.desc().nullslast(),
+                func.lower(Series.series_type).asc(),
+            ]
+        )
+    else:
+        order_clauses.extend(
+            [
+                func.lower(Series.sort_title).asc(),
+                Series.year_start.desc().nullslast(),
+            ]
+        )
+    order_clauses.append(Series.id.asc())
 
     query = (
         select(
@@ -231,7 +250,7 @@ async def series_list(
         .outerjoin(Series.publisher)
         .outerjoin(issue_counts, issue_counts.c.series_id == Series.id)
         .options(contains_eager(Series.publisher))
-        .order_by(order_clause)
+        .order_by(*order_clauses)
     )
     offset = (page - 1) * per_page
     query = query.limit(per_page).offset(offset)

--- a/src/pullbox/ui/static/js/pullbox.js
+++ b/src/pullbox/ui/static/js/pullbox.js
@@ -16448,18 +16448,15 @@ function _parseSeriesPaginationBundle(responseText) {
 
   var summary = wrapper.querySelector("#series-summary");
   var dock = wrapper.querySelector("#page-footer-dock");
+  var resultsBody = wrapper.querySelector("#series-results-body");
 
-  if (!summary || !dock) {
+  if (!summary || !dock || !resultsBody) {
     return null;
   }
 
   var summaryHtml = summary.innerHTML;
   var dockHtml = dock.innerHTML;
-
-  summary.remove();
-  dock.remove();
-
-  var resultsHtml = wrapper.innerHTML.trim();
+  var resultsHtml = resultsBody.outerHTML.trim();
   if (!resultsHtml) {
     return null;
   }
@@ -16568,24 +16565,41 @@ function _applySeriesPaginationBundle(bundle) {
     return null;
   }
 
+  var resultsWrapper = document.createElement("div");
+  resultsWrapper.innerHTML = bundle.resultsHtml;
+  var replacementResultsBody = resultsWrapper.querySelector("#series-results-body");
+  if (!replacementResultsBody || !resultsBody.parentNode) {
+    return null;
+  }
+
   summary.innerHTML = bundle.summaryHtml;
-  resultsBody.innerHTML = bundle.resultsHtml;
   dock.innerHTML = bundle.dockHtml;
+
+  var resultsParent = resultsBody.parentNode;
+  var resultsNextSibling = resultsBody.nextSibling;
+  if (window.htmx && typeof window.htmx.remove === "function") {
+    window.htmx.remove(resultsBody);
+  } else {
+    resultsBody.remove();
+  }
+  resultsParent.insertBefore(replacementResultsBody, resultsNextSibling);
 
   if (window.htmx && typeof window.htmx.process === "function") {
     window.htmx.process(summary);
     window.htmx.process(dock);
+    window.htmx.process(replacementResultsBody);
   }
 
   if (window.Alpine) {
     Alpine.initTree(summary);
     Alpine.initTree(dock);
+    Alpine.initTree(replacementResultsBody);
   }
 
   seedSearchFieldStates(summary);
   seedSearchFieldStates(dock);
 
-  return resultsBody;
+  return replacementResultsBody;
 }
 
 function _dispatchSyntheticHtmxAfterSettle(target) {

--- a/src/pullbox/ui/static/js/pullbox.js
+++ b/src/pullbox/ui/static/js/pullbox.js
@@ -15226,6 +15226,14 @@ function pullboxLiveUpdatesEnabled() {
   return !areLiveUpdatesPaused();
 }
 
+function searchHistoryRefreshEnabled() {
+  if (!pullboxLiveUpdatesEnabled()) {
+    return false;
+  }
+
+  return !document.querySelector("[data-search-history-expanded='true']");
+}
+
 function importHistoryToolbarActive() {
   var toolbar = document.querySelector("[data-testid='import-history-toolbar']");
   if (!toolbar) {
@@ -15526,6 +15534,7 @@ function liveUpdatesController() {
 
 applyLiveUpdatesState(areLiveUpdatesPaused());
 window.pullboxLiveUpdatesEnabled = pullboxLiveUpdatesEnabled;
+window.searchHistoryRefreshEnabled = searchHistoryRefreshEnabled;
 window.downloadsHistoryRefreshEnabled = downloadsHistoryRefreshEnabled;
 window.postProcessingHistoryRefreshEnabled = postProcessingHistoryRefreshEnabled;
 window.postProcessingQueueRefreshEnabled = postProcessingQueueRefreshEnabled;

--- a/src/pullbox/ui/templates/pages/series_list.html
+++ b/src/pullbox/ui/templates/pages/series_list.html
@@ -919,7 +919,9 @@
       hx-trigger="every 10s"
       hx-target="#series-results-body"
       hx-select="#series-results-body"
+      hx-sync="#series-results-body:replace"
       hx-swap="outerHTML"
+      hx-push-url="false"
     {% endif %}
   {% endset %}
 

--- a/src/pullbox/ui/templates/pages/series_list.html
+++ b/src/pullbox/ui/templates/pages/series_list.html
@@ -920,7 +920,7 @@
       hx-target="#series-results-body"
       hx-select="#series-results-body"
       hx-sync="#series-results-body:replace"
-      hx-swap="outerHTML"
+      hx-swap="morph:outerHTML"
       hx-push-url="false"
     {% endif %}
   {% endset %}

--- a/src/pullbox/ui/templates/partials/search_history_results_body.html
+++ b/src/pullbox/ui/templates/partials/search_history_results_body.html
@@ -33,7 +33,7 @@
   data-testid="search-history-results-body"
   {% if search_history_has_active_logs %}
     hx-get="{{ search_history_refresh_url }}"
-    hx-trigger="every 2s"
+    hx-trigger="every 2s [window.searchHistoryRefreshEnabled()]"
     hx-target="this"
     hx-swap="outerHTML"
     hx-sync="this:replace"
@@ -64,6 +64,7 @@
                     detailUrl: '/htmx/search-history/logs/{{ log.id }}/detail',
                     detailTarget: '#search-history-detail-content-{{ log.id }}'
                   })"
+          x-bind:data-search-history-expanded="expanded ? 'true' : 'false'"
         >
           <tr id="search-history-row-{{ log.id }}">
             <td>

--- a/src/pullbox/ui/templates/partials/series_content.html
+++ b/src/pullbox/ui/templates/partials/series_content.html
@@ -8,7 +8,9 @@
     hx-trigger="every 10s"
     hx-target="#series-results-body"
     hx-select="#series-results-body"
+    hx-sync="#series-results-body:replace"
     hx-swap="outerHTML"
+    hx-push-url="false"
     {% endif %}
     class="series-results-body-shell"
   >

--- a/src/pullbox/ui/templates/partials/series_content.html
+++ b/src/pullbox/ui/templates/partials/series_content.html
@@ -9,7 +9,7 @@
     hx-target="#series-results-body"
     hx-select="#series-results-body"
     hx-sync="#series-results-body:replace"
-    hx-swap="outerHTML"
+    hx-swap="morph:outerHTML"
     hx-push-url="false"
     {% endif %}
     class="series-results-body-shell"

--- a/src/pullbox/ui/templates/partials/series_results_bundle.html
+++ b/src/pullbox/ui/templates/partials/series_results_bundle.html
@@ -14,7 +14,7 @@
   hx-target="#series-results-body"
   hx-select="#series-results-body"
   hx-sync="#series-results-body:replace"
-  hx-swap="outerHTML"
+  hx-swap="morph:outerHTML"
   hx-push-url="false"
   {% endif %}
   class="series-results-body-shell"

--- a/src/pullbox/ui/templates/partials/series_results_bundle.html
+++ b/src/pullbox/ui/templates/partials/series_results_bundle.html
@@ -13,7 +13,9 @@
   hx-trigger="every 10s"
   hx-target="#series-results-body"
   hx-select="#series-results-body"
+  hx-sync="#series-results-body:replace"
   hx-swap="outerHTML"
+  hx-push-url="false"
   {% endif %}
   class="series-results-body-shell"
 >

--- a/src/pullbox/ui/templates/partials/settings_clients.html
+++ b/src/pullbox/ui/templates/partials/settings_clients.html
@@ -1243,23 +1243,32 @@ function clientsSettings() {
         });
     },
 
+    async testClientConnection(clientId) {
+      try {
+        const response = await fetch(`/api/v1/clients/${clientId}/test`, {
+          method: 'POST',
+          headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
+        });
+        const data = await response.json();
+        this.setClientResult(clientId, { healthy: data.healthy, message: data.message || '' });
+      } catch {
+        this.setClientResult(clientId, { healthy: false, message: 'Test failed' });
+      }
+    },
+
+    async runClientChecksSequentially(clients) {
+      for (const client of clients) {
+        await this.testClientConnection(client.id);
+      }
+    },
+
     testAll() {
       this.testingAll = true;
       fetch('/api/v1/clients', {
         headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
       })
         .then(r => r.json())
-        .then(clients => Promise.all(
-          clients.map(c =>
-            fetch(`/api/v1/clients/${c.id}/test`, {
-              method: 'POST',
-              headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
-            })
-              .then(r => r.json())
-              .then(data => { this.setClientResult(c.id, { healthy: data.healthy, message: data.message || '' }); })
-              .catch(() => { this.setClientResult(c.id, { healthy: false, message: 'Test failed' }); })
-          )
-        ))
+        .then(clients => this.runClientChecksSequentially(clients))
         .finally(() => { this.testingAll = false; });
     },
 
@@ -1268,17 +1277,7 @@ function clientsSettings() {
         headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
       })
         .then(r => r.json())
-        .then(clients => Promise.all(
-          clients.map(c =>
-            fetch(`/api/v1/clients/${c.id}/test`, {
-              method: 'POST',
-              headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
-            })
-              .then(r => r.json())
-              .then(data => { this.setClientResult(c.id, { healthy: data.healthy, message: data.message || '' }); })
-              .catch(() => { this.setClientResult(c.id, { healthy: false, message: 'Test failed' }); })
-          )
-        ));
+        .then(clients => this.runClientChecksSequentially(clients));
     },
 
     saveConfig(formEl) {

--- a/src/pullbox/ui/templates/partials/settings_indexers.html
+++ b/src/pullbox/ui/templates/partials/settings_indexers.html
@@ -1082,23 +1082,32 @@ function indexersSettings() {
       }
     },
 
+    async testIndexerConnection(indexerId) {
+      try {
+        const response = await fetch(`/api/v1/indexers/${indexerId}/test`, {
+          method: 'POST',
+          headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
+        });
+        const data = await response.json();
+        this.setIndexerResult(indexerId, data.healthy);
+      } catch {
+        this.setIndexerResult(indexerId, false);
+      }
+    },
+
+    async runIndexerChecksSequentially(indexers) {
+      for (const idx of indexers) {
+        await this.testIndexerConnection(idx.id);
+      }
+    },
+
     testAll() {
       this.testingAll = true;
       fetch('/api/v1/indexers', {
         headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
       })
         .then(r => r.json())
-        .then(indexers => Promise.all(
-          indexers.map(idx =>
-            fetch(`/api/v1/indexers/${idx.id}/test`, {
-              method: 'POST',
-              headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
-            })
-              .then(r => r.json())
-              .then(data => { this.setIndexerResult(idx.id, data.healthy); })
-              .catch(() => { this.setIndexerResult(idx.id, false); })
-          )
-        ))
+        .then(indexers => this.runIndexerChecksSequentially(indexers))
         .finally(() => { this.testingAll = false; });
     },
 
@@ -1107,17 +1116,7 @@ function indexersSettings() {
         headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
       })
         .then(r => r.json())
-        .then(indexers => Promise.all(
-          indexers.map(idx =>
-            fetch(`/api/v1/indexers/${idx.id}/test`, {
-              method: 'POST',
-              headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
-            })
-              .then(r => r.json())
-              .then(data => { this.setIndexerResult(idx.id, data.healthy); })
-              .catch(() => { this.setIndexerResult(idx.id, false); })
-          )
-        ));
+        .then(indexers => this.runIndexerChecksSequentially(indexers));
     },
 
     // ── Prowlarr ─────────────────────────────────────────────────

--- a/src/pullbox/ui/templates/partials/settings_indexers.html
+++ b/src/pullbox/ui/templates/partials/settings_indexers.html
@@ -934,7 +934,6 @@ function indexersSettings() {
 
     init() {
       this.persistIndexerStatusCache();
-      {% if indexers %}this._silentTestAll();{% endif %}
     },
 
     // ── Modal lifecycle ──────────────────────────────────────────
@@ -1107,16 +1106,8 @@ function indexersSettings() {
         headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
       })
         .then(r => r.json())
-        .then(indexers => this.runIndexerChecksSequentially(indexers))
+        .then(indexers => this.runIndexerChecksSequentially(indexers.filter(idx => idx.enabled)))
         .finally(() => { this.testingAll = false; });
-    },
-
-    _silentTestAll() {
-      fetch('/api/v1/indexers', {
-        headers: { 'X-CSRF-Token': '{{ csrf_token }}' },
-      })
-        .then(r => r.json())
-        .then(indexers => this.runIndexerChecksSequentially(indexers));
     },
 
     // ── Prowlarr ─────────────────────────────────────────────────

--- a/src/pullbox/ui/templates/partials/settings_media.html
+++ b/src/pullbox/ui/templates/partials/settings_media.html
@@ -248,7 +248,7 @@
             type="submit"
             data-testid="settings-media-import-save"
             :disabled="!isDirty"
-            :class="!isDirty && 'opacity-50 cursor-not-allowed'"
+            :class="isDirty ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'"
             class="btn-primary"
           >
             Save import rules

--- a/src/pullbox/ui/templates/partials/system_tasks.html
+++ b/src/pullbox/ui/templates/partials/system_tasks.html
@@ -42,7 +42,7 @@
     </div>
 
     <div x-show="!loading && scheduled.length > 0" class="section-body">
-      <div class="downloads-table-wrap" data-testid="system-tasks-table">
+      <div class="downloads-table-wrap is-clipped" data-testid="system-tasks-table">
         <div
           class="overflow-x-auto"
           role="region"

--- a/tests/api/test_clients_api.py
+++ b/tests/api/test_clients_api.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
+import sqlite3
 import sys
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from pullbox.api.v1 import clients as clients_api
 from pullbox.core.encryption import decrypt_secret, encrypt_secret
@@ -25,6 +28,10 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 pytest_plugins = ["conftest_security"]
+
+
+async def _instant_sleep(_seconds: float) -> None:
+    return None
 
 
 def _client_payload(
@@ -769,6 +776,59 @@ class TestClientRouteFunctions:
         assert client.last_success_at is not None
         assert client.last_error is None
         assert client.last_test_message == f"{client_type.value} healthy"
+
+    async def test_saved_client_test_route_retries_transient_sqlite_lock(
+        self,
+        sec_db: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _healthy_test(_self) -> ProviderHealthResult:
+            return _health_result("qBittorrent reachable after retry")
+
+        monkeypatch.setattr(
+            "pullbox.providers.download.qbittorrent.QBittorrentClient.test_connection",
+            _healthy_test,
+        )
+
+        async with sec_db() as session:
+            client = DownloadClientConfig(
+                name="qBittorrent saved",
+                client_type=DownloadClientType.QBITTORRENT,
+                url="http://localhost:8080",
+                enabled=True,
+                priority=50,
+                username="admin",
+                password=encrypt_secret("qbit-password"),
+            )
+            session.add(client)
+            await session.commit()
+            client_id = client.id
+            original_flush = session.flush
+            flush_attempts = 0
+
+            async def _flaky_flush(*args: object, **kwargs: object) -> None:
+                nonlocal flush_attempts
+                flush_attempts += 1
+                if flush_attempts == 1:
+                    raise OperationalError(
+                        "UPDATE download_client_configs",
+                        {},
+                        sqlite3.OperationalError("database is locked"),
+                    )
+                await original_flush(*args, **kwargs)
+
+            monkeypatch.setattr(session, "flush", _flaky_flush)
+            monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+            result = await clients_api.test_client(client_id, object(), session)  # type: ignore[arg-type]
+            refreshed = await session.get(DownloadClientConfig, client_id)
+
+        assert flush_attempts == 2
+        assert result["healthy"] is True
+        assert refreshed is not None
+        assert refreshed.last_success_at is not None
+        assert refreshed.last_error is None
+        assert refreshed.last_test_message == "qBittorrent reachable after retry"
 
     async def test_saved_client_test_route_persists_failure_and_handles_errors(
         self,

--- a/tests/api/test_downloads_api.py
+++ b/tests/api/test_downloads_api.py
@@ -20,6 +20,7 @@ from pullbox.models.download import DownloadClientType, DownloadHistory, Downloa
 from pullbox.models.issue import Issue, IssueStatus
 from pullbox.models.series import Series
 from pullbox.models.user import APIKey, User
+from pullbox.providers.download.qbittorrent import QBittorrentError
 from pullbox.services.auth_service import AuthService
 
 if TYPE_CHECKING:
@@ -350,6 +351,47 @@ class TestDownloadRetry:
         assert download.external_id == "torrent-hash"
         issue = await _get_issue(db_factory, issue_id)
         assert issue.status == IssueStatus.DOWNLOADING
+
+    @pytest.mark.asyncio
+    async def test_retry_failed_torrent_returns_provider_error_without_advancing_state(
+        self,
+        client: AsyncClient,
+        db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        issue_id = await _seed_issue(db_factory, status=IssueStatus.OWNED)
+        download_id = await _seed_download(
+            db_factory,
+            issue_id,
+            client_type=DownloadClientType.QBITTORRENT,
+            download_url="https://example.com/absolute-wonder-woman-012.torrent",
+            downloaded_path=None,
+            error_message="Cancelled by user",
+        )
+        provider_message = "Torrent was not added to qBittorrent."
+        mock_client = AsyncMock()
+        mock_client.client_type = "qbittorrent"
+        mock_client.add_torrent = AsyncMock(side_effect=QBittorrentError(provider_message))
+
+        with patch(
+            "pullbox.composition.providers.register_download_clients",
+            new_callable=AsyncMock,
+        ) as mock_register:
+
+            async def _register(_session: object, registry: object) -> None:
+                registry.register_download_client(2, mock_client)  # type: ignore[union-attr]
+
+            mock_register.side_effect = _register
+
+            response = await client.post(f"/api/v1/downloads/{download_id}/retry")
+
+        assert response.status_code == 502
+        assert response.json()["detail"] == provider_message
+        download = await _get_download(db_factory, download_id)
+        assert download.state == DownloadState.FAILED
+        assert download.external_id == "download-ext"
+        assert download.error_message == "Cancelled by user"
+        issue = await _get_issue(db_factory, issue_id)
+        assert issue.status == IssueStatus.OWNED
 
     @pytest.mark.asyncio
     async def test_retry_download_rejects_post_processing_failures(

--- a/tests/api/test_indexers_api.py
+++ b/tests/api/test_indexers_api.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from pullbox.api.v1 import indexers as indexers_api
 from pullbox.core.encryption import decrypt_secret, encrypt_secret, is_encrypted
@@ -44,6 +46,10 @@ def _health(message: str = "reachable", *, healthy: bool = True) -> ProviderHeal
         message=message,
         response_time_ms=14.25,
     )
+
+
+async def _instant_sleep(_seconds: float) -> None:
+    return None
 
 
 async def _seed_indexer(
@@ -410,3 +416,45 @@ class TestIndexerConnectionRoutes:
         assert result["healthy"] is False
         assert indexer.last_failure_at is not None
         assert indexer.last_error == "indexer refused connection"
+
+    async def test_indexer_test_route_retries_transient_sqlite_lock(
+        self,
+        sec_db: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _FakeProvider:
+            def __init__(self, **kwargs: object) -> None:
+                self.kwargs = kwargs
+
+            async def test_connection(self) -> ProviderHealthResult:
+                return _health("indexer reachable after retry")
+
+        monkeypatch.setattr("pullbox.providers.indexer.newznab.NewznabIndexer", _FakeProvider)
+
+        async with sec_db() as session:
+            indexer = await _seed_indexer(session)
+            await session.commit()
+            original_flush = session.flush
+            flush_attempts = 0
+
+            async def _flaky_flush(*args: object, **kwargs: object) -> None:
+                nonlocal flush_attempts
+                flush_attempts += 1
+                if flush_attempts == 1:
+                    raise OperationalError(
+                        "UPDATE indexer_configs",
+                        {},
+                        sqlite3.OperationalError("database is locked"),
+                    )
+                await original_flush(*args, **kwargs)
+
+            monkeypatch.setattr(session, "flush", _flaky_flush)
+            monkeypatch.setattr(indexers_api.asyncio, "sleep", _instant_sleep)
+
+            result = await indexers_api.test_indexer(indexer.id, object(), session)  # type: ignore[arg-type]
+            await session.refresh(indexer)
+
+        assert flush_attempts == 2
+        assert result["healthy"] is True
+        assert indexer.last_success_at is not None
+        assert indexer.last_error is None

--- a/tests/api/test_series_bulk.py
+++ b/tests/api/test_series_bulk.py
@@ -209,7 +209,7 @@ async def _seed_series(
                     comicvine_id=60000 + i * 10 + 1,
                     issue_number=1.0,
                     title="Issue #1",
-                    status=IssueStatus.WANTED,
+                    status=IssueStatus.WANTED if monitored else IssueStatus.SKIPPED,
                 )
             )
             session.add(
@@ -251,7 +251,33 @@ class TestBulkMonitorUpdate:
 
         assert result == {"updated": 3, "skipped": 0}
         assert [stmt.lstrip().split(maxsplit=1)[0].upper() for stmt in recorder.statements] == [
-            "UPDATE"
+            "UPDATE",
+            "UPDATE",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_bulk_update_chunks_large_all_results_selection(
+        self,
+        _db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """Large all-results selections stay below SQLite bind-variable limits."""
+        series_ids = list(range(1, 502))
+
+        async with _db_factory() as session:
+            engine = cast("AsyncEngine", session.bind)
+            with StatementRecorder(engine) as recorder:
+                result = await bulk_update_series(
+                    SeriesBulkUpdate(series_ids=series_ids, monitored=True),
+                    cast("AuthenticatedUser", object()),
+                    session,
+                )
+
+        assert result == {"updated": 0, "skipped": 501}
+        assert [stmt.lstrip().split(maxsplit=1)[0].upper() for stmt in recorder.statements] == [
+            "UPDATE",
+            "UPDATE",
+            "UPDATE",
+            "UPDATE",
         ]
 
     @pytest.mark.asyncio
@@ -276,6 +302,19 @@ class TestBulkMonitorUpdate:
                 s = await session.get(Series, sid)
                 assert s is not None
                 assert s.monitored is True
+                issues = list(
+                    (
+                        await session.execute(
+                            select(Issue).where(Issue.series_id == sid).order_by(Issue.issue_number)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                assert [issue.status for issue in issues] == [
+                    IssueStatus.WANTED,
+                    IssueStatus.OWNED,
+                ]
 
     @pytest.mark.asyncio
     async def test_set_monitored_false(
@@ -298,6 +337,140 @@ class TestBulkMonitorUpdate:
                 s = await session.get(Series, sid)
                 assert s is not None
                 assert s.monitored is False
+                issues = list(
+                    (
+                        await session.execute(
+                            select(Issue).where(Issue.series_id == sid).order_by(Issue.issue_number)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                assert [issue.status for issue in issues] == [
+                    IssueStatus.SKIPPED,
+                    IssueStatus.OWNED,
+                ]
+
+    @pytest.mark.asyncio
+    async def test_bulk_monitor_preserves_manual_skips(
+        self,
+        client: AsyncClient,
+        _db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = await _seed_series(_db_factory, count=1, monitored=False)
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            issue.manual_skip = True
+            await session.commit()
+
+        resp = await client.patch(
+            "/api/v1/series/bulk",
+            json={"series_ids": ids, "monitored": True},
+        )
+
+        assert resp.status_code == 200
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            assert issue.status == IssueStatus.SKIPPED
+            assert issue.manual_skip is True
+
+    @pytest.mark.asyncio
+    async def test_bulk_monitor_repairs_skipped_issue_when_series_is_already_monitored(
+        self,
+        client: AsyncClient,
+        _db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = await _seed_series(_db_factory, count=1, monitored=True)
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            issue.status = IssueStatus.SKIPPED
+            await session.commit()
+
+        resp = await client.patch(
+            "/api/v1/series/bulk",
+            json={"series_ids": ids, "monitored": True},
+        )
+
+        assert resp.status_code == 200
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            assert issue.status == IssueStatus.WANTED
+
+    @pytest.mark.asyncio
+    async def test_bulk_unmonitor_repairs_wanted_issue_when_series_is_already_unmonitored(
+        self,
+        client: AsyncClient,
+        _db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = await _seed_series(_db_factory, count=1, monitored=False)
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            issue.status = IssueStatus.WANTED
+            await session.commit()
+
+        resp = await client.patch(
+            "/api/v1/series/bulk",
+            json={"series_ids": ids, "monitored": False},
+        )
+
+        assert resp.status_code == 200
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            assert issue.status == IssueStatus.SKIPPED
+
+    @pytest.mark.asyncio
+    async def test_bulk_unmonitor_skips_downloading_issues(
+        self,
+        client: AsyncClient,
+        _db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ids = await _seed_series(_db_factory, count=1, monitored=True)
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            issue.status = IssueStatus.DOWNLOADING
+            await session.commit()
+
+        resp = await client.patch(
+            "/api/v1/series/bulk",
+            json={"series_ids": ids, "monitored": False},
+        )
+
+        assert resp.status_code == 200
+        async with _db_factory() as session:
+            issue = (
+                await session.execute(
+                    select(Issue).where(Issue.series_id == ids[0], Issue.issue_number == 1.0)
+                )
+            ).scalar_one()
+            assert issue.status == IssueStatus.SKIPPED
 
     @pytest.mark.asyncio
     async def test_nonexistent_series_skipped(
@@ -326,15 +499,30 @@ class TestBulkMonitorUpdate:
         assert resp.status_code == 422
 
     @pytest.mark.asyncio
-    async def test_over_max_returns_422(
+    async def test_all_results_sized_update_is_accepted(
         self,
         client: AsyncClient,
     ) -> None:
-        """More than 100 IDs returns 422."""
+        """Selecting more than one page of series remains a valid bulk update."""
         resp = await client.patch(
             "/api/v1/series/bulk",
             json={"series_ids": list(range(1, 102)), "monitored": True},
         )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"updated": 0, "skipped": 101}
+
+    @pytest.mark.asyncio
+    async def test_over_safety_max_returns_422(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        """Unreasonably large bulk payloads retain a defensive upper bound."""
+        resp = await client.patch(
+            "/api/v1/series/bulk",
+            json={"series_ids": list(range(1, 10_002)), "monitored": True},
+        )
+
         assert resp.status_code == 422
 
 

--- a/tests/e2e/test_search_history_page.py
+++ b/tests/e2e/test_search_history_page.py
@@ -174,6 +174,30 @@ class TestSearchHistoryPage:
             diagnostics_toggle.click()
             diagnostics_panel.wait_for(state="visible")
 
+    def test_search_history_poll_pauses_while_detail_is_expanded(
+        self,
+        authed_page,
+        seeded_server: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        search_history = SearchHistoryPage(authed_page, seeded_server)
+        search_history.goto()
+
+        assert authed_page.evaluate("() => window.searchHistoryRefreshEnabled()") is True
+
+        search_history.first_detail_toggle.click()
+        search_history.first_detail_row.wait_for(state="visible", timeout=5000)
+        authed_page.wait_for_function(
+            "() => window.searchHistoryRefreshEnabled() === false",
+            timeout=5000,
+        )
+
+        search_history.first_detail_toggle.click()
+        search_history.first_detail_row.wait_for(state="hidden", timeout=5000)
+        authed_page.wait_for_function(
+            "() => window.searchHistoryRefreshEnabled() === true",
+            timeout=5000,
+        )
+
     def test_search_history_remembered_detail_reloads_after_navigation(
         self,
         authed_page,

--- a/tests/e2e/test_series_page.py
+++ b/tests/e2e/test_series_page.py
@@ -7,7 +7,7 @@ from urllib.parse import parse_qs, urlparse
 
 import pytest
 
-from tests.e2e.conftest import wait_for_htmx
+from tests.e2e.conftest import _run_async_blocking, wait_for_htmx
 from tests.e2e.pages.series_list import SeriesListPage
 
 pytestmark = pytest.mark.e2e
@@ -31,6 +31,49 @@ def _wait_for_animation_frames(page, count: int = 3) -> None:  # type: ignore[no
             step(count);
         })""",
         count,
+    )
+
+
+async def _set_series_catalog_state(title: str, state: str) -> None:
+    from sqlalchemy import select
+
+    from pullbox.database import get_session_factory
+    from pullbox.models.series import IssueCatalogState, Series
+
+    factory = get_session_factory()
+    async with factory() as session:
+        series = (await session.execute(select(Series).where(Series.title == title))).scalar_one()
+        series.issue_catalog_state = IssueCatalogState(state)
+        await session.commit()
+
+
+def _trigger_series_catalog_refresh(page) -> None:  # type: ignore[no-untyped-def]
+    page.evaluate(
+        """() => new Promise((resolve, reject) => {
+            const target = document.querySelector("#series-results-body");
+            if (!target || !window.htmx) {
+                reject(new Error("Series results or HTMX was unavailable"));
+                return;
+            }
+
+            target.__pbSelectionRefreshSentinel = true;
+            const timeout = window.setTimeout(() => {
+                reject(new Error("Series catalog refresh did not settle"));
+            }, 5000);
+
+            window.htmx.ajax("GET", target.getAttribute("hx-get"), {
+                source: target,
+                target,
+                select: "#series-results-body",
+                swap: target.getAttribute("hx-swap"),
+            }).then(() => {
+                window.clearTimeout(timeout);
+                resolve();
+            }).catch((error) => {
+                window.clearTimeout(timeout);
+                reject(error);
+            });
+        })"""
     )
 
 
@@ -942,6 +985,33 @@ class TestSeriesPage:
 
         assert series.query_param("page") == "2"
         assert authed_page.locator("#series-results-body").count() == 1
+
+    @pytest.mark.parametrize("view", ["list", "grid"])
+    def test_catalog_refresh_preserves_series_selection(
+        self,
+        authed_page,
+        seeded_server: str,  # type: ignore[no-untyped-def]
+        view: str,
+    ) -> None:
+        _run_async_blocking(_set_series_catalog_state("Batman", "hydrating"))
+        try:
+            series = SeriesListPage(authed_page, seeded_server)
+            series.goto("q=Batman&per_page=25", preferred_view=view)
+            assert series.results_body.get_attribute("hx-swap") == "morph:outerHTML"
+
+            series.toggle_row_selection("Batman")
+            assert series.selected_count_text() == "1 selected"
+            assert series.row_is_selected("Batman")
+
+            _trigger_series_catalog_refresh(authed_page)
+
+            assert series.selected_count_text() == "1 selected"
+            assert series.row_is_selected("Batman")
+            assert authed_page.evaluate(
+                "() => document.querySelector('#series-results-body').__pbSelectionRefreshSentinel === true"
+            )
+        finally:
+            _run_async_blocking(_set_series_catalog_state("Batman", "complete"))
 
     def test_pagination_returns_viewport_to_results_top_in_grid_view(
         self,

--- a/tests/e2e/test_series_page.py
+++ b/tests/e2e/test_series_page.py
@@ -928,6 +928,21 @@ class TestSeriesPage:
         assert series.footer.is_visible()
         assert series.results_body.is_visible()
 
+    def test_pagination_replaces_results_body_without_nesting_duplicate_ids(
+        self,
+        authed_page,
+        seeded_server: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        series = SeriesListPage(authed_page, seeded_server)
+        series.goto("per_page=2")
+
+        assert authed_page.locator("#series-results-body").count() == 1
+
+        series.click_next_page()
+
+        assert series.query_param("page") == "2"
+        assert authed_page.locator("#series-results-body").count() == 1
+
     def test_pagination_returns_viewport_to_results_top_in_grid_view(
         self,
         authed_page,

--- a/tests/providers/test_newznab.py
+++ b/tests/providers/test_newznab.py
@@ -118,13 +118,12 @@ class TestSearch:
             {"t": "search", "q": "Annual Special 1.5"}
         )
 
-    async def test_search_returns_empty_list_when_request_fails(self) -> None:
+    async def test_search_propagates_request_failure(self) -> None:
         indexer = _make_indexer()
         indexer._request = AsyncMock(side_effect=NewznabError("timeout"))  # type: ignore[method-assign]
 
-        results = await indexer.search(SearchQuery(series_title="Batman", issue_number=1.0))
-
-        assert results == []
+        with pytest.raises(NewznabError, match="timeout"):
+            await indexer.search(SearchQuery(series_title="Batman", issue_number=1.0))
 
     async def test_search_returns_empty_list_for_malformed_xml(self) -> None:
         indexer = _make_indexer()

--- a/tests/providers/test_prowlarr.py
+++ b/tests/providers/test_prowlarr.py
@@ -187,13 +187,12 @@ class TestSearch:
             timeout=45.0,
         )
 
-    async def test_search_returns_empty_list_when_prowlarr_errors(self) -> None:
+    async def test_search_propagates_prowlarr_error(self) -> None:
         indexer = _make_indexer()
         indexer._api_request = AsyncMock(side_effect=ProwlarrError("down"))  # type: ignore[method-assign]
 
-        results = await indexer.search(SearchQuery(series_title="Batman"))
-
-        assert results == []
+        with pytest.raises(ProwlarrError, match="down"):
+            await indexer.search(SearchQuery(series_title="Batman"))
 
 
 @pytest.mark.asyncio

--- a/tests/ui/test_search_history_shell_ui_routes.py
+++ b/tests/ui/test_search_history_shell_ui_routes.py
@@ -294,7 +294,10 @@ class TestSearchHistoryShellRouteContracts:
 
         assert response.status_code == 200
         assert 'hx-get="/search-history"' in response.text
-        assert 'hx-trigger="every 2s"' in response.text
+        assert 'hx-trigger="every 2s [window.searchHistoryRefreshEnabled()]"' in response.text
         assert 'hx-sync="this:replace"' in response.text
+        assert (
+            "x-bind:data-search-history-expanded=\"expanded ? 'true' : 'false'\"" in response.text
+        )
         assert "Searching" in response.text
         assert "Search is still running for this issue." not in response.text

--- a/tests/ui/test_series_ui_routes.py
+++ b/tests/ui/test_series_ui_routes.py
@@ -446,6 +446,8 @@ class TestSeriesRouteContracts:
         assert 'data-testid="series-catalog-state-badge"' in response.text
         assert 'data-catalog-refresh-active="true"' in response.text
         assert 'hx-trigger="every 10s"' in response.text
+        assert 'hx-push-url="false"' in response.text
+        assert 'hx-sync="#series-results-body:replace"' in response.text
         assert "Metadata syncing" in response.text
 
     async def test_series_grid_surfaces_catalog_sync_state(

--- a/tests/ui/test_series_ui_routes.py
+++ b/tests/ui/test_series_ui_routes.py
@@ -446,9 +446,19 @@ class TestSeriesRouteContracts:
         assert 'data-testid="series-catalog-state-badge"' in response.text
         assert 'data-catalog-refresh-active="true"' in response.text
         assert 'hx-trigger="every 10s"' in response.text
+        assert 'hx-swap="morph:outerHTML"' in response.text
         assert 'hx-push-url="false"' in response.text
         assert 'hx-sync="#series-results-body:replace"' in response.text
         assert "Metadata syncing" in response.text
+
+        fragment_response = await authenticated_client.get(
+            "/series?q=Batman",
+            headers={"HX-Request": "true"},
+        )
+
+        assert fragment_response.status_code == 200
+        assert 'data-catalog-refresh-active="true"' in fragment_response.text
+        assert 'hx-swap="morph:outerHTML"' in fragment_response.text
 
     async def test_series_grid_surfaces_catalog_sync_state(
         self,

--- a/tests/ui/test_series_ui_routes.py
+++ b/tests/ui/test_series_ui_routes.py
@@ -132,6 +132,44 @@ def _extract_pagination_urls(markup: str) -> list[str]:
     return [html.unescape(url) for url in re.findall(pattern, markup)]
 
 
+def _extract_series_titles(markup: str) -> list[str]:
+    pattern = r'data-testid="series-item-link"[^>]*>\s*([^<]+)</a>'
+    return [html.unescape(title.strip()) for title in re.findall(pattern, markup)]
+
+
+@pytest.fixture
+async def seeded_series_sort_ties(sec_db, seeded_series_ui_data) -> None:  # type: ignore[no-untyped-def]
+    """Seed equal-key rows in reverse title order to expose unstable sorting."""
+    from pullbox.models.library import LibraryRoot
+    from pullbox.models.publisher import Publisher
+    from pullbox.models.series import Series, SeriesStatus, SeriesType
+
+    async with sec_db() as session:
+        publisher = (
+            await session.execute(select(Publisher).where(Publisher.name == "DC Comics"))
+        ).scalar_one()
+        root = (
+            await session.execute(select(LibraryRoot).where(LibraryRoot.name == "UI Test Library"))
+        ).scalar_one()
+        tied_at = datetime(2035, 1, 1, tzinfo=UTC)
+        for title in ("Zulu Sort Tie", "Alpha Sort Tie"):
+            session.add(
+                Series(
+                    title=title,
+                    sort_title=title.lower(),
+                    year_start=2035,
+                    created_at=tied_at,
+                    status=SeriesStatus.ENDED,
+                    monitored=False,
+                    issue_count=0,
+                    publisher_id=publisher.id,
+                    library_root_id=root.id,
+                    series_type=SeriesType.ANNUAL,
+                )
+            )
+        await session.commit()
+
+
 class SelectRecorder:
     """Capture SELECT statements emitted by the test app engine."""
 
@@ -1465,6 +1503,47 @@ class TestSeriesRouteContracts:
         assert all(query.get("monitored") == ["true"] for query in parsed)
         assert all(query.get("sort") == ["-title"] for query in parsed)
         assert all(query.get("per_page") == ["1"] for query in parsed)
+
+    @pytest.mark.parametrize(
+        "sort",
+        [
+            "date_added",
+            "-date_added",
+            "year",
+            "-year",
+            "publisher",
+            "-publisher",
+            "issues",
+            "-issues",
+            "series_type",
+            "-series_type",
+            "status",
+        ],
+    )
+    async def test_grouped_sorts_use_title_tiebreakers(
+        self,
+        authenticated_client,
+        seeded_series_sort_ties,
+        sort: str,
+    ) -> None:  # type: ignore[no-untyped-def]
+        response = await authenticated_client.get(f"/series?sort={sort}&per_page=100")
+
+        assert response.status_code == 200
+        titles = _extract_series_titles(response.text)
+        assert titles.index("Alpha Sort Tie") < titles.index("Zulu Sort Tie")
+
+    async def test_year_sort_is_deterministic_across_page_boundaries(
+        self,
+        authenticated_client,
+        seeded_series_sort_ties,
+    ) -> None:  # type: ignore[no-untyped-def]
+        first_page = await authenticated_client.get("/series?sort=-year&per_page=1&page=1")
+        second_page = await authenticated_client.get("/series?sort=-year&per_page=1&page=2")
+
+        assert first_page.status_code == 200
+        assert second_page.status_code == 200
+        assert _extract_series_titles(first_page.text) == ["Alpha Sort Tie"]
+        assert _extract_series_titles(second_page.text) == ["Zulu Sort Tie"]
 
     async def test_empty_state_renders_inside_mounted_results_contract(
         self,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -23,6 +23,12 @@ pytest_plugins = ["conftest_security"]
 os.environ.setdefault("PULLBOX_SECRET_KEY", "test-secret-key-for-settings-ui")
 
 
+def _script_block(html: str, start_marker: str, end_marker: str) -> str:
+    start = html.index(start_marker)
+    end = html.index(end_marker, start)
+    return html[start:end]
+
+
 @pytest.mark.asyncio
 class TestSettingsRouteContracts:
     """Verify the settings area renders a stable mounted shell."""
@@ -162,6 +168,22 @@ class TestSettingsRouteContracts:
         assert response.status_code == 200
         assert "const stored = '" not in response.text
         assert "\\u0027; window.__pullboxXss = true; //" in response.text
+
+    async def test_settings_indexer_bulk_tests_are_serialized_to_avoid_write_storm(
+        self,
+        authenticated_client,
+    ) -> None:  # type: ignore[no-untyped-def]
+        response = await authenticated_client.get("/settings?tab=indexers")
+
+        assert response.status_code == 200
+        block = _script_block(
+            response.text,
+            "    async testIndexerConnection(indexerId) {",
+            "    // ── Prowlarr",
+        )
+        assert "Promise.all(" not in block
+        assert "for (const idx of indexers)" in block
+        assert "await this.testIndexerConnection(idx.id)" in block
 
     async def test_settings_media_naming_preview_escapes_template_values_and_results(
         self,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -232,6 +232,17 @@ class TestSettingsRouteContracts:
         assert "escapeHtml(ex.input || '')" in response.text
         assert "escapeHtml(ex.output || '')" in response.text
 
+    async def test_settings_media_import_save_uses_enabled_pointer_cursor(
+        self,
+        authenticated_client,
+    ) -> None:  # type: ignore[no-untyped-def]
+        response = await authenticated_client.get("/settings?tab=media")
+
+        assert response.status_code == 200
+        assert (
+            ":class=\"isDirty ? 'cursor-pointer' : 'opacity-50 cursor-not-allowed'\""
+        ) in response.text
+
     async def test_settings_media_naming_previews_use_stable_panel_contract(
         self,
         authenticated_client,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -200,6 +200,19 @@ class TestSettingsRouteContracts:
         assert "Promise.all(" not in block
         assert "for (const idx of indexers)" in block
         assert "await this.testIndexerConnection(idx.id)" in block
+        assert (
+            ".then(indexers => this.runIndexerChecksSequentially("
+            "indexers.filter(idx => idx.enabled)))"
+        ) in block
+
+    async def test_settings_indexers_do_not_run_connection_tests_on_page_load(
+        self,
+        authenticated_client,
+    ) -> None:  # type: ignore[no-untyped-def]
+        response = await authenticated_client.get("/settings?tab=indexers")
+
+        assert response.status_code == 200
+        assert "_silentTestAll" not in response.text
 
     async def test_settings_media_naming_preview_escapes_template_values_and_results(
         self,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -92,6 +92,22 @@ class TestSettingsRouteContracts:
         assert 'placeholder="/downloads"' in response.text
         assert 'placeholder="/data/downloads"' in response.text
 
+    async def test_settings_client_bulk_tests_are_serialized_to_avoid_write_storm(
+        self,
+        authenticated_client,
+    ) -> None:  # type: ignore[no-untyped-def]
+        response = await authenticated_client.get("/settings?tab=clients")
+
+        assert response.status_code == 200
+        block = _script_block(
+            response.text,
+            "    async testClientConnection(clientId) {",
+            "    saveConfig(formEl)",
+        )
+        assert "Promise.all(" not in block
+        assert "for (const client of clients)" in block
+        assert "await this.testClientConnection(client.id)" in block
+
     async def test_settings_metadata_is_minimal_and_shows_last_five_key_chars(
         self,
         authenticated_client,

--- a/tests/ui/test_system_shell_ui_routes.py
+++ b/tests/ui/test_system_shell_ui_routes.py
@@ -230,7 +230,7 @@ class TestSystemRouteContracts:
         assert logs.status_code == 200
 
         assert 'data-testid="system-tasks-table"' in tasks.text
-        assert 'class="downloads-table-wrap"' in tasks.text
+        assert 'class="downloads-table-wrap is-clipped"' in tasks.text
         assert 'role="region"' in tasks.text
         assert 'aria-label="Scheduled tasks table"' in tasks.text
         assert 'tabindex="0"' in tasks.text

--- a/tests/unit/test_blocklist_filtering.py
+++ b/tests/unit/test_blocklist_filtering.py
@@ -14,9 +14,11 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import pytest
+from sqlalchemy import event
 
 from pullbox.models.blocklist import BlocklistReason
 from pullbox.models.config import SystemConfig
+from pullbox.models.indexer import IndexerConfig, IndexerType
 from pullbox.providers.base import ReleaseResult
 from pullbox.services.blocklist_service import BlocklistService
 
@@ -277,6 +279,49 @@ class TestFilterResultsByTitle:
         original_len = len(results)
         await svc.filter_results(db_session, results)
         assert len(results) == original_len
+
+    async def test_does_not_autoflush_unrelated_indexer_health_updates(
+        self, db_session: AsyncSession, svc: BlocklistService
+    ) -> None:
+        indexer = IndexerConfig(
+            name="NZBgeek",
+            indexer_type=IndexerType.NEWZNAB,
+            url="https://example.test/newznab",
+            api_key="encrypted-test-key",
+            enabled=True,
+            priority=25,
+            failure_count=1,
+        )
+        db_session.add(indexer)
+        await db_session.commit()
+        indexer.failure_count = 0
+        indexer.last_success_at = datetime.now(UTC)
+
+        statements: list[str] = []
+
+        def _record_statement(
+            _conn: object,
+            _cursor: object,
+            statement: str,
+            _parameters: object,
+            _context: object,
+            _executemany: bool,
+        ) -> None:
+            statements.append(statement)
+
+        engine = db_session.bind
+        assert engine is not None
+        event.listen(engine.sync_engine, "before_cursor_execute", _record_statement)
+        try:
+            filtered = await svc.filter_results(db_session, [_make_release("Saga.073.2026")])
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", _record_statement)
+
+        assert len(filtered) == 1
+        assert not any(
+            statement.lstrip().upper().startswith("UPDATE INDEXER_CONFIGS")
+            for statement in statements
+        )
 
 
 @pytest.mark.slow

--- a/tests/unit/test_comicvine_provider.py
+++ b/tests/unit/test_comicvine_provider.py
@@ -307,6 +307,7 @@ async def test_request_maps_comicvine_status_errors(
         await provider._client.aclose()
 
     assert exc_info.value.status_code == expected_status
+    assert exc_info.value.retryable is (expected_status == 107)
 
 
 @pytest.mark.asyncio
@@ -327,6 +328,28 @@ async def test_request_maps_http_404_to_not_found_error() -> None:
         await provider._client.aclose()
 
     assert exc_info.value.status_code == 101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [420, 429, 503])
+async def test_request_preserves_retryable_http_status(status_code: int) -> None:
+    provider = ComicVineProvider(api_key="http-test-key", rate_limit=999_999)
+    response = _make_response(status_code=status_code)
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "provider unavailable",
+        request=MagicMock(),
+        response=response,
+    )
+    provider._client.get = AsyncMock(return_value=response)  # type: ignore[method-assign]
+
+    try:
+        with pytest.raises(ComicVineError, match=f"HTTP {status_code}") as exc_info:
+            await provider._request("/issue/4000-123/")
+    finally:
+        await provider._client.aclose()
+
+    assert exc_info.value.status_code == status_code
+    assert exc_info.value.retryable is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_import_comicinfo_enrichment.py
+++ b/tests/unit/test_import_comicinfo_enrichment.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from pullbox.core.exceptions import ProviderError
 from pullbox.models.import_job import (
     ImportedFile,
     ImportedFileStatus,
@@ -124,10 +125,12 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         *,
         source_path: Path | None = None,
         defer_issue_enrichment: bool = False,
+        propagate_retryable_provider_errors: bool = False,
     ) -> dict[str, Any]:
         nonlocal build_calls, payload_session
         assert source_path == archive_path
         assert defer_issue_enrichment is False
+        assert propagate_retryable_provider_errors is True
         build_calls += 1
         payload_session = session
         issue.description = "Refreshed ComicVine summary."
@@ -291,6 +294,61 @@ async def test_locked_pending_file_does_not_stop_later_enrichment(
 
 
 @pytest.mark.asyncio
+async def test_retryable_provider_error_stops_enrichment_and_leaves_queue_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def load_pending_ids(_factory: object, *, job_id: int) -> list[int]:
+        assert job_id == 7
+        return [101, 202]
+
+    prepared_ids: list[int] = []
+
+    async def prepare_pending(
+        _factory: object,
+        *,
+        imported_file_id: int,
+        build_comicinfo_payload: object,
+    ) -> PreparedComicInfoEnrichment | None:
+        _ = build_comicinfo_payload
+        prepared_ids.append(imported_file_id)
+        raise ProviderError(
+            "comicvine",
+            "HTTP 420: /issue/4000-1234/",
+            details={"status_code": 420, "retryable": True},
+        )
+
+    async def should_not_mark_failed(*_args: object, **_kwargs: object) -> bool:
+        raise AssertionError("retryable enrichment must remain pending")
+
+    monkeypatch.setattr(enrichment_module, "_load_pending_imported_file_ids", load_pending_ids)
+    monkeypatch.setattr(
+        enrichment_module,
+        "_prepare_pending_imported_file_with_retry",
+        prepare_pending,
+    )
+    monkeypatch.setattr(enrichment_module, "_mark_pending_file_failed", should_not_mark_failed)
+
+    def should_not_apply(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("partial ComicInfo must not be applied")
+
+    async def unused_build_payload(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        raise AssertionError("preparation was replaced for this control-flow test")
+
+    async def unused_log_event(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("no durable file event is expected")
+
+    await run_import_comicinfo_enrichment(
+        object(),  # type: ignore[arg-type]
+        job_id=7,
+        build_comicinfo_payload=unused_build_payload,
+        apply_comicinfo=should_not_apply,
+        log_event=unused_log_event,
+    )
+
+    assert prepared_ids == [101]
+
+
+@pytest.mark.asyncio
 async def test_run_pending_import_comicinfo_enrichment_recovers_completed_jobs_after_restart(
     async_engine,
     tmp_path: Path,
@@ -414,9 +472,11 @@ async def test_run_pending_import_comicinfo_enrichment_recovers_completed_jobs_a
         *,
         source_path: Path | None = None,
         defer_issue_enrichment: bool = False,
+        propagate_retryable_provider_errors: bool = False,
     ) -> dict[str, Any]:
         _ = session, issue, source_path
         assert defer_issue_enrichment is False
+        assert propagate_retryable_provider_errors is True
         return {"Series": "Recovered Series", "Number": "1"}
 
     def apply_comicinfo(artifact_path: Path, payload: dict[str, Any]) -> None:

--- a/tests/unit/test_import_comicinfo_enrichment.py
+++ b/tests/unit/test_import_comicinfo_enrichment.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sqlite3
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from pullbox.models.import_job import (
@@ -18,7 +20,9 @@ from pullbox.models.import_job import (
 from pullbox.models.issue import Issue, IssueStatus, IssueType
 from pullbox.models.library import FileFormat, LibraryFile, LibraryRoot, MatchConfidence
 from pullbox.models.series import Series
+from pullbox.services import import_comicinfo_enrichment as enrichment_module
 from pullbox.services.import_comicinfo_enrichment import (
+    PreparedComicInfoEnrichment,
     run_import_comicinfo_enrichment,
     run_pending_import_comicinfo_enrichment,
 )
@@ -31,6 +35,7 @@ if TYPE_CHECKING:
 async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
     async_engine,
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     session_factory = async_sessionmaker(async_engine, expire_on_commit=False)
     archive_path = tmp_path / "King Dracula 004.cbz"
@@ -110,6 +115,9 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         issue_id = issue.id
         imported_file_id = imported_file.id
 
+    payload_session: AsyncSession | None = None
+    build_calls = 0
+
     async def build_payload(
         session: AsyncSession,
         issue: Issue,
@@ -117,8 +125,11 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         source_path: Path | None = None,
         defer_issue_enrichment: bool = False,
     ) -> dict[str, Any]:
+        nonlocal build_calls, payload_session
         assert source_path == archive_path
         assert defer_issue_enrichment is False
+        build_calls += 1
+        payload_session = session
         issue.description = "Refreshed ComicVine summary."
         issue.release_date = date(2026, 6, 17)
         issue.comicvine_url = "https://comicvine.gamespot.com/king-dracula-4/4000-1234567/"
@@ -132,6 +143,8 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
     applied: list[tuple[Path, dict[str, Any]]] = []
 
     def apply_comicinfo(artifact_path: Path, payload: dict[str, Any]) -> None:
+        assert payload_session is not None
+        assert not payload_session.in_transaction()
         applied.append((artifact_path, dict(payload)))
         artifact_path.write_text("updated archive")
 
@@ -148,6 +161,23 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
     ) -> None:
         _ = session, job_id, level, message, details
         log_events.append(event)
+
+    original_commit = AsyncSession.commit
+    lock_injected = False
+
+    async def commit_with_one_transient_lock(session: AsyncSession) -> None:
+        nonlocal lock_injected
+        if build_calls == 1 and not lock_injected:
+            lock_injected = True
+            raise OperationalError(
+                "UPDATE issues",
+                {},
+                sqlite3.OperationalError("database is locked"),
+            )
+        await original_commit(session)
+
+    monkeypatch.setattr(AsyncSession, "commit", commit_with_one_transient_lock)
+    monkeypatch.setattr(enrichment_module, "sqlite_lock_retry_delay", lambda _attempt: 0.0)
 
     await run_import_comicinfo_enrichment(
         session_factory,
@@ -169,6 +199,8 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         )
     ]
     assert "import_file_comicinfo_enrichment_completed" in log_events
+    assert lock_injected is True
+    assert build_calls == 2
     async with session_factory() as session:
         imported_file = await session.get(ImportedFile, imported_file_id)
         issue = await session.get(Issue, issue_id)
@@ -177,6 +209,85 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         assert imported_file.diagnostics["comicinfo_enrichment"]["status"] == "complete"
         assert imported_file.diagnostics["comicinfo_enrichment"]["library_file_id"] is not None
         assert issue.description == "Refreshed ComicVine summary."
+
+
+@pytest.mark.asyncio
+async def test_locked_pending_file_does_not_stop_later_enrichment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    later_archive = tmp_path / "Later Issue.cbz"
+    later_archive.write_text("archive")
+    prepared = PreparedComicInfoEnrichment(
+        artifact_path=later_archive,
+        payload={"Series": "Later Series", "Number": "2"},
+        library_file_id=22,
+        library_file_name=later_archive.name,
+        issue_id=202,
+        issue_cv_id=2002,
+    )
+
+    async def load_pending_ids(_factory: object, *, job_id: int) -> list[int]:
+        assert job_id == 7
+        return [101, 202]
+
+    async def prepare_pending(
+        _factory: object,
+        *,
+        imported_file_id: int,
+        build_comicinfo_payload: object,
+    ) -> PreparedComicInfoEnrichment | None:
+        _ = build_comicinfo_payload
+        return None if imported_file_id == 101 else prepared
+
+    completed: list[int] = []
+
+    async def mark_complete(
+        _factory: object,
+        *,
+        job_id: int,
+        imported_file_id: int,
+        prepared: PreparedComicInfoEnrichment,
+        log_event: object,
+    ) -> bool:
+        _ = job_id, prepared, log_event
+        completed.append(imported_file_id)
+        return True
+
+    monkeypatch.setattr(enrichment_module, "_load_pending_imported_file_ids", load_pending_ids)
+    monkeypatch.setattr(
+        enrichment_module,
+        "_prepare_pending_imported_file_with_retry",
+        prepare_pending,
+    )
+    monkeypatch.setattr(
+        enrichment_module,
+        "_mark_pending_file_complete_with_retry",
+        mark_complete,
+    )
+
+    applied: list[Path] = []
+
+    def apply_comicinfo(path: Path, payload: dict[str, Any]) -> None:
+        assert payload == {"Series": "Later Series", "Number": "2"}
+        applied.append(path)
+
+    async def unused_build_payload(*_args: object, **_kwargs: object) -> dict[str, Any]:
+        raise AssertionError("preparation was replaced for this control-flow test")
+
+    async def unused_log_event(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("completion persistence was replaced for this test")
+
+    await run_import_comicinfo_enrichment(
+        object(),  # type: ignore[arg-type]
+        job_id=7,
+        build_comicinfo_payload=unused_build_payload,
+        apply_comicinfo=apply_comicinfo,
+        log_event=unused_log_event,
+    )
+
+    assert applied == [later_archive]
+    assert completed == [202]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_import_comicinfo_metadata.py
+++ b/tests/unit/test_import_comicinfo_metadata.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 from sqlalchemy.exc import OperationalError
 
+from pullbox.core.exceptions import ProviderError
 from pullbox.models.issue import Issue
 from pullbox.services.import_comicinfo_metadata import (
     enrich_issue_for_comicinfo,
@@ -51,3 +52,46 @@ async def test_enrich_issue_propagates_sqlite_lock_for_outer_retry(
             issue,
             metadata_service=metadata_service,
         )
+
+
+@pytest.mark.asyncio
+async def test_enrich_issue_propagates_retryable_provider_error_when_required(
+    db_session: AsyncSession,
+) -> None:
+    issue = Issue(comicvine_id=1234)
+    provider_error = ProviderError(
+        "comicvine",
+        "HTTP 420: /issue/4000-1234/",
+        details={"status_code": 420, "retryable": True},
+    )
+    metadata_service = AsyncMock()
+    metadata_service.fetch_issue.side_effect = provider_error
+
+    with pytest.raises(ProviderError, match="HTTP 420"):
+        await enrich_issue_for_comicinfo(
+            db_session,
+            issue,
+            metadata_service=metadata_service,
+            propagate_retryable_provider_errors=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_enrich_issue_still_tolerates_retryable_provider_error_by_default(
+    db_session: AsyncSession,
+) -> None:
+    issue = Issue(comicvine_id=1234)
+    metadata_service = AsyncMock()
+    metadata_service.fetch_issue.side_effect = ProviderError(
+        "comicvine",
+        "HTTP 420: /issue/4000-1234/",
+        details={"status_code": 420, "retryable": True},
+    )
+
+    enriched = await enrich_issue_for_comicinfo(
+        db_session,
+        issue,
+        metadata_service=metadata_service,
+    )
+
+    assert enriched is issue

--- a/tests/unit/test_import_comicinfo_metadata.py
+++ b/tests/unit/test_import_comicinfo_metadata.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 from datetime import date
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from pullbox.models.issue import Issue
-from pullbox.services.import_comicinfo_metadata import issue_needs_comicinfo_enrichment
+from pullbox.services.import_comicinfo_metadata import (
+    enrich_issue_for_comicinfo,
+    issue_needs_comicinfo_enrichment,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,3 +30,24 @@ async def test_issue_needs_comicinfo_enrichment_skips_complete_transient_issue(
     )
 
     assert await issue_needs_comicinfo_enrichment(db_session, issue) is False
+
+
+@pytest.mark.asyncio
+async def test_enrich_issue_propagates_sqlite_lock_for_outer_retry(
+    db_session: AsyncSession,
+) -> None:
+    issue = Issue(comicvine_id=1234)
+    lock_error = OperationalError(
+        "UPDATE issues SET description = ?",
+        {},
+        Exception("database is locked"),
+    )
+    metadata_service = AsyncMock()
+    metadata_service.fetch_issue.side_effect = lock_error
+
+    with pytest.raises(OperationalError, match="database is locked"):
+        await enrich_issue_for_comicinfo(
+            db_session,
+            issue,
+            metadata_service=metadata_service,
+        )

--- a/tests/unit/test_refresh_series_metadata.py
+++ b/tests/unit/test_refresh_series_metadata.py
@@ -167,6 +167,20 @@ async def test_metadata_fetch_wrappers_translate_comicvine_errors(
         await getattr(service, method_name)(*args)
 
 
+@pytest.mark.asyncio
+async def test_fetch_issue_preserves_retryable_provider_details() -> None:
+    provider = MagicMock()
+    provider.get_issue = AsyncMock(
+        side_effect=ComicVineError(420, "HTTP 420: /issue/4000-123/", retryable=True)
+    )
+    service = MetadataService(provider=provider, covers_dir=MagicMock())
+
+    with pytest.raises(ProviderError, match="HTTP 420") as exc_info:
+        await service.fetch_issue(MagicMock(), 123)
+
+    assert exc_info.value.details == {"status_code": 420, "retryable": True}
+
+
 class TestRefreshSeries:
     """Tests for MetadataService.refresh_series."""
 

--- a/tests/unit/test_search_indexer_timing.py
+++ b/tests/unit/test_search_indexer_timing.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pullbox.models.indexer import IndexerConfig, IndexerType
 from pullbox.providers.base import ProviderRegistry, ReleaseResult, SearchQuery
 from pullbox.services.search_indexers import search_indexers
 
@@ -26,6 +27,11 @@ class _FakeIndexer:
 
     async def test_connection(self) -> ProviderHealthResult:
         raise NotImplementedError
+
+
+class _FailingIndexer(_FakeIndexer):
+    async def search(self, query: SearchQuery) -> list[ReleaseResult]:
+        raise TimeoutError(f"{self.name} timed out")
 
 
 def _release(title: str, *, category: str | None = "7030") -> ReleaseResult:
@@ -79,3 +85,43 @@ async def test_search_indexers_records_per_indexer_timing_diagnostics() -> None:
         }
     ]
     assert isinstance(timings[0]["elapsed_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_search_indexers_records_failure_without_losing_healthy_results() -> None:
+    registry = ProviderRegistry()
+    registry.register_indexer(1, _FailingIndexer("UnavailableIndexer", []))
+    registry.register_indexer(
+        2,
+        _FakeIndexer("HealthyIndexer", [_release("Absolute Flash 001 (2025).cbz")]),
+    )
+    failed_config = IndexerConfig(
+        name="UnavailableIndexer",
+        indexer_type=IndexerType.PROWLARR,
+        url="https://unavailable.example.test",
+        api_key="encrypted",
+        failure_count=0,
+    )
+    healthy_config = IndexerConfig(
+        name="HealthyIndexer",
+        indexer_type=IndexerType.PROWLARR,
+        url="https://healthy.example.test",
+        api_key="encrypted",
+        failure_count=2,
+    )
+    timings: list[dict[str, object]] = []
+
+    results = await search_indexers(
+        registry,
+        SearchQuery(series_title="Absolute Flash #001", issue_number=None),
+        indexer_configs={1: failed_config, 2: healthy_config},
+        timing_collector=timings,
+    )
+
+    assert [result.title for result in results] == ["Absolute Flash 001 (2025).cbz"]
+    assert [timing["status"] for timing in timings] == ["failed", "completed"]
+    assert timings[0]["error"] == "UnavailableIndexer timed out"
+    assert failed_config.failure_count == 1
+    assert failed_config.last_failure_at is not None
+    assert healthy_config.failure_count == 0
+    assert healthy_config.last_success_at is not None

--- a/tests/unit/test_search_task_scheduler_resilience.py
+++ b/tests/unit/test_search_task_scheduler_resilience.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.exc import OperationalError
 
+from pullbox.models.issue import IssueType
 from pullbox.providers.base import ProviderRegistry
+from pullbox.services.search_service import IssueSearchOutcome, IssueSearchTarget
 from pullbox.tasks import search_task
 
 
@@ -53,6 +56,81 @@ class _FakeSessionFactory:
     def __call__(self) -> _FakeSession:
         self.session_count += 1
         return _FakeSession(self)
+
+
+@pytest.mark.asyncio
+async def test_search_series_issues_retries_fanout_after_sqlite_lock(monkeypatch) -> None:
+    """A transient fan-out commit lock must not discard fetched series outcomes."""
+    factory = _FakeSessionFactory()
+    target = IssueSearchTarget(
+        issue_id=123,
+        series_id=456,
+        series_title="Retry Series",
+        issue_number=1.0,
+        issue_type=IssueType.ISSUE,
+        series_year=2026,
+    )
+    outcome = IssueSearchOutcome(
+        target=target,
+        mode="fast",
+        query_count=1,
+        raw_results=[],
+        filtered_results=[],
+        matched=[],
+        rejected=[],
+        best_release=None,
+        best_validation=None,
+        search_details={"results_count": 0},
+        elapsed_ms=1,
+    )
+    runtime = SimpleNamespace(
+        registry=ProviderRegistry(),
+        failure_threshold=3,
+        two_pass_enabled=False,
+        indexer_configs={},
+        eval_kwargs={},
+        validator_kwargs={},
+        source_priority={},
+        type_thresholds={},
+    )
+    search_mock = AsyncMock(return_value=[outcome])
+
+    monkeypatch.setattr(search_task, "get_session_factory", lambda: factory)
+    monkeypatch.setattr(
+        search_task,
+        "_build_task_search_runtime",
+        AsyncMock(return_value=runtime),
+    )
+    monkeypatch.setattr(
+        search_task,
+        "load_series_wanted_search_targets",
+        AsyncMock(return_value=[target]),
+    )
+    monkeypatch.setattr(
+        search_task.SearchService,
+        "search_targets_quick_first",
+        search_mock,
+    )
+    monkeypatch.setattr(
+        search_task,
+        "_persist_bulk_search_log",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(search_task, "_build_download_service", MagicMock())
+    monkeypatch.setattr(search_task, "InterventionService", MagicMock())
+    monkeypatch.setattr(search_task, "sqlite_lock_retry_delay", lambda _attempt: 0.0)
+    monkeypatch.setattr(
+        _FakeSession,
+        "get",
+        AsyncMock(return_value=SimpleNamespace(title="Retry Series", year_start=2026)),
+    )
+
+    result = await search_task.search_series_issues(456)
+
+    assert result == {"wanted": 1, "sent": 0, "queued": 0}
+    assert factory.commit_attempts == 2
+    assert factory.rollback_attempts == 1
+    assert search_mock.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_search_task_shared_runner_paths.py
+++ b/tests/unit/test_search_task_shared_runner_paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,6 +13,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from pullbox.models import Base
 from pullbox.models.config import SystemConfig
+from pullbox.models.indexer import IndexerConfig, IndexerType
 from pullbox.models.issue import Issue, IssueStatus, IssueType
 from pullbox.models.library import MatchConfidence
 from pullbox.models.search_log import SearchLog, SearchType
@@ -120,6 +122,16 @@ async def task_db() -> AsyncGenerator[dict[str, object], None]:
             issue_type=IssueType.ISSUE,
         )
         session.add_all([tpb_issue, wanted_issue])
+        indexer = IndexerConfig(
+            name="NZBgeek",
+            indexer_type=IndexerType.NEWZNAB,
+            url="https://example.test/newznab",
+            api_key="encrypted-test-key",
+            enabled=True,
+            priority=25,
+            failure_count=1,
+        )
+        session.add(indexer)
         session.add(SystemConfig(key="source_priority", value="not-json"))
         await session.commit()
 
@@ -128,6 +140,7 @@ async def task_db() -> AsyncGenerator[dict[str, object], None]:
             "tpb_series_id": tpb_series.id,
             "tpb_issue_id": tpb_issue.id,
             "wanted_issue_id": wanted_issue.id,
+            "indexer_id": indexer.id,
         }
 
     await engine.dispose()
@@ -250,6 +263,70 @@ async def test_search_series_issues_real_path_uses_quick_first_batch_strategy(
     assert search_targets_quick_first.await_args.kwargs["concurrency"] == 1
     mock_download_cls.return_value.send_to_client.assert_awaited_once()
     mock_intervention.create_pending_match.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_search_series_issues_persists_indexer_health_before_download_routing(
+    task_db: dict[str, object],
+) -> None:
+    factory = task_db["factory"]
+    target = IssueSearchTarget(
+        issue_id=task_db["tpb_issue_id"],
+        series_id=task_db["tpb_series_id"],
+        series_title="Search Task TPB",
+        issue_number=1.0,
+        issue_type=IssueType.TPB,
+        issue_title="Vol. 1: Deluxe",
+        series_year=2025,
+    )
+    release = _make_release("Search Task TPB Vol 1")
+    validation = _make_validation(release)
+    outcome = _make_outcome(target, release=release, validation=validation, mode="fast")
+    loaded_indexer: IndexerConfig | None = None
+
+    async def _build_registry(session, **_kwargs):
+        nonlocal loaded_indexer
+        loaded_indexer = await session.get(IndexerConfig, task_db["indexer_id"])
+        assert loaded_indexer is not None
+        return MagicMock(), {loaded_indexer.id: loaded_indexer}
+
+    async def _search_targets(*_args, **_kwargs):
+        assert loaded_indexer is not None
+        loaded_indexer.failure_count = 0
+        loaded_indexer.last_success_at = datetime.now(UTC)
+        return [outcome]
+
+    async def _send_to_client(*_args, **_kwargs):
+        async with factory() as verification_session:
+            persisted = await verification_session.get(IndexerConfig, task_db["indexer_id"])
+            assert persisted is not None
+            assert persisted.failure_count == 0
+            assert persisted.last_success_at is not None
+        return MagicMock()
+
+    with (
+        patch("pullbox.tasks.search_task.get_session_factory", return_value=factory),
+        patch(
+            "pullbox.tasks.search_task.build_registry",
+            new_callable=AsyncMock,
+            side_effect=_build_registry,
+        ),
+        patch(
+            "pullbox.tasks.search_task.SearchService.search_targets_quick_first",
+            new_callable=AsyncMock,
+            side_effect=_search_targets,
+        ),
+        patch("pullbox.tasks.search_task.DownloadService") as mock_download_cls,
+        patch("pullbox.tasks.search_task.InterventionService") as mock_intervention_cls,
+    ):
+        mock_download_cls.return_value.send_to_client = AsyncMock(side_effect=_send_to_client)
+        mock_intervention = mock_intervention_cls.return_value
+        mock_intervention.has_pending_for_issue = AsyncMock(return_value=False)
+        mock_intervention.create_pending_match = AsyncMock()
+
+        result = await search_task.search_series_issues(task_db["tpb_series_id"])
+
+    assert result == {"wanted": 1, "sent": 1, "queued": 0}
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_series_ui_route_branches.py
+++ b/tests/unit/test_series_ui_route_branches.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
 
 from pullbox.models.issue import Issue, IssueStatus
 from pullbox.models.library import FileFormat, LibraryFile, LibraryRoot, MatchConfidence
@@ -50,6 +52,16 @@ def _request(
 
 def _user() -> SimpleNamespace:
     return SimpleNamespace(username="admin")
+
+
+@pytest.mark.parametrize("column", [Series.status, Series.series_type])
+def test_series_enum_sort_expression_casts_before_lowering(column) -> None:  # type: ignore[no-untyped-def]
+    statement = select(Series.id).order_by(series_routes._lower_enum_sort(column))
+
+    compiled = str(statement.compile(dialect=postgresql.dialect()))
+
+    assert "lower(CAST(" in compiled
+    assert f"lower(series.{column.key})" not in compiled
 
 
 async def _config_values(


### PR DESCRIPTION
## Summary
- Hardens download, indexer, metadata, and ComicInfo background workflows against production failures, provider throttling, and SQLite contention.
- Makes bulk monitoring and global series sorting consistent across all result pages.
- Preserves active-page and selection state during metadata hydration, and prevents open search-history details from flashing during live polling.
- Aligns task and settings interactions with established UI contracts.

## Validation
- Added focused API, service, route-contract, and Playwright regressions using the project TDD process.
- Relevant focused suites and commit hooks pass.
- Each production-facing fix was hot-patched and manually verified against the live instance before commit.
- Full required GitHub Actions CI will be enabled after automated review completes.

## Release Intent
- Intended for Pullbox v1.0.5 after merge to develop and the standard release-prep PR to main.