### PR TITLE
Release v1.1.1

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -19,17 +19,17 @@ ignore:
   - vulnerability: CVE-2026-14456
     package:
       name: libssl3t64
-      version: 3.5.6-1~deb13u2+dhi1
+      version: 3.5.6-1~deb13u2+dhi2
       type: deb
   - vulnerability: CVE-2026-14456
     package:
       name: openssl
-      version: 3.5.6-1~deb13u2+dhi1
+      version: 3.5.6-1~deb13u2+dhi2
       type: deb
   - vulnerability: CVE-2026-14456
     package:
       name: openssl-provider-legacy
-      version: 3.5.6-1~deb13u2+dhi1
+      version: 3.5.6-1~deb13u2+dhi2
       type: deb
 
   # CPython 3.14.6 binary findings. Grype reports either no fixed version or a
@@ -98,6 +98,18 @@ ignore:
   # The application XML path uses Python's bundled Expat, which the container
   # runtime check requires to be 2.8.1 or newer. The Debian 13 libexpat copy is
   # retained only as the Fontconfig dependency used by Poppler PDF tools.
+  # CVE-2026-66046 is currently marked won't-fix for Debian 13. Retain this
+  # exact DHI exception only until Debian ships a fixed package.
+  - vulnerability: CVE-2026-66046
+    package:
+      name: libexpat1
+      version: 2.8.3-1~deb13u1+dhi2
+      type: deb
+  - vulnerability: CVE-2026-66046
+    package:
+      name: libexpat1-dev
+      version: 2.8.3-1~deb13u1+dhi2
+      type: deb
   - vulnerability: CVE-2025-59375
     package:
       name: libexpat1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-08-23
