### PR TITLE
Sync develop after v1.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Internal
 
+## [1.0.5] - 2026-07-15
+
+Patch release focused on production reliability under sustained background work
+and large-library metadata synchronization.
+
+### Fixed
+
+- Hardened indexer, download-client, scheduled-search, metadata, and ComicInfo
+  background workflows against remote failures, provider throttling, and SQLite
+  lock contention.
+- Preserved failed and rejected indexer outcomes so retry, intervention, and
+  blocklist handling remain visible instead of silently losing results.
+- Deferred ComicInfo enrichment safely when providers throttle requests, while
+  allowing imports to complete and enrichment to resume later.
+- Made series sorting deterministic across all pages and compatible with native
+  PostgreSQL enum columns.
+- Reconciled issue wanted/skipped states during bulk monitor changes across all
+  selected results.
+- Preserved the active page and selected series during metadata hydration, and
+  stopped expanded search-history details from flashing during live polling.
+- Prevented automatic health checks from probing disabled indexers.
+- Corrected scheduled-task table styling and pointer feedback for enabled import
+  rule saves.
+
 ## [1.0.4] - 2026-07-13
 
 Maintenance release focused on reliable multi-platform publication across

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.5"
+__version__ = "1.0.6-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.0.5-dev"
+__version__ = "1.0.5"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Carries the released `main` history back into `develop`.
- Reopens development at `1.0.6-dev`.

## Validation
- Version-only post-release sync using the documented fast-path shape.
- Commit hooks passed, including lint, formatting, type checking, and fast unit tests.
- `v1.0.5` Docker Release and GitHub Release completed successfully.