### PR TITLE
feat: add provider-neutral direct download identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ pip-delete-this-directory.txt
 *.spec
 MANIFEST
 
+# Pullbox uses pip and pyproject metadata; local uv resolution is not a build input.
+uv.lock
+
 # Virtual environments
 .venv/
 venv/

--- a/src/pullbox/api/v1/issues.py
+++ b/src/pullbox/api/v1/issues.py
@@ -277,6 +277,8 @@ def build_direct_interactive_results(
     matched_items: list[SearchResultItem] = []
     rejected_items: list[RejectedResultItem] = []
     for discovery in discoveries:
+        if not discovery.visible:
+            continue
         result = discovery.result
         candidate = result.candidate
         common = {

--- a/src/pullbox/providers/direct/contract.py
+++ b/src/pullbox/providers/direct/contract.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import ipaddress
 import re
 from datetime import datetime  # noqa: TC003 - Pydantic resolves this at runtime
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Self
+from urllib.parse import urlsplit
 from uuid import UUID  # noqa: TC003 - Pydantic resolves this at runtime
 
 from pydantic import (
@@ -43,9 +45,18 @@ _ALLOWED_FIELD_KEYS = {
     "maxLength",
     "x-pullbox-secret",
     "x-pullbox-placeholder",
+    "x-pullbox-suggestions",
+    "x-pullbox-source-origin",
 }
 _ALLOWED_FIELD_TYPES = frozenset({"string", "boolean", "integer", "number"})
 _ALLOWED_INPUT_FORMATS = frozenset({"uri"})
+_SPECIAL_USE_SOURCE_SUFFIXES = (
+    "localhost",
+    "local",
+    "onion",
+    "internal",
+    "home.arpa",
+)
 
 
 class ProviderConfigurationSchemaError(ValueError):
@@ -89,6 +100,8 @@ class DirectConfigurationControl(DirectContractModel):
     min_length: int | None = None
     max_length: int | None = None
     placeholder: str | None = None
+    suggestions: tuple[str, ...] = ()
+    source_origin: bool = False
 
 
 class DirectProviderCapabilities(DirectContractModel):
@@ -212,6 +225,11 @@ class DirectCandidate(DirectContractModel):
     raw_title: str = Field(min_length=1, max_length=2_000)
     parsed: DirectParsedCandidate
     provider_confidence: float = Field(ge=0, le=1)
+    content_fingerprint: str | None = Field(
+        default=None,
+        pattern=r"^md5:[0-9a-f]{32}$",
+        repr=False,
+    )
     provenance: dict[str, DiagnosticScalar] = Field(default_factory=dict)
     can_resolve: bool = True
     expires_at: datetime | None = None
@@ -357,11 +375,28 @@ def validate_provider_configuration_schema(
         ):
             raise ProviderConfigurationSchemaError("Provider configuration choices are invalid.")
         choices = tuple(_typed_configuration_value(value, str(value_type)) for value in choices_raw)
+        suggestions = _uri_suggestions(
+            raw_field.get("x-pullbox-suggestions"),
+            value_type=value_type,
+            input_format=input_format,
+            secret=secret,
+        )
+        source_origin = raw_field.get("x-pullbox-source-origin", False)
+        if not isinstance(source_origin, bool):
+            raise ProviderConfigurationSchemaError("Provider source-origin control is invalid.")
+        if source_origin and (value_type != "string" or input_format != "uri" or secret):
+            raise ProviderConfigurationSchemaError("Provider source-origin control is invalid.")
         default = None
         if "default" in raw_field:
             default = _typed_configuration_value(raw_field["default"], str(value_type))
             if choices and default not in choices:
                 raise ProviderConfigurationSchemaError("Provider configuration default is invalid.")
+            if (source_origin or suggestions) and (
+                not isinstance(default, str) or not _is_safe_https_origin(default)
+            ):
+                raise ProviderConfigurationSchemaError(
+                    "Provider configuration URI default is unsafe."
+                )
         minimum = _number_or_none(raw_field.get("minimum"))
         maximum = _number_or_none(raw_field.get("maximum"))
         min_length = _integer_or_none(raw_field.get("minLength"))
@@ -396,9 +431,92 @@ def validate_provider_configuration_schema(
                 min_length=min_length,
                 max_length=max_length,
                 placeholder=_bounded_control_text(raw_field.get("x-pullbox-placeholder")),
+                suggestions=suggestions,
+                source_origin=source_origin,
             )
         )
     return tuple(controls)
+
+
+def _uri_suggestions(
+    raw: object,
+    *,
+    value_type: object,
+    input_format: object,
+    secret: bool,
+) -> tuple[str, ...]:
+    if raw is None:
+        return ()
+    if value_type != "string" or input_format != "uri" or secret:
+        raise ProviderConfigurationSchemaError("Provider URI suggestions are invalid.")
+    if not isinstance(raw, list) or not raw or len(raw) > 20:
+        raise ProviderConfigurationSchemaError("Provider URI suggestions are invalid.")
+    suggestions: list[str] = []
+    for value in raw:
+        if not isinstance(value, str) or not _is_safe_https_origin(value):
+            raise ProviderConfigurationSchemaError("Provider URI suggestions are invalid.")
+        if value in suggestions:
+            raise ProviderConfigurationSchemaError("Provider URI suggestions are duplicated.")
+        suggestions.append(value)
+    return tuple(suggestions)
+
+
+def _is_safe_https_origin(raw: str) -> bool:
+    if not raw or len(raw) > 2_000:
+        return False
+    try:
+        parsed = urlsplit(raw)
+        port = parsed.port
+    except ValueError:
+        return False
+    hostname = parsed.hostname
+    if hostname is None:
+        return False
+    normalized_hostname = hostname.casefold().rstrip(".")
+    if not is_public_source_hostname_syntax(normalized_hostname):
+        return False
+
+    return bool(
+        parsed.scheme == "https"
+        and parsed.username is None
+        and parsed.password is None
+        and port in {None, 443}
+        and parsed.path in {"", "/"}
+        and not parsed.query
+        and not parsed.fragment
+    )
+
+
+def is_public_source_hostname_syntax(hostname: str) -> bool:
+    """Reject IP literals, legacy numeric forms, and special-use namespaces."""
+    if any(
+        hostname == suffix or hostname.endswith(f".{suffix}")
+        for suffix in _SPECIAL_USE_SOURCE_SUFFIXES
+    ):
+        return False
+    try:
+        ipaddress.ip_address(hostname)
+    except ValueError:
+        pass
+    else:
+        return False
+    return not _looks_like_legacy_ipv4_literal(hostname)
+
+
+def _looks_like_legacy_ipv4_literal(hostname: str) -> bool:
+    labels = hostname.split(".")
+    if not 1 <= len(labels) <= 4:
+        return False
+    for label in labels:
+        if not label:
+            return False
+        if label.startswith("0x"):
+            digits = label[2:]
+            if not digits or any(character not in "0123456789abcdef" for character in digits):
+                return False
+        elif not label.isascii() or not label.isdigit():
+            return False
+    return True
 
 
 def _bounded_control_text(value: object) -> str | None:

--- a/src/pullbox/providers/direct/contract.py
+++ b/src/pullbox/providers/direct/contract.py
@@ -24,6 +24,7 @@ SUPPORTED_DIRECT_PROVIDER_PROTOCOLS = (DIRECT_PROVIDER_PROTOCOL_V1,)
 MAX_DIRECT_PROVIDER_RESULTS = 100
 
 _FIELD_NAME = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_DNS_LABEL = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\Z")
 _ALLOWED_SCHEMA_KEYS = {
     "type",
     "title",
@@ -489,6 +490,14 @@ def _is_safe_https_origin(raw: str) -> bool:
 
 def is_public_source_hostname_syntax(hostname: str) -> bool:
     """Reject IP literals, legacy numeric forms, and special-use namespaces."""
+    labels = hostname.split(".")
+    if (
+        len(hostname) > 253
+        or len(labels) < 2
+        or any(_DNS_LABEL.fullmatch(label) is None for label in labels)
+        or not any(character.isalpha() for character in labels[-1])
+    ):
+        return False
     if any(
         hostname == suffix or hostname.endswith(f".{suffix}")
         for suffix in _SPECIAL_USE_SOURCE_SUFFIXES

--- a/src/pullbox/schemas/direct_provider.py
+++ b/src/pullbox/schemas/direct_provider.py
@@ -46,6 +46,8 @@ class DirectConfigurationControlResponse(BaseModel):
     min_length: int | None
     max_length: int | None
     placeholder: str | None
+    suggestions: tuple[str, ...]
+    source_origin: bool
 
 
 class DirectProviderResponse(BaseModel):

--- a/src/pullbox/services/direct_provider_registration.py
+++ b/src/pullbox/services/direct_provider_registration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol
-from urllib.parse import urlsplit
 
 from sqlalchemy import select
 
@@ -34,13 +33,21 @@ from pullbox.services.direct_provider_quota import (
     provider_supports_quota,
     set_automatic_quota_reserve,
 )
+from pullbox.services.direct_provider_source_origin import (
+    DirectProviderSourceOriginError,
+    configured_direct_provider_source_domain,
+    validate_direct_provider_source_origin,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
-    from pullbox.providers.direct.endpoint import ValidatedProviderEndpoint
+    from pullbox.providers.direct.endpoint import (
+        ProviderEndpointResolver,
+        ValidatedProviderEndpoint,
+    )
 
 
 class DirectProviderRegistrationError(RuntimeError):
@@ -382,6 +389,7 @@ async def update_direct_provider(
     secret_configuration: Mapping[str, str | None] | None = None,
     resolver_enabled: bool | None = None,
     automatic_quota_reserve_value: int | None = None,
+    source_origin_resolver: ProviderEndpointResolver | None = None,
 ) -> DirectProviderRecord:
     """Update native provider settings while keeping secrets write-only."""
     config = await _get_config(session, provider_config_id)
@@ -400,7 +408,11 @@ async def update_direct_provider(
         manifest = _stored_manifest(config)
         controls = {control.name: control for control in manifest.configuration_controls}
         if public_configuration is not None:
-            public_values = _validate_public_configuration(public_configuration, controls)
+            public_values = await _validate_public_configuration(
+                public_configuration,
+                controls,
+                source_origin_resolver=source_origin_resolver,
+            )
             metadata = _metadata(config)
             metadata["public_values"] = public_values
             config.configuration_metadata = metadata
@@ -495,16 +507,7 @@ def _health_error_code(
 
 
 def _configured_source_domain(config: DirectProviderConfig) -> str | None:
-    raw_public = _metadata(config).get("public_values", {})
-    if not isinstance(raw_public, dict):
-        return None
-    raw_domain = raw_public.get("domain")
-    if not isinstance(raw_domain, str):
-        return None
-    try:
-        return urlsplit(raw_domain).hostname
-    except ValueError:
-        return None
+    return configured_direct_provider_source_domain(config)
 
 
 def _configured_source_is_unreachable(
@@ -604,9 +607,11 @@ def _record(config: DirectProviderConfig) -> DirectProviderRecord:
     )
 
 
-def _validate_public_configuration(
+async def _validate_public_configuration(
     values: Mapping[str, object],
     controls: Mapping[str, DirectConfigurationControl],
+    *,
+    source_origin_resolver: ProviderEndpointResolver | None,
 ) -> dict[str, str | int | float | bool]:
     result: dict[str, str | int | float | bool] = {}
     for name, value in values.items():
@@ -616,6 +621,16 @@ def _validate_public_configuration(
         if control.secret:
             raise DirectProviderRegistrationError(name, "Secret field requires a write-only value.")
         _validate_control_value(control, value)
+        if control.source_origin and isinstance(value, str):
+            try:
+                value = (
+                    await validate_direct_provider_source_origin(
+                        value,
+                        resolver=source_origin_resolver,
+                    )
+                ).url
+            except DirectProviderSourceOriginError as exc:
+                raise DirectProviderRegistrationError(name, str(exc)) from exc
         if not isinstance(value, (str, int, float, bool)):
             raise DirectProviderRegistrationError(name, "Provider configuration value is invalid.")
         result[name] = value

--- a/src/pullbox/services/direct_provider_source_origin.py
+++ b/src/pullbox/services/direct_provider_source_origin.py
@@ -1,0 +1,180 @@
+"""Validated effective source origins for direct-download providers."""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from urllib.parse import urlsplit, urlunsplit
+
+from pullbox.providers.direct.contract import (
+    DirectManifestResponse,
+    is_public_source_hostname_syntax,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pullbox.models.direct_acquisition import DirectProviderConfig
+    from pullbox.providers.direct.endpoint import ProviderEndpointResolver
+
+
+class DirectProviderSourceOriginError(ValueError):
+    """A provider source origin is unsafe or cannot be resolved."""
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedDirectProviderSourceOrigin:
+    url: str
+    host: str
+
+
+async def validate_direct_provider_source_origin(
+    raw_url: str,
+    *,
+    resolver: ProviderEndpointResolver | None = None,
+) -> ValidatedDirectProviderSourceOrigin:
+    """Validate one HTTPS origin and reject any known unsafe DNS resolution."""
+    if not isinstance(raw_url, str) or not raw_url.strip() or len(raw_url) > 2_000:
+        raise DirectProviderSourceOriginError("Provider source origin must be a bounded URL.")
+    try:
+        parsed = urlsplit(raw_url.strip())
+        port = parsed.port
+    except ValueError as exc:
+        raise DirectProviderSourceOriginError("Provider source origin is malformed.") from exc
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 443}
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise DirectProviderSourceOriginError(
+            "Provider source origin must be one HTTPS origin without credentials or a path."
+        )
+
+    host = parsed.hostname.casefold().rstrip(".")
+    if not is_public_source_hostname_syntax(host):
+        raise DirectProviderSourceOriginError(
+            "Provider source origin must use a public network hostname."
+        )
+
+    resolve = resolver or _resolve_source_addresses
+    validated = ValidatedDirectProviderSourceOrigin(
+        url=urlunsplit(("https", host, "", "", "")),
+        host=host,
+    )
+    try:
+        raw_addresses = await resolve(host, 443)
+    except (OSError, TimeoutError):
+        return validated
+    if not raw_addresses:
+        return validated
+    for raw_address in raw_addresses:
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError as exc:
+            raise DirectProviderSourceOriginError(
+                "Provider source origin resolved to an invalid public network address."
+            ) from exc
+        if not address.is_global:
+            raise DirectProviderSourceOriginError(
+                "Provider source origin must resolve only to the public network."
+            )
+
+    return validated
+
+
+def effective_direct_provider_source_domains(config: DirectProviderConfig) -> tuple[str, ...]:
+    """Return manifest domains plus this provider's selected source origin."""
+    raw_manifest = config.manifest_snapshot
+    raw_domains = raw_manifest.get("source_domains", []) if isinstance(raw_manifest, dict) else []
+    domains = (
+        [_normalize_domain(value) for value in raw_domains if isinstance(value, str)]
+        if isinstance(raw_domains, list)
+        else []
+    )
+    try:
+        manifest = DirectManifestResponse.model_validate(raw_manifest)
+    except ValueError:
+        return tuple(dict.fromkeys(domain for domain in domains if domain))
+    domains.extend(_configured_source_origin_domains(config, manifest))
+    return tuple(dict.fromkeys(domain for domain in domains if domain))
+
+
+def configured_direct_provider_source_domain(config: DirectProviderConfig) -> str | None:
+    """Return the selected source domain used by provider health diagnostics."""
+    try:
+        manifest = DirectManifestResponse.model_validate(config.manifest_snapshot)
+    except ValueError:
+        return None
+    configured = _configured_source_origin_domains(config, manifest)
+    if configured:
+        return configured[0]
+
+    # Protocol v1 providers released before source-origin metadata used `domain`.
+    public_values = _public_configuration(config)
+    raw_domain = public_values.get("domain")
+    return _origin_hostname(raw_domain) if isinstance(raw_domain, str) else None
+
+
+def _configured_source_origin_domains(
+    config: DirectProviderConfig,
+    manifest: DirectManifestResponse,
+) -> list[str]:
+    public_values = _public_configuration(config)
+    domains: list[str] = []
+    for control in manifest.configuration_controls:
+        value = public_values.get(control.name)
+        if control.source_origin and isinstance(value, str):
+            hostname = _origin_hostname(value)
+            if hostname:
+                domains.append(hostname)
+    return domains
+
+
+def _public_configuration(config: DirectProviderConfig) -> dict[str, object]:
+    metadata = config.configuration_metadata
+    if not isinstance(metadata, dict):
+        return {}
+    values = metadata.get("public_values")
+    return values if isinstance(values, dict) else {}
+
+
+def _origin_hostname(raw_url: str) -> str | None:
+    try:
+        parsed = urlsplit(raw_url)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or port not in {None, 443}
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+    ):
+        return None
+    return parsed.hostname.casefold().rstrip(".")
+
+
+def _normalize_domain(raw_domain: str) -> str:
+    return raw_domain.strip().casefold().lstrip(".").rstrip(".")
+
+
+async def _resolve_source_addresses(host: str, port: int) -> Sequence[str]:
+    records = await asyncio.to_thread(
+        socket.getaddrinfo,
+        host,
+        port,
+        type=socket.SOCK_STREAM,
+    )
+    return tuple(sorted({str(record[4][0]) for record in records}))

--- a/src/pullbox/services/direct_provider_source_origin.py
+++ b/src/pullbox/services/direct_provider_source_origin.py
@@ -25,6 +25,9 @@ class DirectProviderSourceOriginError(ValueError):
     """A provider source origin is unsafe or cannot be resolved."""
 
 
+_MAX_EFFECTIVE_SOURCE_DOMAINS = 100
+
+
 @dataclass(frozen=True, slots=True)
 class ValidatedDirectProviderSourceOrigin:
     url: str
@@ -102,9 +105,24 @@ def effective_direct_provider_source_domains(config: DirectProviderConfig) -> tu
     try:
         manifest = DirectManifestResponse.model_validate(raw_manifest)
     except ValueError:
-        return tuple(dict.fromkeys(domain for domain in domains if domain))
-    domains.extend(_configured_source_origin_domains(config, manifest))
-    return tuple(dict.fromkeys(domain for domain in domains if domain))
+        unique_domains = tuple(dict.fromkeys(domain for domain in domains if domain))
+        return unique_domains[:_MAX_EFFECTIVE_SOURCE_DOMAINS]
+
+    manifest_domains = list(dict.fromkeys(domain for domain in domains if domain))
+    configured_domains = list(dict.fromkeys(_configured_source_origin_domains(config, manifest)))
+    merged = list(dict.fromkeys([*manifest_domains, *configured_domains]))
+    if len(merged) <= _MAX_EFFECTIVE_SOURCE_DOMAINS:
+        return tuple(merged)
+
+    configured_set = set(configured_domains)
+    retained_manifest = [domain for domain in manifest_domains if domain not in configured_set]
+    manifest_limit = max(0, _MAX_EFFECTIVE_SOURCE_DOMAINS - len(configured_domains))
+    return tuple(
+        [
+            *retained_manifest[:manifest_limit],
+            *configured_domains[:_MAX_EFFECTIVE_SOURCE_DOMAINS],
+        ]
+    )
 
 
 def configured_direct_provider_source_domain(config: DirectProviderConfig) -> str | None:

--- a/src/pullbox/services/direct_resolver_service.py
+++ b/src/pullbox/services/direct_resolver_service.py
@@ -26,6 +26,9 @@ from pullbox.providers.direct.resolver import (
     DirectResolverResult,
     ResolverCircuitBreaker,
 )
+from pullbox.services.direct_provider_source_origin import (
+    effective_direct_provider_source_domains,
+)
 from pullbox.services.direct_resolver_configuration import (
     DirectResolverConfigRead,
     load_resolver_auth_headers,
@@ -519,7 +522,8 @@ async def build_provider_resolver_profiles(
         manifest = DirectManifestResponse.model_validate(provider.manifest_snapshot)
     except ValueError:
         return ()
-    if not manifest.capabilities.browser_challenge or not manifest.source_domains:
+    source_domains = effective_direct_provider_source_domains(provider)
+    if not manifest.capabilities.browser_challenge or not source_domains:
         return ()
     resolvers = tuple(config for config in await _eligible_resolvers(session) if config.endpoint)
     return tuple(
@@ -536,7 +540,7 @@ async def build_provider_resolver_profiles(
                 ),
                 timeout_seconds=float(resolver.timeout_seconds),
                 max_concurrency=resolver.max_concurrency,
-                declared_domains=list(manifest.source_domains),
+                declared_domains=list(source_domains),
                 authentication_headers=load_resolver_auth_headers(resolver).headers,
             ),
         )

--- a/src/pullbox/services/direct_search_coordinator.py
+++ b/src/pullbox/services/direct_search_coordinator.py
@@ -33,6 +33,9 @@ from pullbox.providers.direct.contract import (
     DirectSearchResponse,
 )
 from pullbox.services.direct_provider_quota import refresh_expired_provider_quota
+from pullbox.services.direct_provider_source_origin import (
+    effective_direct_provider_source_domains,
+)
 from pullbox.services.release_validator import ReleaseValidator, ValidationResult
 from pullbox.services.search_scoring import match_confidence_rank
 
@@ -93,6 +96,7 @@ class DirectValidatedCandidate:
     candidate: DirectCandidate
     release: ReleaseResult
     validation: ValidationResult
+    alternate_results: tuple[DirectValidatedCandidate, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -113,6 +117,7 @@ class DirectSearchDiscovery:
 
     attempt_id: int
     result: DirectValidatedCandidate
+    visible: bool = True
 
 
 class DirectSearchClient(Protocol):
@@ -191,13 +196,6 @@ async def load_direct_search_providers(
         metadata = config.configuration_metadata or {}
         raw_public = metadata.get("public_values", {})
         public_config = dict(raw_public) if isinstance(raw_public, dict) else {}
-        manifest = config.manifest_snapshot or {}
-        raw_domains = manifest.get("source_domains", [])
-        source_domains = (
-            tuple(str(domain) for domain in raw_domains if isinstance(domain, str))
-            if isinstance(raw_domains, list)
-            else ()
-        )
         providers.append(
             DirectSearchProvider(
                 provider_config_id=config.id,
@@ -211,7 +209,7 @@ async def load_direct_search_providers(
                 provider_config=public_config,
                 source_credentials=material.configuration,
                 resolver_options=await build_provider_resolver_profiles(session, config),
-                source_domains=source_domains,
+                source_domains=effective_direct_provider_source_domains(config),
             )
         )
     return tuple(providers)
@@ -225,36 +223,41 @@ async def persist_direct_search_discoveries(
     search_log_id: int | None = None,
 ) -> tuple[DirectSearchDiscovery, ...]:
     """Persist redacted candidate evidence and return server-issued IDs."""
-    pending: list[tuple[DirectAcquisitionAttempt, DirectValidatedCandidate]] = []
+    pending: list[tuple[DirectAcquisitionAttempt, DirectValidatedCandidate, bool]] = []
     issue_number = f"{target.issue_number:g}"
     volume = _target_volume(target)
-    for result in (*outcome.matched, *outcome.rejected):
-        attempt = DirectAcquisitionAttempt(
-            request_key=f"direct-search:{uuid4().hex}",
-            issue_id=target.issue_id,
-            search_log_id=search_log_id,
-            provider_config_id=result.provider.provider_config_id,
-            provider_identity=result.provider.provider_identity,
-            provider_candidate_id=result.candidate.provider_candidate_id,
-            state=DirectAcquisitionState.DISCOVERED,
-            requested_coverage={
-                "issue_numbers": [issue_number],
-                "issue_type": target.issue_type.value,
-                "volume": volume,
-            },
-            candidate_snapshot=_candidate_snapshot(result),
-            plan_snapshot={},
-            progress_snapshot={
-                "schema_version": 1,
-                "stage": "discovered",
-            },
-        )
-        session.add(attempt)
-        pending.append((attempt, result))
+    for primary in (*outcome.matched, *outcome.rejected):
+        for result, visible in (
+            (primary, True),
+            *((alternate, False) for alternate in primary.alternate_results),
+        ):
+            attempt = DirectAcquisitionAttempt(
+                request_key=f"direct-search:{uuid4().hex}",
+                issue_id=target.issue_id,
+                search_log_id=search_log_id,
+                provider_config_id=result.provider.provider_config_id,
+                provider_identity=result.provider.provider_identity,
+                provider_candidate_id=result.candidate.provider_candidate_id,
+                state=DirectAcquisitionState.DISCOVERED,
+                requested_coverage={
+                    "issue_numbers": [issue_number],
+                    "issue_type": target.issue_type.value,
+                    "volume": volume,
+                },
+                candidate_snapshot=_candidate_snapshot(result),
+                plan_snapshot={},
+                progress_snapshot={
+                    "schema_version": 1,
+                    "stage": "discovered",
+                },
+            )
+            session.add(attempt)
+            pending.append((attempt, result, visible))
     if pending:
         await session.flush()
     return tuple(
-        DirectSearchDiscovery(attempt_id=attempt.id, result=result) for attempt, result in pending
+        DirectSearchDiscovery(attempt_id=attempt.id, result=result, visible=visible)
+        for attempt, result, visible in pending
     )
 
 
@@ -332,6 +335,8 @@ async def search_direct_issue_target(
 
     matched.sort(key=_matched_order_key)
     rejected.sort(key=_rejected_order_key)
+    matched = _group_fingerprint_alternates(matched)
+    rejected = _group_fingerprint_alternates(rejected)
     failures.sort(key=lambda item: (item.provider_identity, item.code))
     return DirectSearchOutcome(
         matched=tuple(matched),
@@ -692,3 +697,27 @@ def _rejected_order_key(item: DirectValidatedCandidate) -> tuple[object, ...]:
         item.provider.provider_identity,
         item.candidate.provider_candidate_id,
     )
+
+
+def _group_fingerprint_alternates(
+    results: list[DirectValidatedCandidate],
+) -> list[DirectValidatedCandidate]:
+    """Collapse identical content only after semantic accept/reject decisions."""
+    grouped: list[DirectValidatedCandidate] = []
+    primary_indexes: dict[str, int] = {}
+    for result in results:
+        fingerprint = result.candidate.content_fingerprint
+        if fingerprint is None:
+            grouped.append(result)
+            continue
+        primary_index = primary_indexes.get(fingerprint)
+        if primary_index is None:
+            primary_indexes[fingerprint] = len(grouped)
+            grouped.append(result)
+            continue
+        primary = grouped[primary_index]
+        grouped[primary_index] = replace(
+            primary,
+            alternate_results=(*primary.alternate_results, result),
+        )
+    return grouped

--- a/src/pullbox/services/search_source_selection.py
+++ b/src/pullbox/services/search_source_selection.py
@@ -58,7 +58,15 @@ def rank_search_sources(
     if limit is not None and limit <= 0:
         return ()
 
-    direct_matches = outcome.direct_outcome.matched if outcome.direct_outcome else ()
+    direct_matches = (
+        tuple(
+            result
+            for primary in outcome.direct_outcome.matched
+            for result in (primary, *primary.alternate_results)
+        )
+        if outcome.direct_outcome
+        else ()
+    )
     ranked: list[SearchSourceSelection] = []
     indexer_matches = outcome.matched
     if (

--- a/src/pullbox/ui/templates/partials/settings_direct.html
+++ b/src/pullbox/ui/templates/partials/settings_direct.html
@@ -491,7 +491,7 @@
                       </select>
                     </template>
 
-                    <template x-if="control.input_format === 'uri' && control.choices.length && !control.secret">
+                    <template x-if="control.input_format === 'uri' && (control.choices.length || control.suggestions.length) && !control.secret">
                       <div
                         class="direct-provider-uri-control"
                         @click.outside="if (configurationChoiceOpen === control.name) configurationChoiceOpen = null"
@@ -545,7 +545,7 @@
                           :aria-label="`${control.title} options`"
                           :data-testid="`settings-direct-provider-control-${control.name}-options`"
                         >
-                          <template x-for="choice in control.choices" :key="String(choice)">
+                          <template x-for="choice in (control.suggestions.length ? control.suggestions : control.choices)" :key="String(choice)">
                             <button
                               type="button"
                               class="direct-provider-uri-option"
@@ -573,7 +573,7 @@
                       </div>
                     </template>
 
-                    <template x-if="!control.secret && control.value_type !== 'boolean' && !control.choices.length">
+                    <template x-if="!control.secret && control.value_type !== 'boolean' && !control.choices.length && !control.suggestions.length">
                       <div>
                         <input
                           class="input-pb"

--- a/tests/api/test_issue_search_results.py
+++ b/tests/api/test_issue_search_results.py
@@ -363,6 +363,53 @@ async def test_build_direct_interactive_results_uses_attempt_identity_not_url() 
     assert "getcomics.org" not in repr(matched[0])
 
 
+async def test_build_direct_interactive_results_hides_fingerprint_alternates() -> None:
+    from pullbox.api.v1.issues import build_direct_interactive_results
+
+    provider = DirectSearchProvider(
+        provider_config_id=9,
+        provider_identity="pullbox.libgen",
+        display_name="LibGen",
+        endpoint="http://libgen-provider:8780",
+        bearer_token="provider-token-with-enough-length",
+        allow_private_http=True,
+    )
+    candidate = DirectCandidate(
+        provider_candidate_id="libgen:batman-1",
+        source_reference="https://libgen.gl/book/1",
+        display_title="Batman 001 (2016) (Digital)",
+        raw_title="Batman 001 (2016) (Digital).cbz",
+        parsed=DirectParsedCandidate(
+            series_title="Batman",
+            issue_numbers=["1"],
+            year=2016,
+            format="cbz",
+        ),
+        provider_confidence=0.97,
+    )
+    release = _make_release("Batman 001 (2016) (Digital).cbz", indexer_name="LibGen")
+    validation = ReleaseValidator().validate_all_results(
+        [release],
+        wanted_series="Batman",
+        wanted_issue=1,
+        wanted_year=2016,
+    )[0][0]
+    hidden = DirectSearchDiscovery(
+        attempt_id=43,
+        result=DirectValidatedCandidate(provider, candidate, release, validation),
+        visible=False,
+    )
+
+    matched, rejected = build_direct_interactive_results(
+        (hidden,),
+        eval_kwargs={},
+        issue_type=IssueType.ISSUE,
+    )
+
+    assert matched == []
+    assert rejected == []
+
+
 def test_interactive_results_respect_direct_source_priority() -> None:
     from pullbox.api.v1.issues import (
         build_interactive_results,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -579,6 +579,8 @@ class TestSettingsRouteContracts:
         assert "Official URL" in response.text
         assert "https://annas-archive.gl" in response.text
         assert "control.input_format === 'uri'" in response.text
+        assert "control.choices.length || control.suggestions.length" in response.text
+        assert "control.suggestions.length ? control.suggestions : control.choices" in response.text
         assert "toggleConfigurationChoices(control.name)" in response.text
         assert "selectConfigurationChoice(control.name, choice)" in response.text
         assert "settings-direct-provider-control-${control.name}-toggle" in response.text

--- a/tests/unit/test_direct_provider_contract.py
+++ b/tests/unit/test_direct_provider_contract.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 
 from pullbox.providers.direct.contract import (
     DIRECT_PROVIDER_PROTOCOL_V1,
+    DirectCandidate,
     DirectManifestResponse,
     DirectMirror,
     DirectResolveResponse,
@@ -15,6 +16,19 @@ from pullbox.providers.direct.contract import (
     DirectSearchResponse,
     negotiate_direct_provider_protocol,
 )
+
+
+def _candidate(**overrides: object) -> DirectCandidate:
+    values: dict[str, object] = {
+        "provider_candidate_id": "provider:item-1",
+        "source_reference": "https://source.example/item/1",
+        "display_title": "Example #1",
+        "raw_title": "Example 001 (2026).cbz",
+        "parsed": {"series_title": "Example", "issue_numbers": ["1"]},
+        "provider_confidence": 0.95,
+    }
+    values.update(overrides)
+    return DirectCandidate.model_validate(values)
 
 
 def _manifest(**overrides: object) -> dict[str, object]:
@@ -96,6 +110,75 @@ def test_manifest_normalizes_allowlisted_uri_controls() -> None:
     )
 
 
+def test_manifest_normalizes_open_uri_suggestions_and_source_origin() -> None:
+    manifest = DirectManifestResponse.model_validate(
+        _manifest(
+            configuration_schema={
+                "type": "object",
+                "properties": {
+                    "source_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "default": "https://custom.example",
+                        "x-pullbox-suggestions": [
+                            "https://source-one.example",
+                            "https://source-two.example",
+                        ],
+                        "x-pullbox-source-origin": True,
+                    }
+                },
+                "additionalProperties": False,
+            }
+        )
+    )
+
+    control = manifest.configuration_controls[0]
+    assert control.choices == ()
+    assert control.suggestions == (
+        "https://source-one.example",
+        "https://source-two.example",
+    )
+    assert control.source_origin is True
+
+
+def test_manifest_keeps_suggestions_and_source_origin_independent() -> None:
+    manifest = DirectManifestResponse.model_validate(
+        _manifest(
+            configuration_schema={
+                "type": "object",
+                "properties": {
+                    "suggested_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "x-pullbox-suggestions": ["https://known.example"],
+                    },
+                    "custom_origin": {
+                        "type": "string",
+                        "format": "uri",
+                        "x-pullbox-source-origin": True,
+                    },
+                },
+                "additionalProperties": False,
+            }
+        )
+    )
+
+    suggested, custom = manifest.configuration_controls
+    assert suggested.suggestions == ("https://known.example",)
+    assert suggested.source_origin is False
+    assert custom.suggestions == ()
+    assert custom.source_origin is True
+
+
+def test_candidate_content_fingerprint_is_optional_and_validated() -> None:
+    assert _candidate().content_fingerprint is None
+    fingerprinted = _candidate(content_fingerprint="md5:0123456789abcdef0123456789abcdef")
+    assert fingerprinted.content_fingerprint == "md5:0123456789abcdef0123456789abcdef"
+    assert fingerprinted.content_fingerprint not in repr(fingerprinted)
+    with pytest.raises(ValidationError):
+        _candidate(content_fingerprint="md5:not-a-hash")
+
+
 def test_manifest_rejects_executable_or_nested_configuration_controls() -> None:
     with pytest.raises(ValidationError, match="configuration control is unsupported"):
         DirectManifestResponse.model_validate(
@@ -121,6 +204,46 @@ def test_manifest_rejects_executable_or_nested_configuration_controls() -> None:
         {"type": "string", "format": "html"},
         {"type": "boolean", "format": "uri"},
         {"type": "string", "format": "uri", "x-pullbox-secret": True},
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://127.0.0.1"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://localhost"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://2130706433"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://0x7f000001"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://source.local"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://source.onion"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://source.internal"],
+        },
+        {
+            "type": "string",
+            "format": "uri",
+            "x-pullbox-suggestions": ["https://source.home.arpa"],
+        },
     ],
 )
 def test_manifest_rejects_internally_inconsistent_configuration_controls(
@@ -132,6 +255,38 @@ def test_manifest_rejects_internally_inconsistent_configuration_controls(
                 configuration_schema={
                     "type": "object",
                     "properties": {"unsafe": field},
+                    "additionalProperties": False,
+                }
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "default",
+    [
+        "http://source.example",
+        "https://127.0.0.1",
+        "https://2130706433",
+        "https://source.local",
+        "https://source.onion",
+        "https://source.internal",
+        "https://source.home.arpa",
+    ],
+)
+def test_manifest_rejects_unsafe_source_origin_default(default: str) -> None:
+    with pytest.raises(ValidationError):
+        DirectManifestResponse.model_validate(
+            _manifest(
+                configuration_schema={
+                    "type": "object",
+                    "properties": {
+                        "source_url": {
+                            "type": "string",
+                            "format": "uri",
+                            "default": default,
+                            "x-pullbox-source-origin": True,
+                        }
+                    },
                     "additionalProperties": False,
                 }
             )

--- a/tests/unit/test_direct_provider_registration.py
+++ b/tests/unit/test_direct_provider_registration.py
@@ -35,7 +35,25 @@ from pullbox.services.direct_provider_registration import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _public_source_resolver(_host: str, _port: int) -> Sequence[str]:
+    return ("93.184.216.34",)
+
+
+async def _private_source_resolver(_host: str, _port: int) -> Sequence[str]:
+    return ("127.0.0.1",)
+
+
+async def _mixed_source_resolver(_host: str, _port: int) -> Sequence[str]:
+    return ("93.184.216.34", "127.0.0.1")
+
+
+async def _unresolved_source_resolver(_host: str, _port: int) -> Sequence[str]:
+    raise OSError("source is temporarily unavailable")
 
 
 def _manifest(
@@ -493,6 +511,131 @@ async def test_configuration_updates_validate_controls_and_disable_until_reteste
             db_session,
             registered.id,
             public_configuration={"source_url": "https://annas-archive.gd.evil.example"},
+        )
+
+
+async def test_open_source_origin_accepts_safe_custom_url_and_rejects_private_dns(
+    db_session: AsyncSession,
+) -> None:
+    _FakeProviderClient.manifest_response = _manifest(
+        configuration_schema={
+            "type": "object",
+            "properties": {
+                "source_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "default": "https://source.example",
+                    "x-pullbox-suggestions": ["https://source.example"],
+                    "x-pullbox-source-origin": True,
+                }
+            },
+            "additionalProperties": False,
+        }
+    )
+    registered = await register_direct_provider(
+        db_session,
+        DirectProviderRegistrationInput(
+            endpoint="http://provider:8780",
+            bearer_token="registration-token-with-sufficient-length",
+            allow_private_http=True,
+            confirm_custom_provider=True,
+        ),
+        client_factory=_factory,
+    )
+
+    updated = await update_direct_provider(
+        db_session,
+        registered.id,
+        public_configuration={"source_url": "https://custom-source.example"},
+        source_origin_resolver=_public_source_resolver,
+    )
+
+    assert updated.public_configuration["source_url"] == "https://custom-source.example"
+
+    unavailable = await update_direct_provider(
+        db_session,
+        registered.id,
+        public_configuration={"source_url": "https://temporarily-unavailable.example"},
+        source_origin_resolver=_unresolved_source_resolver,
+    )
+
+    assert unavailable.public_configuration["source_url"] == (
+        "https://temporarily-unavailable.example"
+    )
+
+    with pytest.raises(DirectProviderRegistrationError, match="public network"):
+        await update_direct_provider(
+            db_session,
+            registered.id,
+            public_configuration={"source_url": "https://private-source.example"},
+            source_origin_resolver=_private_source_resolver,
+        )
+
+    with pytest.raises(DirectProviderRegistrationError, match="public network"):
+        await update_direct_provider(
+            db_session,
+            registered.id,
+            public_configuration={"source_url": "https://mixed-source.example"},
+            source_origin_resolver=_mixed_source_resolver,
+        )
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "http://source.example",
+        "https://user:secret@source.example",
+        "https://source.example/path",
+        "https://source.example?mirror=one",
+        "https://source.example#fragment",
+        "https://127.0.0.1",
+        "https://localhost",
+        "https://provider.localhost",
+        "https://2130706433",
+        "https://0x7f000001",
+        "https://017700000001",
+        "https://source.local",
+        "https://source.onion",
+        "https://source.internal",
+        "https://source.home.arpa",
+    ],
+)
+async def test_open_source_origin_rejects_unsafe_url_shapes(
+    db_session: AsyncSession,
+    source_url: str,
+) -> None:
+    _FakeProviderClient.manifest_response = _manifest(
+        provider_id="community.unsafe",
+        configuration_schema={
+            "type": "object",
+            "properties": {
+                "source_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "x-pullbox-suggestions": ["https://source.example"],
+                    "x-pullbox-source-origin": True,
+                }
+            },
+            "additionalProperties": False,
+        },
+    )
+    registered = await register_direct_provider(
+        db_session,
+        DirectProviderRegistrationInput(
+            endpoint="http://provider:8780",
+            bearer_token="registration-token-with-sufficient-length",
+            allow_private_http=True,
+            confirm_custom_provider=True,
+        ),
+        client_factory=_factory,
+    )
+
+    with pytest.raises(DirectProviderRegistrationError):
+        await update_direct_provider(
+            db_session,
+            registered.id,
+            public_configuration={"source_url": source_url},
+            source_origin_resolver=_public_source_resolver,
         )
 
 

--- a/tests/unit/test_direct_provider_registration.py
+++ b/tests/unit/test_direct_provider_registration.py
@@ -598,6 +598,11 @@ async def test_open_source_origin_accepts_safe_custom_url_and_rejects_private_dn
         "https://source.onion",
         "https://source.internal",
         "https://source.home.arpa",
+        "https://bad host.example",
+        "https://-bad.example",
+        "https://bad-.example",
+        "https://bad..example",
+        "https://singlelabel",
     ],
 )
 async def test_open_source_origin_rejects_unsafe_url_shapes(

--- a/tests/unit/test_direct_resolver_service.py
+++ b/tests/unit/test_direct_resolver_service.py
@@ -529,6 +529,75 @@ async def test_provider_profile_requires_every_capability_and_opt_in_gate(
 
     provider.resolver_enabled = False
     assert await build_provider_resolver_profile(db_session, provider) is None
+
+
+async def test_provider_profile_includes_only_its_configured_effective_source_origin(
+    db_session: AsyncSession,
+) -> None:
+    now = datetime.now(UTC)
+    resolver = DirectResolverConfig(
+        name="default",
+        endpoint="http://resolver:8191",
+        enabled=True,
+        state=DirectResolverState.HEALTHY,
+        allow_private_http=True,
+        timeout_seconds=45,
+        max_concurrency=1,
+        last_tested_at=now,
+    )
+    provider = DirectProviderConfig(
+        provider_id="pullbox.libgen",
+        display_name="LibGen",
+        endpoint="http://provider:8780",
+        enabled=True,
+        priority=10,
+        state=DirectProviderState.HEALTHY,
+        negotiated_protocol=DIRECT_PROVIDER_PROTOCOL_V1,
+        trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+        encrypted_bearer_token="enc:not-used",
+        resolver_enabled=True,
+        configuration_metadata={"public_values": {"source_url": "https://custom-source.example"}},
+        manifest_snapshot={
+            **_manifest(browser_challenge=True, domains=["libgen.gl", "libgen.li"]),
+            "configuration_schema": {
+                "type": "object",
+                "properties": {
+                    "source_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "x-pullbox-suggestions": ["https://libgen.gl"],
+                        "x-pullbox-source-origin": True,
+                    }
+                },
+                "additionalProperties": False,
+            },
+        },
+    )
+    unrelated = DirectProviderConfig(
+        provider_id="community.other",
+        display_name="Other",
+        endpoint="http://other:8780",
+        enabled=True,
+        priority=20,
+        state=DirectProviderState.HEALTHY,
+        negotiated_protocol=DIRECT_PROVIDER_PROTOCOL_V1,
+        trust_level=DirectProviderTrustLevel.CUSTOM,
+        encrypted_bearer_token="enc:not-used",
+        resolver_enabled=True,
+        configuration_metadata={"public_values": {"source_url": "https://unrelated.example"}},
+        manifest_snapshot=_manifest(browser_challenge=True, domains=["other.example"]),
+    )
+    db_session.add_all([resolver, provider, unrelated])
+    await db_session.commit()
+
+    profile = await build_provider_resolver_profile(db_session, provider)
+
+    assert profile is not None
+    assert profile.declared_domains == [
+        "libgen.gl",
+        "libgen.li",
+        "custom-source.example",
+    ]
     provider.resolver_enabled = True
     provider.manifest_snapshot = _manifest(browser_challenge=False, domains=["source.example"])
     assert await build_provider_resolver_profile(db_session, provider) is None

--- a/tests/unit/test_direct_resolver_service.py
+++ b/tests/unit/test_direct_resolver_service.py
@@ -606,6 +606,54 @@ async def test_provider_profile_includes_only_its_configured_effective_source_or
     assert await build_provider_resolver_profile(db_session, provider) is None
 
 
+async def test_provider_profile_bounds_domains_and_keeps_configured_source_origin(
+    db_session: AsyncSession,
+) -> None:
+    resolver = DirectResolverConfig(
+        name="default",
+        endpoint="http://resolver:8191",
+        enabled=True,
+        state=DirectResolverState.HEALTHY,
+        allow_private_http=True,
+    )
+    manifest_domains = [f"source-{index}.example" for index in range(100)]
+    provider = DirectProviderConfig(
+        provider_id="pullbox.libgen",
+        display_name="LibGen",
+        endpoint="http://provider:8780",
+        enabled=True,
+        state=DirectProviderState.HEALTHY,
+        negotiated_protocol=DIRECT_PROVIDER_PROTOCOL_V1,
+        trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+        encrypted_bearer_token="enc:not-used",
+        resolver_enabled=True,
+        configuration_metadata={"public_values": {"source_url": "https://custom-source.example"}},
+        manifest_snapshot={
+            **_manifest(browser_challenge=True, domains=manifest_domains),
+            "configuration_schema": {
+                "type": "object",
+                "properties": {
+                    "source_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "x-pullbox-source-origin": True,
+                    }
+                },
+                "additionalProperties": False,
+            },
+        },
+    )
+    db_session.add_all([resolver, provider])
+    await db_session.commit()
+
+    profile = await build_provider_resolver_profile(db_session, provider)
+
+    assert profile is not None
+    assert len(profile.declared_domains) == 100
+    assert profile.declared_domains[-1] == "custom-source.example"
+    assert "source-99.example" not in profile.declared_domains
+
+
 async def test_provider_profiles_follow_resolver_priority(
     db_session: AsyncSession,
 ) -> None:

--- a/tests/unit/test_direct_search_coordinator.py
+++ b/tests/unit/test_direct_search_coordinator.py
@@ -79,7 +79,12 @@ def _provider(identity: str, priority: int) -> DirectSearchProvider:
     )
 
 
-def _candidate(provider: DirectSearchProvider, title: str) -> DirectCandidate:
+def _candidate(
+    provider: DirectSearchProvider,
+    title: str,
+    *,
+    content_fingerprint: str | None = None,
+) -> DirectCandidate:
     return DirectCandidate(
         provider_candidate_id=f"candidate:{provider.provider_identity}",
         source_reference=f"https://{provider.provider_identity}.example/release",
@@ -92,6 +97,7 @@ def _candidate(provider: DirectSearchProvider, title: str) -> DirectCandidate:
             format="cbz",
         ),
         provider_confidence=0.95,
+        content_fingerprint=content_fingerprint,
         provenance={"fixture": True},
     )
 
@@ -217,6 +223,104 @@ async def test_fanout_is_concurrent_and_completion_order_does_not_change_results
     ]
     assert all(item.validation.confidence is MatchConfidence.HIGH for item in outcome.matched)
     assert outcome.failures == ()
+
+
+async def test_cross_provider_fingerprint_collapses_to_one_result_with_alternate() -> None:
+    _reset()
+    preferred = _provider("pullbox.libgen", 10)
+    alternate = _provider("pullbox.annas_archive", 20)
+    fingerprint = "md5:0123456789abcdef0123456789abcdef"
+    _Client.responses = {
+        preferred.provider_identity: [
+            _candidate(
+                preferred,
+                "Absolute Superman 009 (2025) (Digital)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+        alternate.provider_identity: [
+            _candidate(
+                alternate,
+                "Absolute Superman 009 (2025) (Digital)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+    }
+
+    outcome = await search_direct_issue_target(
+        _target(),
+        [alternate, preferred],
+        client_factory=_factory,
+    )
+
+    assert len(outcome.matched) == 1
+    assert outcome.matched[0].provider is preferred
+    assert [item.provider for item in outcome.matched[0].alternate_results] == [alternate]
+
+
+async def test_different_fingerprints_remain_distinct_results() -> None:
+    _reset()
+    first = _provider("pullbox.libgen", 10)
+    second = _provider("pullbox.annas_archive", 20)
+    _Client.responses = {
+        first.provider_identity: [
+            _candidate(
+                first,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=f"md5:{'1' * 32}",
+            )
+        ],
+        second.provider_identity: [
+            _candidate(
+                second,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=f"md5:{'2' * 32}",
+            )
+        ],
+    }
+
+    outcome = await search_direct_issue_target(
+        _target(),
+        [first, second],
+        client_factory=_factory,
+    )
+
+    assert len(outcome.matched) == 2
+    assert all(item.alternate_results == () for item in outcome.matched)
+
+
+async def test_fingerprint_never_promotes_a_semantically_rejected_candidate() -> None:
+    _reset()
+    accepted_provider = _provider("pullbox.libgen", 10)
+    rejected_provider = _provider("pullbox.annas_archive", 20)
+    fingerprint = f"md5:{'3' * 32}"
+    _Client.responses = {
+        accepted_provider.provider_identity: [
+            _candidate(
+                accepted_provider,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+        rejected_provider.provider_identity: [
+            _candidate(
+                rejected_provider,
+                "Completely Different Series 009 (2025)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+    }
+
+    outcome = await search_direct_issue_target(
+        _target(),
+        [accepted_provider, rejected_provider],
+        client_factory=_factory,
+    )
+
+    assert len(outcome.matched) == 1
+    assert outcome.matched[0].alternate_results == ()
+    assert len(outcome.rejected) == 1
+    assert outcome.rejected[0].alternate_results == ()
 
 
 async def test_one_provider_failure_is_isolated_and_redacted() -> None:
@@ -693,6 +797,7 @@ async def test_persisted_discovery_is_restart_safe_and_contains_no_urls_or_secre
     candidate = _candidate(provider, "Absolute Superman 009 (2025)").model_copy(
         update={
             "source_reference": "https://pullbox.getcomics.example/book?token=signed-secret",
+            "content_fingerprint": f"md5:{'5' * 32}",
             "provenance": {"token": "provider-secret", "layout": "fixture-v1"},
         }
     )
@@ -710,7 +815,84 @@ async def test_persisted_discovery_is_restart_safe_and_contains_no_urls_or_secre
     assert "https://" not in serialized
     assert "signed-secret" not in serialized
     assert "provider-secret" not in serialized
+    assert f"md5:{'5' * 32}" not in serialized
     assert stored.provider_candidate_id == candidate.provider_candidate_id
     assert stored.state.value == "discovered"
     assert stored.requested_coverage["issue_numbers"] == ["9"]
     assert stored.requested_coverage["volume"] is None
+
+
+async def test_fingerprint_alternates_are_persisted_but_only_primary_is_visible(
+    db_session: AsyncSession,
+) -> None:
+    series = Series(
+        comicvine_id=700_101,
+        title="Absolute Superman",
+        sort_title="Absolute Superman",
+        year_start=2025,
+        status=SeriesStatus.CONTINUING,
+        series_type=SeriesType.STANDARD,
+        monitored=True,
+        issue_count=1,
+    )
+    db_session.add(series)
+    await db_session.flush()
+    db_session.add(
+        Issue(
+            id=17,
+            series_id=series.id,
+            comicvine_id=700_117,
+            issue_number=9,
+            issue_type=IssueType.ISSUE,
+            status=IssueStatus.WANTED,
+        )
+    )
+    for provider_id, identity in ((10, "pullbox.libgen"), (20, "pullbox.annas_archive")):
+        db_session.add(
+            DirectProviderConfig(
+                id=provider_id,
+                provider_id=identity,
+                display_name=identity,
+                endpoint=f"https://provider-{provider_id}.example",
+                enabled=True,
+                priority=provider_id,
+                state=DirectProviderState.HEALTHY,
+                trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+            )
+        )
+    await db_session.flush()
+
+    primary_provider = _provider("pullbox.libgen", 10)
+    alternate_provider = _provider("pullbox.annas_archive", 20)
+    fingerprint = f"md5:{'4' * 32}"
+    _reset()
+    _Client.responses = {
+        primary_provider.provider_identity: [
+            _candidate(
+                primary_provider,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+        alternate_provider.provider_identity: [
+            _candidate(
+                alternate_provider,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=fingerprint,
+            )
+        ],
+    }
+    outcome = await search_direct_issue_target(
+        _target(),
+        [primary_provider, alternate_provider],
+        client_factory=_factory,
+    )
+
+    discoveries = await persist_direct_search_discoveries(db_session, _target(), outcome)
+
+    assert len(discoveries) == 2
+    assert [discovery.visible for discovery in discoveries] == [True, False]
+    assert [discovery.result.provider.provider_identity for discovery in discoveries] == [
+        "pullbox.libgen",
+        "pullbox.annas_archive",
+    ]

--- a/tests/unit/test_unified_search_selection.py
+++ b/tests/unit/test_unified_search_selection.py
@@ -281,6 +281,39 @@ def test_direct_provider_priority_precedes_filename_quality_for_automatic_search
     assert [item.direct_result for item in ranked[:2]] == [getcomics, annas]
 
 
+def test_fingerprint_alternate_remains_available_for_acquisition_fallback() -> None:
+    indexer = _release("Batman 001.cbz", "Indexer", size=25_000_000)
+    primary = _direct_result(
+        _release("Batman 001 (2016) (Digital).cbz", "LibGen"),
+        provider_identity="pullbox.libgen",
+        provider_priority=10,
+    )
+    alternate = _direct_result(
+        _release("Batman 001 (2016) (Digital).cbz", "Anna's Archive"),
+        provider_identity="pullbox.annas_archive",
+        provider_priority=20,
+    )
+    primary = replace(primary, alternate_results=(alternate,))
+    outcome = replace(
+        _outcome(indexer, primary),
+        direct_outcome=DirectSearchOutcome(
+            matched=(primary,),
+            rejected=(),
+            failures=(),
+            providers_searched=2,
+            elapsed_ms=1,
+        ),
+    )
+
+    ranked = rank_search_sources(
+        outcome,
+        {},
+        source_priority=["direct", "usenet", "torrent"],
+    )
+
+    assert [item.direct_result for item in ranked[:2]] == [primary, alternate]
+
+
 def test_direct_semantic_confidence_precedes_provider_priority() -> None:
     indexer = _release("Batman 001.cbz", "Indexer", size=25_000_000)
     lower_confidence_getcomics = _direct_result(


### PR DESCRIPTION
## Summary
- add an optional namespaced content fingerprint to direct-provider candidates
- collapse accepted cross-provider duplicates while preserving deterministic fallback routes
- add editable provider source suggestions and safe request-scoped source-origin handling
- preserve existing providers, matching behavior, and closed configuration enums

## Validation
- focused provider contract, registration, resolver, coordinator, ranking, API, and UI suites
- `make validate` (7,985 passed, 13 skipped, 1 xfailed)
- provider compatibility and Docker conformance validated in the companion provider branch

## Scope
This is provider-neutral LG-1 infrastructure only. It does not register LibGen or introduce a provider-specific matcher, byte path, or database migration.