+
+Patch release improving direct-download reliability for collected issue packs.
+
+### Fixed
+
+- Accept safe, separately packaged contiguous direct-download issue packs when
+  their declared coverage includes the requested issue; extract and import the
+  explicitly selected issue plus any other wanted members without replacing
+  existing files.
+- Preserve direct-acquisition fallback source metadata and accept configured
+  alternate series names when validating extracted pack members.
+
+### CI / Build
+
+- Refreshed narrow Docker Hardened Image vulnerability exceptions for the
+  current Debian 13 package revisions that have no upstream fix.
+
 ## [1.1.0] - 2026-08-18
 
 Minor release introducing native direct acquisition, an embedded comic reader,

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/api/v1/issues.py
+++ b/src/pullbox/api/v1/issues.py
@@ -961,7 +961,7 @@ async def download_issue(
         payload: dict[str, object] = {
             "issue_id": issue_id,
             "status": "downloading",
-            "release_title": selection.release.title,
+            "release_title": routed.release_title or selection.release.title,
             "source_kind": routed.source_kind,
         }
         if routed.download_id is not None:
@@ -974,8 +974,8 @@ async def download_issue(
         return {
             "issue_id": issue_id,
             "status": "queued",
-            "release_title": selection.release.title,
-            "confidence": selection.validation.confidence.value,
+            "release_title": routed.release_title or selection.release.title,
+            "confidence": routed.best_confidence or selection.validation.confidence.value,
             "source_kind": routed.source_kind,
             **(
                 {"message": "Already queued for review"}

--- a/src/pullbox/services/direct_acquisition_executor.py
+++ b/src/pullbox/services/direct_acquisition_executor.py
@@ -60,8 +60,10 @@ from pullbox.services.direct_acquisition_state import (
     transition_acquisition,
     transition_artifact,
 )
+from pullbox.services.direct_artifact_pack import DirectArtifactPackError
 from pullbox.services.direct_artifact_post_processing import (
     DirectPostProcessingResult,
+    run_direct_artifact_pack_post_processing,
     run_direct_artifact_post_processing,
 )
 from pullbox.services.direct_artifact_quarantine import (
@@ -568,14 +570,41 @@ class DirectAcquisitionExecutor:
         acquisition_id = attempt.id
         artifact_id = artifact.id
         try:
-            processed = await self._post_processor(
-                session,
-                acquisition_id=attempt.id,
-                issue_id=attempt.issue_id,
-                source_path=final_path,
-                replace_existing_file=attempt.replace_existing_file,
-                allow_resource_safety_exception=_resource_safety_override_allowed(attempt),
-            )
+            pack_coverage = _selected_pack_coverage(attempt)
+            if len(pack_coverage) > 1:
+                processed = await run_direct_artifact_pack_post_processing(
+                    session,
+                    acquisition_id=attempt.id,
+                    issue_id=attempt.issue_id,
+                    source_path=final_path,
+                    expected_issue_numbers=pack_coverage,
+                    replace_existing_file=attempt.replace_existing_file,
+                    allow_resource_safety_exception=_resource_safety_override_allowed(attempt),
+                )
+            else:
+                processed = await self._post_processor(
+                    session,
+                    acquisition_id=attempt.id,
+                    issue_id=attempt.issue_id,
+                    source_path=final_path,
+                    replace_existing_file=attempt.replace_existing_file,
+                    allow_resource_safety_exception=_resource_safety_override_allowed(attempt),
+                )
+        except DirectArtifactPackError as exc:
+            await session.rollback()
+            attempt, artifact = await _load_attempt(session, acquisition_id, artifact_id)
+            progress = _ProgressWriter(session, attempt, artifact, now=self._now)
+            attempt.failure_class = DirectArtifactFailureClass.POST_PROCESS
+            attempt.failure_code = exc.code
+            attempt.error_message = str(exc)
+            artifact.failure_class = DirectArtifactFailureClass.POST_PROCESS
+            artifact.failure_code = exc.code
+            artifact.error_message = str(exc)
+            transition_artifact(artifact, DirectArtifactState.FAILED, at=self._now())
+            transition_acquisition(attempt, DirectAcquisitionState.FAILED, at=self._now())
+            self._quarantine.cleanup(workspace)
+            await progress.write(stage="failed", force=True)
+            return _result(attempt, artifact)
         except Exception:
             await session.rollback()
             attempt, artifact = await _load_attempt(session, acquisition_id, artifact_id)
@@ -720,6 +749,20 @@ class DirectAcquisitionExecutor:
 def _raise_if_cancelled(cancel_event: asyncio.Event | None) -> None:
     if cancel_event is not None and cancel_event.is_set():
         raise ArtifactTransferCancelledError
+
+
+def _selected_pack_coverage(attempt: DirectAcquisitionAttempt) -> frozenset[str]:
+    """Return provider-declared selected content coverage, if durably available."""
+    snapshot = attempt.plan_snapshot or {}
+    coverage = snapshot.get("coverage")
+    if not isinstance(coverage, dict):
+        return frozenset()
+    raw_numbers = coverage.get("selected_content_issue_numbers")
+    if not isinstance(raw_numbers, list):
+        return frozenset()
+    return frozenset(
+        value.strip() for value in raw_numbers if isinstance(value, str) and value.strip()
+    )
 
 
 async def _await_with_cancel[T](

--- a/src/pullbox/services/direct_acquisition_planner_service.py
+++ b/src/pullbox/services/direct_acquisition_planner_service.py
@@ -755,6 +755,7 @@ def _build_durable_snapshot(
     )
     snapshot["coverage"] = {
         "requested": sorted(plan.requested),
+        "selected_content_issue_numbers": sorted(selected.option.coverage),
         "uncovered": sorted(plan.uncovered),
         "complete": plan.complete,
         "explanation_code": plan.explanation_code,

--- a/src/pullbox/services/direct_artifact_pack.py
+++ b/src/pullbox/services/direct_artifact_pack.py
@@ -47,7 +47,7 @@ def extract_same_series_issue_files(
     *,
     destination: Path,
     expected_issue_numbers: frozenset[str],
-    expected_series_title: str,
+    expected_series_titles: frozenset[str],
 ) -> dict[float, Path]:
     """Extract separately packaged issues from one contiguous direct-download pack.
 
@@ -58,8 +58,12 @@ def extract_same_series_issue_files(
         return {}
 
     expected = _normalized_issue_numbers(expected_issue_numbers)
-    normalized_series_title = NameMatcher.normalize(expected_series_title)
-    if not normalized_series_title:
+    normalized_series_titles = {
+        normalized
+        for title in expected_series_titles
+        if (normalized := NameMatcher.normalize(title))
+    }
+    if not normalized_series_titles:
         raise DirectArtifactPackError(
             code="direct_pack_series_invalid",
             message="The direct-download pack has no reliable series identity.",
@@ -102,7 +106,7 @@ def extract_same_series_issue_files(
         if issue_number is None or issue_number not in expected:
             continue
         parsed_series_title = NameMatcher.normalize(parsed.series_name or "") if parsed else ""
-        if parsed_series_title != normalized_series_title:
+        if parsed_series_title not in normalized_series_titles:
             raise DirectArtifactPackError(
                 code="direct_pack_mixed_series",
                 message="The direct-download pack contains files for a different series.",

--- a/src/pullbox/services/direct_artifact_pack.py
+++ b/src/pullbox/services/direct_artifact_pack.py
@@ -1,0 +1,128 @@
+"""Safe extraction of separable same-series direct-download packs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pullbox.core.archive import ArchiveError, ArchiveReader
+from pullbox.core.file_safety import has_archive_member_path_traversal
+from pullbox.core.name_matcher import NameMatcher
+from pullbox.core.release_parser import parse_release_title
+
+_COMIC_FILE_SUFFIXES = frozenset({".cbz", ".cbr", ".cb7", ".cbt", ".pdf"})
+
+
+class DirectArtifactPackError(RuntimeError):
+    """A stable, user-facing direct-pack post-processing failure."""
+
+    def __init__(self, *, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def extract_same_series_issue_files(
+    source_path: Path,
+    *,
+    destination: Path,
+    expected_issue_numbers: frozenset[str],
+    expected_series_title: str,
+) -> dict[float, Path]:
+    """Extract separately packaged issues from one contiguous direct-download pack.
+
+    A pack with page images but no nested comic files is one combined comic file.
+    Pullbox intentionally will not guess page boundaries or split that file.
+    """
+    if len(expected_issue_numbers) < 2:
+        return {}
+
+    expected = _normalized_issue_numbers(expected_issue_numbers)
+    normalized_series_title = NameMatcher.normalize(expected_series_title)
+    if not normalized_series_title:
+        raise DirectArtifactPackError(
+            code="direct_pack_series_invalid",
+            message="The direct-download pack has no reliable series identity.",
+        )
+    reader = ArchiveReader(source_path)
+    try:
+        members = reader.list_members()
+    except ArchiveError as exc:
+        raise DirectArtifactPackError(
+            code="direct_pack_unreadable",
+            message="Pullbox could not inspect the downloaded direct-download pack.",
+        ) from exc
+
+    candidates = [
+        member
+        for member in members
+        if member.is_regular_file
+        and not member.is_link
+        and Path(member.name).suffix.lower() in _COMIC_FILE_SUFFIXES
+    ]
+    if not candidates:
+        raise DirectArtifactPackError(
+            code="direct_pack_combined_file",
+            message=(
+                "This direct-download pack contains multiple issues in one combined comic "
+                "file. Pullbox can only import packs with separate issue files."
+            ),
+        )
+
+    destination.mkdir(mode=0o700, parents=True, exist_ok=True)
+    extracted: dict[float, Path] = {}
+    for member in candidates:
+        if has_archive_member_path_traversal(member.name):
+            raise DirectArtifactPackError(
+                code="direct_pack_unsafe_member",
+                message="The direct-download pack contains an unsafe archive member path.",
+            )
+        parsed = parse_release_title(Path(member.name).name)
+        issue_number = parsed.issue_number if parsed is not None else None
+        if issue_number is None or issue_number not in expected:
+            continue
+        parsed_series_title = NameMatcher.normalize(parsed.series_name or "") if parsed else ""
+        if parsed_series_title != normalized_series_title:
+            raise DirectArtifactPackError(
+                code="direct_pack_mixed_series",
+                message="The direct-download pack contains files for a different series.",
+            )
+        if issue_number in extracted:
+            raise DirectArtifactPackError(
+                code="direct_pack_ambiguous_issue",
+                message="The direct-download pack contains more than one file for the same issue.",
+            )
+        suffix = Path(member.name).suffix.lower()
+        target = destination / f"issue-{_issue_path_token(issue_number)}{suffix}"
+        try:
+            target.write_bytes(reader.read_file(member.name, max_bytes=member.size))
+            target.chmod(0o600)
+        except (ArchiveError, OSError) as exc:
+            raise DirectArtifactPackError(
+                code="direct_pack_extract_failed",
+                message="Pullbox could not safely extract the direct-download pack.",
+            ) from exc
+        extracted[issue_number] = target
+
+    missing = expected - set(extracted)
+    if missing:
+        raise DirectArtifactPackError(
+            code="direct_pack_incomplete",
+            message="The direct-download pack does not contain every issue it claimed to cover.",
+        )
+    return extracted
+
+
+def _normalized_issue_numbers(issue_numbers: frozenset[str]) -> set[float]:
+    normalized: set[float] = set()
+    for value in issue_numbers:
+        try:
+            normalized.add(float(value))
+        except (TypeError, ValueError) as exc:
+            raise DirectArtifactPackError(
+                code="direct_pack_coverage_invalid",
+                message="The direct-download pack has invalid issue coverage.",
+            ) from exc
+    return normalized
+
+
+def _issue_path_token(issue_number: float) -> str:
+    return str(issue_number).replace(".", "_")

--- a/src/pullbox/services/direct_artifact_pack.py
+++ b/src/pullbox/services/direct_artifact_pack.py
@@ -20,6 +20,28 @@ class DirectArtifactPackError(RuntimeError):
         self.code = code
 
 
+def is_separable_issue_pack(source_path: Path) -> bool:
+    """Return whether an archive safely presents multiple named comic members.
+
+    This is deliberately structural only. Series identity and complete claimed
+    coverage are enforced by ``extract_same_series_issue_files`` before import.
+    """
+    try:
+        members = ArchiveReader(source_path).list_members()
+    except ArchiveError:
+        return False
+    candidates = [
+        member
+        for member in members
+        if member.is_regular_file
+        and not member.is_link
+        and Path(member.name).suffix.lower() in _COMIC_FILE_SUFFIXES
+        and not has_archive_member_path_traversal(member.name)
+        and _issue_number_from_member(member.name) is not None
+    ]
+    return len(candidates) >= 2
+
+
 def extract_same_series_issue_files(
     source_path: Path,
     *,
@@ -126,3 +148,8 @@ def _normalized_issue_numbers(issue_numbers: frozenset[str]) -> set[float]:
 
 def _issue_path_token(issue_number: float) -> str:
     return str(issue_number).replace(".", "_")
+
+
+def _issue_number_from_member(name: str) -> float | None:
+    parsed = parse_release_title(Path(name).name)
+    return parsed.issue_number if parsed is not None else None

--- a/src/pullbox/services/direct_artifact_post_processing.py
+++ b/src/pullbox/services/direct_artifact_post_processing.py
@@ -19,6 +19,7 @@ from pullbox.models.issue import Issue, IssueStatus
 from pullbox.models.library import LibraryFile
 from pullbox.models.series import Series
 from pullbox.services.direct_artifact_pack import extract_same_series_issue_files
+from pullbox.services.direct_artifact_quarantine import validate_direct_artifact
 from pullbox.services.issue_import_service import (
     ManualIssueImportResult,
     execute_manual_issue_import,
@@ -169,11 +170,15 @@ async def run_direct_artifact_pack_post_processing(
         candidate = issue_by_number.get(issue_number)
         if candidate is None:
             continue
+        has_existing_file = getattr(candidate, "library_file", None) is not None
+        if has_existing_file and (candidate.id != issue_id or not replace_existing_file):
+            continue
         if candidate.id != issue_id and candidate.status not in {
             IssueStatus.WANTED,
             IssueStatus.DOWNLOADING,
         }:
             continue
+        await validate_direct_artifact(session, file_path)
         prepared_imports.append(
             await prepare_manual_issue_import(
                 session,
@@ -188,12 +193,16 @@ async def run_direct_artifact_pack_post_processing(
     imported_results: list[ManualIssueImportResult] = []
     try:
         for prepared in prepared_imports:
-            imported_results.append(
-                await execute_manual_issue_import(
-                    session,
-                    prepared,
-                    allow_resource_safety_exception=allow_resource_safety_exception,
-                )
+            imported = await execute_manual_issue_import(
+                session,
+                prepared,
+                allow_resource_safety_exception=allow_resource_safety_exception,
+            )
+            imported_results.append(imported)
+            await asyncio.to_thread(
+                _materialize_library_symlink,
+                Path(imported.library_file.file_path),
+                prepared.source_path,
             )
     except Exception:
         # The executor rolls database state back. Remove any files copied before a later

--- a/src/pullbox/services/direct_artifact_post_processing.py
+++ b/src/pullbox/services/direct_artifact_post_processing.py
@@ -151,7 +151,9 @@ async def run_direct_artifact_pack_post_processing(
         source_path,
         destination=source_path.parent / "pack-members",
         expected_issue_numbers=expected_issue_numbers,
-        expected_series_title=initiating_issue.series.title,
+        expected_series_titles=frozenset(
+            (initiating_issue.series.title, *(initiating_issue.series.alternate_names or []))
+        ),
     )
     issues_result = await session.execute(
         select(Issue)
@@ -167,8 +169,7 @@ async def run_direct_artifact_pack_post_processing(
         candidate = issue_by_number.get(issue_number)
         if candidate is None:
             continue
-        is_explicit_replacement = candidate.id == issue_id and replace_existing_file
-        if not is_explicit_replacement and candidate.status not in {
+        if candidate.id != issue_id and candidate.status not in {
             IssueStatus.WANTED,
             IssueStatus.DOWNLOADING,
         }:

--- a/src/pullbox/services/direct_artifact_post_processing.py
+++ b/src/pullbox/services/direct_artifact_post_processing.py
@@ -12,9 +12,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
 from pullbox.models.download import DownloadState
+from pullbox.models.issue import Issue, IssueStatus
 from pullbox.models.library import LibraryFile
+from pullbox.models.series import Series
+from pullbox.services.direct_artifact_pack import extract_same_series_issue_files
+from pullbox.services.issue_import_service import (
+    ManualIssueImportResult,
+    execute_manual_issue_import,
+    prepare_manual_issue_import,
+)
 from pullbox.tasks.download_task import _run_post_processing
 
 if TYPE_CHECKING:
@@ -64,6 +73,7 @@ class DirectPostProcessingResult:
 
     library_file_id: int
     final_path: Path
+    imported_issue_ids: tuple[int, ...] = ()
 
 
 async def run_direct_artifact_post_processing(
@@ -112,6 +122,92 @@ async def run_direct_artifact_post_processing(
     return DirectPostProcessingResult(
         library_file_id=library_file.id,
         final_path=final_path,
+        imported_issue_ids=(issue_id,),
+    )
+
+
+async def run_direct_artifact_pack_post_processing(
+    session: AsyncSession,
+    *,
+    acquisition_id: int,
+    issue_id: int,
+    source_path: Path,
+    expected_issue_numbers: frozenset[str],
+    replace_existing_file: bool,
+    allow_resource_safety_exception: bool = False,
+) -> DirectPostProcessingResult:
+    """Import separable same-series pack members through normal issue ingestion."""
+    initiating_issue_result = await session.execute(
+        select(Issue)
+        .options(joinedload(Issue.series).joinedload(Series.publisher))
+        .where(Issue.id == issue_id)
+    )
+    initiating_issue = initiating_issue_result.unique().scalar_one_or_none()
+    if initiating_issue is None:
+        raise RuntimeError("The target issue for this direct-download pack no longer exists.")
+
+    extracted_paths = await asyncio.to_thread(
+        extract_same_series_issue_files,
+        source_path,
+        destination=source_path.parent / "pack-members",
+        expected_issue_numbers=expected_issue_numbers,
+        expected_series_title=initiating_issue.series.title,
+    )
+    issues_result = await session.execute(
+        select(Issue)
+        .options(
+            joinedload(Issue.series).joinedload(Series.publisher),
+            joinedload(Issue.library_file),
+        )
+        .where(Issue.series_id == initiating_issue.series_id)
+    )
+    issue_by_number = {issue.issue_number: issue for issue in issues_result.unique().scalars()}
+    prepared_imports = []
+    for issue_number, file_path in sorted(extracted_paths.items()):
+        candidate = issue_by_number.get(issue_number)
+        if candidate is None:
+            continue
+        is_explicit_replacement = candidate.id == issue_id and replace_existing_file
+        if not is_explicit_replacement and candidate.status not in {
+            IssueStatus.WANTED,
+            IssueStatus.DOWNLOADING,
+        }:
+            continue
+        prepared_imports.append(
+            await prepare_manual_issue_import(
+                session,
+                issue_id=candidate.id,
+                file_path=str(file_path),
+                move_to_library=True,
+            )
+        )
+    if not prepared_imports:
+        raise RuntimeError("No wanted issues in this direct-download pack can be imported.")
+
+    imported_results: list[ManualIssueImportResult] = []
+    try:
+        for prepared in prepared_imports:
+            imported_results.append(
+                await execute_manual_issue_import(
+                    session,
+                    prepared,
+                    allow_resource_safety_exception=allow_resource_safety_exception,
+                )
+            )
+    except Exception:
+        # The executor rolls database state back. Remove any files copied before a later
+        # member failed so a rejected pack never leaves partial library artifacts behind.
+        for result in imported_results:
+            await asyncio.to_thread(Path(result.library_file.file_path).unlink, missing_ok=True)
+        raise
+    primary_import_result = next(
+        (result for result in imported_results if result.issue_id == issue_id),
+        imported_results[0],
+    )
+    return DirectPostProcessingResult(
+        library_file_id=primary_import_result.library_file.id,
+        final_path=Path(primary_import_result.library_file.file_path),
+        imported_issue_ids=tuple(result.issue_id for result in imported_results),
     )
 
 

--- a/src/pullbox/services/direct_artifact_quarantine.py
+++ b/src/pullbox/services/direct_artifact_quarantine.py
@@ -19,6 +19,7 @@ from pullbox.core.file_safety import (
     run_safety_checks,
 )
 from pullbox.models.direct_acquisition import DirectArtifactFailureClass
+from pullbox.services.direct_artifact_pack import is_separable_issue_pack
 from pullbox.utilities.executors.integrity_checker import check_file_integrity
 
 if TYPE_CHECKING:
@@ -175,7 +176,11 @@ async def validate_direct_artifact(
         ) from exc
 
     integrity = await check_file_integrity(path, deep=False)
-    if integrity.status == "corrupt":
+    is_pack = integrity.status == "corrupt" and await asyncio.to_thread(
+        is_separable_issue_pack,
+        path,
+    )
+    if integrity.status == "corrupt" and not is_pack:
         raise DirectArtifactValidationError(
             code="artifact_integrity_failed",
             message="The downloaded artifact failed Pullbox integrity checks.",
@@ -192,8 +197,8 @@ async def validate_direct_artifact(
     return DirectArtifactValidationResult(
         path=path,
         file_size=file_size,
-        page_count=integrity.page_count,
-        file_hash=integrity.file_hash,
+        page_count=None if is_pack else integrity.page_count,
+        file_hash=None if is_pack else integrity.file_hash,
     )
 
 

--- a/src/pullbox/services/direct_search_coordinator.py
+++ b/src/pullbox/services/direct_search_coordinator.py
@@ -470,7 +470,11 @@ def _validate_direct_candidate(
     validation = accepted[0] if accepted else declined[0]
     if validation.is_match or not _is_explicit_direct_pack_for_target(candidate, target):
         return validation
-    if not (validation.rejection_reason or "").startswith("Multi-issue pack"):
+    rejection_reason = validation.rejection_reason or ""
+    if not (
+        rejection_reason.startswith("Multi-issue pack")
+        or rejection_reason.startswith("Issue mismatch")
+    ):
         return validation
 
     # Validate title, type, and year with the requested member as a synthetic

--- a/src/pullbox/services/direct_search_coordinator.py
+++ b/src/pullbox/services/direct_search_coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Protocol
 from urllib.parse import urlsplit, urlunsplit
@@ -422,17 +422,12 @@ async def _search_provider(
             continue
         seen_candidate_ids.add(candidate.provider_candidate_id)
         release = _candidate_release(provider, candidate)
-        accepted, declined = validator.validate_all_results(
-            [release],
-            wanted_series=target.series_title,
-            wanted_issue=target.issue_number,
-            wanted_year=target.search_year,
-            wanted_issue_type=target.issue_type,
-            alternate_names=_validation_alternate_names(target, candidate),
-            wanted_issue_title=target.issue_title,
-            wanted_series_issue_count=target.series_issue_count,
+        validation = _validate_direct_candidate(
+            validator,
+            release=release,
+            candidate=candidate,
+            target=target,
         )
-        validation = accepted[0] if accepted else declined[0]
         result = DirectValidatedCandidate(
             provider=provider,
             candidate=candidate,
@@ -441,6 +436,72 @@ async def _search_provider(
         )
         (matched if validation.is_match else rejected).append(result)
     return matched, rejected, None
+
+
+def _validate_direct_candidate(
+    validator: ReleaseValidator,
+    *,
+    release: ReleaseResult,
+    candidate: DirectCandidate,
+    target: IssueSearchTarget,
+) -> ValidationResult:
+    """Validate a direct candidate, allowing only explicitly-covered issue packs.
+
+    Generic torrent and Usenet releases remain conservative: their contents cannot
+    be safely assumed to be separable. Direct candidates carry provider-parsed
+    coverage and pass a dedicated nested-archive validation path before import.
+    """
+
+    def validate(
+        candidate_release: ReleaseResult,
+    ) -> tuple[list[ValidationResult], list[ValidationResult]]:
+        return validator.validate_all_results(
+            [candidate_release],
+            wanted_series=target.series_title,
+            wanted_issue=target.issue_number,
+            wanted_year=target.search_year,
+            wanted_issue_type=target.issue_type,
+            alternate_names=_validation_alternate_names(target, candidate),
+            wanted_issue_title=target.issue_title,
+            wanted_series_issue_count=target.series_issue_count,
+        )
+
+    accepted, declined = validate(release)
+    validation = accepted[0] if accepted else declined[0]
+    if validation.is_match or not _is_explicit_direct_pack_for_target(candidate, target):
+        return validation
+    if not (validation.rejection_reason or "").startswith("Multi-issue pack"):
+        return validation
+
+    # Validate title, type, and year with the requested member as a synthetic
+    # single-issue title, then retain the original range evidence for display.
+    pack_member_release = replace(
+        release,
+        title=_direct_pack_member_title(candidate, target),
+    )
+    accepted, _declined = validate(pack_member_release)
+    if not accepted:
+        return validation
+    return replace(accepted[0], parsed=validation.parsed, release=release)
+
+
+def _is_explicit_direct_pack_for_target(
+    candidate: DirectCandidate,
+    target: IssueSearchTarget,
+) -> bool:
+    target_issue = f"{target.issue_number:g}"
+    return (
+        len(candidate.parsed.issue_numbers) > 1 and target_issue in candidate.parsed.issue_numbers
+    )
+
+
+def _direct_pack_member_title(
+    candidate: DirectCandidate,
+    target: IssueSearchTarget,
+) -> str:
+    year = candidate.parsed.year or target.search_year
+    suffix = f" ({year})" if year is not None else ""
+    return f"{candidate.parsed.series_title} #{target.issue_number:g}{suffix}"
 
 
 def _validation_alternate_names(

--- a/src/pullbox/services/search_acquisition_router.py
+++ b/src/pullbox/services/search_acquisition_router.py
@@ -102,6 +102,7 @@ class SearchAcquisitionRoutingResult:
     notices: tuple[str, ...] = ()
     download_id: int | None = None
     acquisition_id: int | None = None
+    release_title: str | None = None
 
 
 async def route_search_acquisition(
@@ -166,6 +167,7 @@ async def route_search_acquisition(
                     "indexer",
                     tuple(notices),
                     download_id=getattr(download, "id", None),
+                    release_title=selected.release.title,
                 )
             if not await intervention_service.has_pending_for_issue(session, target.issue_id):
                 await intervention_service.create_pending_match(
@@ -175,10 +177,22 @@ async def route_search_acquisition(
                     selected.validation,
                 )
                 return SearchAcquisitionRoutingResult(
-                    0, 1, "queued", confidence, "indexer", tuple(notices)
+                    0,
+                    1,
+                    "queued",
+                    confidence,
+                    "indexer",
+                    tuple(notices),
+                    release_title=selected.release.title,
                 )
             return SearchAcquisitionRoutingResult(
-                0, 0, "pending_exists", confidence, "indexer", tuple(notices)
+                0,
+                0,
+                "pending_exists",
+                confidence,
+                "indexer",
+                tuple(notices),
+                release_title=selected.release.title,
             )
 
         direct_result = selected.direct_result
@@ -194,7 +208,13 @@ async def route_search_acquisition(
                 intervention_service,
             )
             return SearchAcquisitionRoutingResult(
-                0, 1, "intervention", confidence, "direct", tuple(notices)
+                0,
+                1,
+                "intervention",
+                confidence,
+                "direct",
+                tuple(notices),
+                release_title=selected.release.title,
             )
 
         provider = await session.get(
@@ -228,7 +248,13 @@ async def route_search_acquisition(
                 )
                 await session.commit()
                 return SearchAcquisitionRoutingResult(
-                    0, 1, "intervention", confidence, "direct", tuple(notices)
+                    0,
+                    1,
+                    "intervention",
+                    confidence,
+                    "direct",
+                    tuple(notices),
+                    release_title=selected.release.title,
                 )
             notices.append(_provider_failure_notice(direct_result.provider.display_name, exc))
             await session.commit()
@@ -249,6 +275,7 @@ async def route_search_acquisition(
             "direct",
             tuple(notices),
             acquisition_id=planned.attempt.id,
+            release_title=selected.release.title,
         )
 
     return SearchAcquisitionRoutingResult(

--- a/src/pullbox/ui/templates/partials/issue_search_results.html
+++ b/src/pullbox/ui/templates/partials/issue_search_results.html
@@ -166,7 +166,13 @@
               <td><span class="pill{% if item.source_kind == 'direct' %} pill-info{% else %} pill-muted{% endif %}">{{ item.method }}</span></td>
               <td>
                 {% if item.coverage %}
-                  <span class="pill pill-success">Issue {{ item.coverage|join(', ') }}</span>
+                  <span class="pill pill-success">
+                    {% if item.coverage|length > 1 %}
+                      Pack: issues {{ item.coverage|join(', ') }}
+                    {% else %}
+                      Issue {{ item.coverage|join(', ') }}
+                    {% endif %}
+                  </span>
                 {% else %}
                   <span class="pill pill-muted">Issue {{ issue.issue_number|issue_num }}</span>
                 {% endif %}
@@ -247,7 +253,15 @@
               <td class="downloads-mono-cell">{{ item.indexer_name }}</td>
               <td><span class="pill pill-muted opacity-60">{{ item.method }}</span></td>
               <td>
-                {% if item.coverage %}<span class="pill pill-muted opacity-60">Issue {{ item.coverage|join(', ') }}</span>{% else %}—{% endif %}
+                {% if item.coverage %}
+                  <span class="pill pill-muted opacity-60">
+                    {% if item.coverage|length > 1 %}
+                      Pack: issues {{ item.coverage|join(', ') }}
+                    {% else %}
+                      Issue {{ item.coverage|join(', ') }}
+                    {% endif %}
+                  </span>
+                {% else %}—{% endif %}
               </td>
               <td>
                 {% if item.format %}<span class="pill pill-muted opacity-60">{{ item.format|upper }}</span>{% endif %}

--- a/tests/api/test_issue_download_search.py
+++ b/tests/api/test_issue_download_search.py
@@ -394,3 +394,82 @@ async def test_issue_download_routes_direct_only_match_through_shared_acquisitio
     assert route.await_args is not None
     assert route.await_args.kwargs["outcome"] is outcome
     assert route.await_args.kwargs["source_priority"] == ["direct", "usenet", "torrent"]
+
+
+@pytest.mark.asyncio
+async def test_issue_download_returns_the_source_metadata_selected_after_fallback(
+    client: AsyncClient,
+    _db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    issue_id = await _create_issue(_db_factory)
+    initial_release = _make_release("Initial Direct Candidate")
+    runtime = SearchRuntime(
+        registry=ProviderRegistry(),
+        indexer_configs={},
+        source_priority=["direct", "usenet", "torrent"],
+        eval_kwargs={},
+        validator_kwargs={},
+        type_thresholds={"issue": "high"},
+        failure_threshold=3,
+        direct_providers=(SimpleNamespace(),),
+    )
+    target = IssueSearchTarget(
+        issue_id=issue_id,
+        series_id=1,
+        series_title="Absolute Superman",
+        issue_number=9.0,
+        issue_type=IssueType.ISSUE,
+        issue_title="Issue #9",
+        series_year=2025,
+    )
+    outcome = IssueSearchOutcome(
+        target=target,
+        mode="deep",
+        query_count=1,
+        raw_results=[initial_release],
+        filtered_results=[initial_release],
+        matched=[],
+        rejected=[],
+        best_release=None,
+        best_validation=None,
+        search_details={},
+        elapsed_ms=0,
+    )
+    routed = SearchAcquisitionRoutingResult(
+        grabbed=1,
+        queued=0,
+        action_status="downloading",
+        best_confidence="high",
+        source_kind="indexer",
+        release_title="Fallback Indexer Candidate",
+    )
+
+    with (
+        patch(
+            "pullbox.api.v1.issues._run_issue_search",
+            new_callable=AsyncMock,
+            return_value=_bundle(issue_id, runtime=runtime, outcome=outcome),
+        ),
+        patch(
+            "pullbox.api.v1.issues.route_search_acquisition",
+            new_callable=AsyncMock,
+            return_value=routed,
+        ),
+        patch(
+            "pullbox.api.v1.issues.select_search_source",
+            return_value=SimpleNamespace(
+                release=initial_release,
+                validation=SimpleNamespace(confidence=MatchConfidence.HIGH),
+            ),
+        ),
+        patch(
+            "pullbox.api.v1.issues.get_direct_acquisition_runner",
+            return_value=SimpleNamespace(),
+        ),
+    ):
+        response = await client.post(f"/api/v1/issues/{issue_id}/download")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["source_kind"] == "indexer"
+    assert payload["release_title"] == "Fallback Indexer Candidate"

--- a/tests/unit/test_direct_acquisition_executor.py
+++ b/tests/unit/test_direct_acquisition_executor.py
@@ -13,6 +13,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+import pullbox.services.direct_acquisition_executor as direct_executor_module
 from pullbox.models import Base
 from pullbox.models.blocklist import BlocklistEntry
 from pullbox.models.config import SystemConfig
@@ -491,6 +492,52 @@ async def test_executor_completes_with_durable_redacted_progress(
     assert refreshed_history.final_path == "/library/Issue 1.cbz"
     assert refreshed_history.imported_at == NOW
     assert refreshed_history.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_executor_routes_contiguous_pack_to_pack_post_processor(
+    session: AsyncSession,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempt = _attempt()
+    attempt.plan_snapshot = {
+        "coverage": {"selected_content_issue_numbers": ["1", "2"]},
+    }
+    session.add(attempt)
+    await session.commit()
+    observed: dict[str, Any] = {}
+
+    async def pack_post_processor(*_args: Any, **kwargs: Any) -> DirectPostProcessingResult:
+        observed.update(kwargs)
+        return DirectPostProcessingResult(
+            library_file_id=77,
+            final_path=Path("/library/Issue 1.cbz"),
+            imported_issue_ids=(attempt.issue_id, 2),
+        )
+
+    async def single_post_processor(*_args: Any, **_kwargs: Any) -> DirectPostProcessingResult:
+        raise AssertionError("A contiguous pack must not use the one-file post-processor.")
+
+    monkeypatch.setattr(
+        direct_executor_module,
+        "run_direct_artifact_pack_post_processing",
+        pack_post_processor,
+    )
+    artifact = attempt.artifact_attempts[0]
+    result = await _executor(
+        tmp_path,
+        transport=_SuccessfulTransport(),
+        post_processor=single_post_processor,
+    ).execute(
+        session,
+        acquisition_id=attempt.id,
+        artifact_id=artifact.id,
+        source_factory=lambda: _async_value(_source_request()),
+    )
+
+    assert result.state is DirectAcquisitionState.COMPLETED
+    assert observed["expected_issue_numbers"] == frozenset({"1", "2"})
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_direct_acquisition_planner_service.py
+++ b/tests/unit/test_direct_acquisition_planner_service.py
@@ -324,6 +324,28 @@ async def test_planning_accepts_matching_volume_only_coverage_for_collection(
 
 
 @pytest.mark.asyncio
+async def test_planning_persists_selected_contiguous_pack_coverage(
+    session: AsyncSession,
+) -> None:
+    attempt = await session.get(DirectAcquisitionAttempt, 1)
+    assert attempt is not None
+    attempt.requested_coverage = {"issue_numbers": ["5"], "issue_type": "issue"}
+    response = _response()
+    response.artifacts[0].coverage = DirectArtifactCoverage(issue_numbers=["5", "6"])
+    await session.flush()
+
+    result = await plan_direct_acquisition(
+        session,
+        acquisition_id=1,
+        provider_client_factory=lambda **_kwargs: _ResolveClient(response),
+        provider_secret_loader=lambda _config: _provider_material(),
+        now=lambda: NOW,
+    )
+
+    assert result.attempt.plan_snapshot["coverage"]["selected_content_issue_numbers"] == ["5", "6"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("requested_coverage", "artifact_volume"),
     [

--- a/tests/unit/test_direct_artifact_pack.py
+++ b/tests/unit/test_direct_artifact_pack.py
@@ -1,0 +1,91 @@
+"""Tests for safe same-series direct-download pack extraction."""
+
+from __future__ import annotations
+
+import zipfile
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pullbox.services.direct_artifact_pack import (
+    DirectArtifactPackError,
+    extract_same_series_issue_files,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_nested_pack(path: Path, *names: str) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in names:
+            archive.writestr(name, b"nested comic")
+
+
+def test_extracts_separate_contiguous_issue_files(tmp_path: Path) -> None:
+    pack = tmp_path / "Alien #5-6.cbz"
+    _write_nested_pack(
+        pack,
+        "Alien - The Friendliest Facehugger #5.cbz",
+        "Alien - The Friendliest Facehugger #6.cbz",
+    )
+
+    extracted = extract_same_series_issue_files(
+        pack,
+        destination=tmp_path / "extracted",
+        expected_issue_numbers=frozenset({"5", "6"}),
+        expected_series_title="Alien - The Friendliest Facehugger",
+    )
+
+    assert set(extracted) == {5.0, 6.0}
+    assert extracted[5.0].read_bytes() == b"nested comic"
+    assert extracted[6.0].read_bytes() == b"nested comic"
+
+
+def test_rejects_a_combined_comic_with_only_page_images(tmp_path: Path) -> None:
+    pack = tmp_path / "Alien #5-6.cbz"
+    _write_nested_pack(pack, "001.jpg", "002.jpg")
+
+    with pytest.raises(DirectArtifactPackError, match="separate issue files") as caught:
+        extract_same_series_issue_files(
+            pack,
+            destination=tmp_path / "extracted",
+            expected_issue_numbers=frozenset({"5", "6"}),
+            expected_series_title="Alien - The Friendliest Facehugger",
+        )
+
+    assert caught.value.code == "direct_pack_combined_file"
+
+
+def test_rejects_pack_when_a_declared_issue_file_is_missing(tmp_path: Path) -> None:
+    pack = tmp_path / "Alien #5-6.cbz"
+    _write_nested_pack(pack, "Alien - The Friendliest Facehugger #5.cbz")
+
+    with pytest.raises(DirectArtifactPackError, match="does not contain every issue") as caught:
+        extract_same_series_issue_files(
+            pack,
+            destination=tmp_path / "extracted",
+            expected_issue_numbers=frozenset({"5", "6"}),
+            expected_series_title="Alien - The Friendliest Facehugger",
+        )
+
+    assert caught.value.code == "direct_pack_incomplete"
+
+
+def test_rejects_nested_issue_file_for_a_different_series(tmp_path: Path) -> None:
+    pack = tmp_path / "Alien #5-6.cbz"
+    _write_nested_pack(
+        pack,
+        "Alien - The Friendliest Facehugger #5.cbz",
+        "Other Series #6.cbz",
+    )
+
+    with pytest.raises(DirectArtifactPackError, match="different series") as caught:
+        extract_same_series_issue_files(
+            pack,
+            destination=tmp_path / "extracted",
+            expected_issue_numbers=frozenset({"5", "6"}),
+            expected_series_title="Alien - The Friendliest Facehugger",
+        )
+
+    assert caught.value.code == "direct_pack_mixed_series"

--- a/tests/unit/test_direct_artifact_pack.py
+++ b/tests/unit/test_direct_artifact_pack.py
@@ -34,12 +34,30 @@ def test_extracts_separate_contiguous_issue_files(tmp_path: Path) -> None:
         pack,
         destination=tmp_path / "extracted",
         expected_issue_numbers=frozenset({"5", "6"}),
-        expected_series_title="Alien - The Friendliest Facehugger",
+        expected_series_titles=frozenset({"Alien - The Friendliest Facehugger"}),
     )
 
     assert set(extracted) == {5.0, 6.0}
     assert extracted[5.0].read_bytes() == b"nested comic"
     assert extracted[6.0].read_bytes() == b"nested comic"
+
+
+def test_accepts_nested_files_using_a_configured_alternate_series_name(tmp_path: Path) -> None:
+    pack = tmp_path / "The Aliens #5-6.cbz"
+    _write_nested_pack(
+        pack,
+        "The Aliens #5.cbz",
+        "The Aliens #6.cbz",
+    )
+
+    extracted = extract_same_series_issue_files(
+        pack,
+        destination=tmp_path / "extracted",
+        expected_issue_numbers=frozenset({"5", "6"}),
+        expected_series_titles=frozenset({"Alien - The Friendliest Facehugger", "The Aliens"}),
+    )
+
+    assert set(extracted) == {5.0, 6.0}
 
 
 def test_rejects_a_combined_comic_with_only_page_images(tmp_path: Path) -> None:
@@ -51,7 +69,7 @@ def test_rejects_a_combined_comic_with_only_page_images(tmp_path: Path) -> None:
             pack,
             destination=tmp_path / "extracted",
             expected_issue_numbers=frozenset({"5", "6"}),
-            expected_series_title="Alien - The Friendliest Facehugger",
+            expected_series_titles=frozenset({"Alien - The Friendliest Facehugger"}),
         )
 
     assert caught.value.code == "direct_pack_combined_file"
@@ -66,7 +84,7 @@ def test_rejects_pack_when_a_declared_issue_file_is_missing(tmp_path: Path) -> N
             pack,
             destination=tmp_path / "extracted",
             expected_issue_numbers=frozenset({"5", "6"}),
-            expected_series_title="Alien - The Friendliest Facehugger",
+            expected_series_titles=frozenset({"Alien - The Friendliest Facehugger"}),
         )
 
     assert caught.value.code == "direct_pack_incomplete"
@@ -85,7 +103,7 @@ def test_rejects_nested_issue_file_for_a_different_series(tmp_path: Path) -> Non
             pack,
             destination=tmp_path / "extracted",
             expected_issue_numbers=frozenset({"5", "6"}),
-            expected_series_title="Alien - The Friendliest Facehugger",
+            expected_series_titles=frozenset({"Alien - The Friendliest Facehugger"}),
         )
 
     assert caught.value.code == "direct_pack_mixed_series"

--- a/tests/unit/test_direct_artifact_post_processing.py
+++ b/tests/unit/test_direct_artifact_post_processing.py
@@ -167,7 +167,7 @@ async def test_direct_pack_always_imports_the_explicitly_selected_skipped_issue(
 
     async def fake_prepare(_session: Any, *, issue_id: int, **_kwargs: Any) -> SimpleNamespace:
         prepared_issue_ids.append(issue_id)
-        return SimpleNamespace(issue_id=issue_id)
+        return SimpleNamespace(issue_id=issue_id, source_path=extracted_path)
 
     async def fake_execute(
         _session: Any,
@@ -181,6 +181,8 @@ async def test_direct_pack_always_imports_the_explicitly_selected_skipped_issue(
 
     monkeypatch.setattr(post_processing, "prepare_manual_issue_import", fake_prepare)
     monkeypatch.setattr(post_processing, "execute_manual_issue_import", fake_execute)
+    validator = AsyncMock()
+    monkeypatch.setattr(post_processing, "validate_direct_artifact", validator)
 
     result = await run_direct_artifact_pack_post_processing(
         session,
@@ -193,3 +195,139 @@ async def test_direct_pack_always_imports_the_explicitly_selected_skipped_issue(
 
     assert prepared_issue_ids == [target_issue.id]
     assert result.imported_issue_ids == (target_issue.id,)
+    validator.assert_awaited_once_with(session, extracted_path)
+
+
+@pytest.mark.asyncio
+async def test_direct_pack_only_replaces_the_explicitly_selected_existing_issue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_issue = SimpleNamespace(
+        id=7,
+        issue_number=5.0,
+        status=IssueStatus.SKIPPED,
+        series_id=3,
+        library_file=object(),
+        series=SimpleNamespace(title="Alien", alternate_names=[]),
+    )
+    supplemental_issue = SimpleNamespace(
+        id=8,
+        issue_number=6.0,
+        status=IssueStatus.WANTED,
+        series_id=3,
+        library_file=object(),
+        series=target_issue.series,
+    )
+    session = AsyncMock()
+    session.execute.side_effect = [
+        SimpleNamespace(unique=lambda: SimpleNamespace(scalar_one_or_none=lambda: target_issue)),
+        SimpleNamespace(
+            unique=lambda: SimpleNamespace(scalars=lambda: [target_issue, supplemental_issue])
+        ),
+    ]
+    target_path = tmp_path / "issue-5.cbz"
+    supplemental_path = tmp_path / "issue-6.cbz"
+    target_path.write_bytes(b"target")
+    supplemental_path.write_bytes(b"supplemental")
+    prepared_issue_ids: list[int] = []
+
+    monkeypatch.setattr(
+        post_processing.asyncio,
+        "to_thread",
+        AsyncMock(return_value={5.0: target_path, 6.0: supplemental_path}),
+    )
+
+    async def fake_prepare(_session: Any, *, issue_id: int, **_kwargs: Any) -> SimpleNamespace:
+        prepared_issue_ids.append(issue_id)
+        return SimpleNamespace(issue_id=issue_id, source_path=target_path)
+
+    async def fake_execute(
+        _session: Any,
+        prepared: SimpleNamespace,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            issue_id=prepared.issue_id,
+            library_file=SimpleNamespace(id=prepared.issue_id, file_path=str(target_path)),
+        )
+
+    monkeypatch.setattr(post_processing, "prepare_manual_issue_import", fake_prepare)
+    monkeypatch.setattr(post_processing, "execute_manual_issue_import", fake_execute)
+    monkeypatch.setattr(post_processing, "validate_direct_artifact", AsyncMock())
+
+    await run_direct_artifact_pack_post_processing(
+        session,
+        acquisition_id=1,
+        issue_id=target_issue.id,
+        source_path=tmp_path / "pack.cbz",
+        expected_issue_numbers=frozenset({"5", "6"}),
+        replace_existing_file=True,
+    )
+
+    assert prepared_issue_ids == [target_issue.id]
+
+
+@pytest.mark.asyncio
+async def test_direct_pack_materializes_library_symlinks_before_workspace_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_issue = SimpleNamespace(
+        id=7,
+        issue_number=5.0,
+        status=IssueStatus.WANTED,
+        series_id=3,
+        library_file=None,
+        series=SimpleNamespace(title="Alien", alternate_names=[]),
+    )
+    session = AsyncMock()
+    session.execute.side_effect = [
+        SimpleNamespace(unique=lambda: SimpleNamespace(scalar_one_or_none=lambda: target_issue)),
+        SimpleNamespace(unique=lambda: SimpleNamespace(scalars=lambda: [target_issue])),
+    ]
+    source_path = tmp_path / "issue-5.cbz"
+    source_path.write_bytes(b"issue")
+    library_path = tmp_path / "library" / "issue-5.cbz"
+    library_path.parent.mkdir()
+
+    monkeypatch.setattr(
+        post_processing,
+        "extract_same_series_issue_files",
+        lambda *_args, **_kwargs: {5.0: source_path},
+    )
+
+    async def run_inline(function: Any, *args: Any, **kwargs: Any) -> Any:
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(post_processing.asyncio, "to_thread", run_inline)
+
+    async def fake_prepare(_session: Any, **_kwargs: Any) -> SimpleNamespace:
+        return SimpleNamespace(issue_id=target_issue.id, source_path=source_path)
+
+    async def fake_execute(
+        _session: Any,
+        prepared: SimpleNamespace,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        library_path.symlink_to(prepared.source_path)
+        return SimpleNamespace(
+            issue_id=prepared.issue_id,
+            library_file=SimpleNamespace(id=1, file_path=str(library_path)),
+        )
+
+    monkeypatch.setattr(post_processing, "prepare_manual_issue_import", fake_prepare)
+    monkeypatch.setattr(post_processing, "execute_manual_issue_import", fake_execute)
+    monkeypatch.setattr(post_processing, "validate_direct_artifact", AsyncMock())
+
+    await run_direct_artifact_pack_post_processing(
+        session,
+        acquisition_id=1,
+        issue_id=target_issue.id,
+        source_path=tmp_path / "pack.cbz",
+        expected_issue_numbers=frozenset({"5"}),
+        replace_existing_file=False,
+    )
+
+    assert library_path.is_symlink() is False
+    assert library_path.read_bytes() == b"issue"

--- a/tests/unit/test_direct_artifact_post_processing.py
+++ b/tests/unit/test_direct_artifact_post_processing.py
@@ -9,7 +9,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+import pullbox.services.direct_artifact_post_processing as post_processing
+from pullbox.models.issue import IssueStatus
 from pullbox.services.direct_artifact_post_processing import (
+    run_direct_artifact_pack_post_processing,
     run_direct_artifact_post_processing,
 )
 
@@ -123,3 +126,70 @@ async def test_direct_handoff_materializes_library_symlink_before_quarantine_cle
     assert library_path.is_symlink() is False
     assert library_path.read_bytes() == b"direct artifact"
     assert source.exists()
+
+
+@pytest.mark.asyncio
+async def test_direct_pack_always_imports_the_explicitly_selected_skipped_issue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target_issue = SimpleNamespace(
+        id=7,
+        issue_number=5.0,
+        status=IssueStatus.SKIPPED,
+        series_id=3,
+        series=SimpleNamespace(title="Alien", alternate_names=[]),
+    )
+    wanted_issue = SimpleNamespace(
+        id=8,
+        issue_number=6.0,
+        status=IssueStatus.WANTED,
+        series_id=3,
+        series=target_issue.series,
+    )
+    initiating_result = SimpleNamespace(
+        unique=lambda: SimpleNamespace(scalar_one_or_none=lambda: target_issue)
+    )
+    issues_result = SimpleNamespace(
+        unique=lambda: SimpleNamespace(scalars=lambda: [target_issue, wanted_issue])
+    )
+    session = AsyncMock()
+    session.execute.side_effect = [initiating_result, issues_result]
+    extracted_path = tmp_path / "issue-5.cbz"
+    extracted_path.write_bytes(b"issue")
+    prepared_issue_ids: list[int] = []
+
+    monkeypatch.setattr(
+        post_processing.asyncio,
+        "to_thread",
+        AsyncMock(return_value={5.0: extracted_path}),
+    )
+
+    async def fake_prepare(_session: Any, *, issue_id: int, **_kwargs: Any) -> SimpleNamespace:
+        prepared_issue_ids.append(issue_id)
+        return SimpleNamespace(issue_id=issue_id)
+
+    async def fake_execute(
+        _session: Any,
+        prepared: SimpleNamespace,
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            issue_id=prepared.issue_id,
+            library_file=SimpleNamespace(id=prepared.issue_id, file_path=str(extracted_path)),
+        )
+
+    monkeypatch.setattr(post_processing, "prepare_manual_issue_import", fake_prepare)
+    monkeypatch.setattr(post_processing, "execute_manual_issue_import", fake_execute)
+
+    result = await run_direct_artifact_pack_post_processing(
+        session,
+        acquisition_id=1,
+        issue_id=target_issue.id,
+        source_path=tmp_path / "pack.cbz",
+        expected_issue_numbers=frozenset({"5"}),
+        replace_existing_file=False,
+    )
+
+    assert prepared_issue_ids == [target_issue.id]
+    assert result.imported_issue_ids == (target_issue.id,)

--- a/tests/unit/test_direct_artifact_quarantine.py
+++ b/tests/unit/test_direct_artifact_quarantine.py
@@ -25,6 +25,12 @@ def _write_cbz(path: Path, *, entry: str = "001.jpg") -> None:
         archive.writestr(entry, b"synthetic image fixture")
 
 
+def _write_nested_pack(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("Alien 005.cbz", b"issue five")
+        archive.writestr("Alien 006.cbz", b"issue six")
+
+
 def test_quarantine_uses_private_deterministic_attempt_paths(tmp_path: Path) -> None:
     quarantine = DirectArtifactQuarantine(tmp_path / "direct")
 
@@ -67,6 +73,23 @@ async def test_direct_artifact_reuses_existing_safety_and_integrity_checks(
     assert result.page_count == 1
     assert result.file_size == final_path.stat().st_size
     assert result.file_hash
+
+
+@pytest.mark.asyncio
+async def test_direct_artifact_accepts_a_valid_separable_issue_pack(
+    tmp_path: Path,
+) -> None:
+    quarantine = DirectArtifactQuarantine(tmp_path / "direct")
+    workspace = quarantine.prepare(acquisition_id=1, artifact_id=2)
+    _write_nested_pack(workspace.partial_path)
+    final_path = quarantine.finalize(workspace, filename_hint="pack.cbz")
+    session = AsyncMock()
+    session.get.return_value = None
+
+    result = await validate_direct_artifact(session, final_path)
+
+    assert result.page_count is None
+    assert result.file_size == final_path.stat().st_size
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_direct_search_coordinator.py
+++ b/tests/unit/test_direct_search_coordinator.py
@@ -100,8 +100,8 @@ def _contiguous_pack_candidate(provider: DirectSearchProvider) -> DirectCandidat
     return DirectCandidate(
         provider_candidate_id=f"pack:{provider.provider_identity}",
         source_reference=f"https://{provider.provider_identity}.example/pack",
-        display_title="Absolute Superman #5-10 (2025)",
-        raw_title="Absolute Superman #5-10 (2025)",
+        display_title="Absolute Superman #5 \N{EN DASH} 10 (2025)",
+        raw_title="Absolute Superman #5 \N{EN DASH} 10 (2025)",
         parsed=DirectParsedCandidate(
             series_title="Absolute Superman",
             issue_numbers=["5", "6", "7", "8", "9", "10"],

--- a/tests/unit/test_direct_search_coordinator.py
+++ b/tests/unit/test_direct_search_coordinator.py
@@ -96,6 +96,23 @@ def _candidate(provider: DirectSearchProvider, title: str) -> DirectCandidate:
     )
 
 
+def _contiguous_pack_candidate(provider: DirectSearchProvider) -> DirectCandidate:
+    return DirectCandidate(
+        provider_candidate_id=f"pack:{provider.provider_identity}",
+        source_reference=f"https://{provider.provider_identity}.example/pack",
+        display_title="Absolute Superman #5-10 (2025)",
+        raw_title="Absolute Superman #5-10 (2025)",
+        parsed=DirectParsedCandidate(
+            series_title="Absolute Superman",
+            issue_numbers=["5", "6", "7", "8", "9", "10"],
+            year=2025,
+            format="cbz",
+        ),
+        provider_confidence=0.95,
+        provenance={"fixture": "contiguous-pack"},
+    )
+
+
 class _Client:
     delays: ClassVar[dict[str, float]] = {}
     responses: ClassVar[dict[str, list[DirectCandidate]]] = {}
@@ -239,6 +256,22 @@ async def test_duplicate_provider_candidate_identity_is_returned_once() -> None:
 
     assert len(outcome.matched) == 1
     assert outcome.matched[0].candidate.provider_candidate_id == candidate.provider_candidate_id
+
+
+async def test_direct_search_accepts_contiguous_pack_for_interior_issue() -> None:
+    _reset()
+    provider = _provider("pullbox.getcomics", 10)
+    _Client.responses = {provider.provider_identity: [_contiguous_pack_candidate(provider)]}
+
+    outcome = await search_direct_issue_target(
+        _target(),
+        [provider],
+        client_factory=_factory,
+    )
+
+    assert len(outcome.matched) == 1
+    assert outcome.rejected == ()
+    assert outcome.matched[0].candidate.parsed.issue_numbers == ["5", "6", "7", "8", "9", "10"]
 
 
 async def test_provider_search_tries_ordinary_http_then_ranked_resolvers() -> None:

--- a/tests/unit/test_github_actions_security_contracts.py
+++ b/tests/unit/test_github_actions_security_contracts.py
@@ -927,6 +927,7 @@ def test_grype_config_tracks_current_dhi_runtime() -> None:
     assert "CVE-2026-11822" in config_text
     assert "CVE-2026-11824" in config_text
     assert "CVE-2026-14456" in config_text
+    assert "CVE-2026-66046" in config_text
     assert "3.14.6" in config_text
     assert config.get("ignore")
 
@@ -937,9 +938,20 @@ def test_grype_config_tracks_current_dhi_runtime() -> None:
         (entry["package"]["name"], entry["package"]["version"], entry["package"]["type"])
         for entry in openssl_exceptions
     } == {
-        ("libssl3t64", "3.5.6-1~deb13u2+dhi1", "deb"),
-        ("openssl", "3.5.6-1~deb13u2+dhi1", "deb"),
-        ("openssl-provider-legacy", "3.5.6-1~deb13u2+dhi1", "deb"),
+        ("libssl3t64", "3.5.6-1~deb13u2+dhi2", "deb"),
+        ("openssl", "3.5.6-1~deb13u2+dhi2", "deb"),
+        ("openssl-provider-legacy", "3.5.6-1~deb13u2+dhi2", "deb"),
+    }
+
+    expat_exceptions = [
+        entry for entry in config["ignore"] if entry.get("vulnerability") == "CVE-2026-66046"
+    ]
+    assert {
+        (entry["package"]["name"], entry["package"]["version"], entry["package"]["type"])
+        for entry in expat_exceptions
+    } == {
+        ("libexpat1", "2.8.3-1~deb13u1+dhi2", "deb"),
+        ("libexpat1-dev", "2.8.3-1~deb13u1+dhi2", "deb"),
     }
 
 


### PR DESCRIPTION
## Summary
- Releases contiguous direct-download pack support for safely separable same-series issue archives.
- Preserves selected-issue intent, configured alternate series identities, and fallback source metadata.
- Refreshes exact DHI Grype exceptions for current no-fix Debian 13 packages.

## Validation
- [x] `make ci-full` on the feature branch before integration
- [x] Focused direct-acquisition and pack-import regression tests
- [x] Ruff and strict mypy
- [x] `make release-changelog-check VERSION=1.1.1`
- [ ] GitHub CI and Docker validation green

## Release
- After this PR is green and merged, create and verify the signed `v1.1.1` tag from `main`.