### PR TITLE
feat: integrate LibGen direct-download fallback

### DIFF
--- a/src/pullbox/api/v1/issues.py
+++ b/src/pullbox/api/v1/issues.py
@@ -50,6 +50,7 @@ from pullbox.services.airdcpp_route_tokens import get_airdcpp_route_token_store
 from pullbox.services.direct_acquisition_planner_service import (
     DirectAcquisitionPlanningError,
     plan_direct_acquisition,
+    plan_direct_acquisition_with_provider_fallback,
 )
 from pullbox.services.direct_search_coordinator import (
     DirectSearchDiscovery,
@@ -68,7 +69,11 @@ from pullbox.services.release_validator import (
     ValidationResult,
 )
 from pullbox.services.search_acquisition_router import route_search_acquisition
-from pullbox.services.search_scoring import match_confidence_rank, normalize_source_priority
+from pullbox.services.search_scoring import (
+    DIRECT_PROVIDER_NEUTRAL_PRIORITY,
+    match_confidence_rank,
+    normalize_source_priority,
+)
 from pullbox.services.search_service import (
     DEFAULT_TYPE_THRESHOLDS,
     IssueSearchOutcome,
@@ -180,6 +185,7 @@ def build_interactive_results(
     *,
     issue_type: IssueType = IssueType.ISSUE,
     type_thresholds: dict[str, str] | None = None,
+    scoring_priority: int | None = None,
 ) -> tuple[list[SearchResultItem], list[RejectedResultItem]]:
     """Build schema objects from validation results with quality scoring.
 
@@ -202,6 +208,7 @@ def build_interactive_results(
     for vr in matched_vr:
         quality = score_release(
             vr.release,
+            scoring_priority,
             min_size_mb=int(str(min_size_mb)) if min_size_mb else 50,
             max_size_mb=int(str(max_size_mb)) if max_size_mb else 2000,
             preferred_format=str(preferred_format) if preferred_format else None,
@@ -306,6 +313,7 @@ def build_direct_interactive_results(
                 eval_kwargs,
                 issue_type=issue_type,
                 type_thresholds=type_thresholds,
+                scoring_priority=DIRECT_PROVIDER_NEUTRAL_PRIORITY,
             )
             matched_items.append(direct_matched[0].model_copy(update=common))
         else:
@@ -315,6 +323,7 @@ def build_direct_interactive_results(
                 eval_kwargs,
                 issue_type=issue_type,
                 type_thresholds=type_thresholds,
+                scoring_priority=DIRECT_PROVIDER_NEUTRAL_PRIORITY,
             )
             rejected_items.append(direct_rejected[0].model_copy(update=common))
     return matched_items, rejected_items
@@ -339,11 +348,11 @@ def sort_interactive_results_by_source_priority[
 
     def _rank(
         item: SearchResultItem | RejectedResultItem,
-    ) -> tuple[int, int, float, int, float]:
+    ) -> tuple[int, int, float, float, int]:
         score = getattr(item, "quality_score", None)
         source_rank = priority_map.get(_source(item), 0)
         if item.source_kind != "direct" or normalized is None:
-            return source_rank, 0, 0.0, 0, -float(score) if score is not None else 0.0
+            return source_rank, 0, 0.0, -float(score) if score is not None else 0.0, 0
         similarity = (
             item.match_details.series_similarity if isinstance(item, SearchResultItem) else 0.0
         )
@@ -351,8 +360,8 @@ def sort_interactive_results_by_source_priority[
             source_rank,
             match_confidence_rank(item.confidence),
             -similarity,
-            item.ranking_priority,
             -float(score) if score is not None else 0.0,
+            item.ranking_priority,
         )
 
     return sorted(items, key=_rank)
@@ -822,10 +831,11 @@ async def grab_direct_release(
     attempt.replace_existing_file = issue.library_file is not None
 
     try:
-        planned = await plan_direct_acquisition(
+        planned = await plan_direct_acquisition_with_provider_fallback(
             session,
             acquisition_id=attempt.id,
             pinned_route_identity=body.pinned_route_identity,
+            planner=plan_direct_acquisition,
         )
     except DirectAcquisitionPlanningError as exc:
         await session.commit()
@@ -834,27 +844,27 @@ async def grab_direct_release(
     await _increment_search_log_grabbed(
         session,
         issue_id=issue_id,
-        search_log_id=attempt.search_log_id,
+        search_log_id=planned.attempt.search_log_id,
     )
     await session.commit()
 
     runner = get_direct_acquisition_runner()
     await runner.dispatch(
-        attempt.id,
+        planned.attempt.id,
         planned.selected_artifact.id,
         initial_source=planned.initial_source,
     )
-    title = str(attempt.candidate_snapshot.get("display_title") or "Direct download")
+    title = str(planned.attempt.candidate_snapshot.get("display_title") or "Direct download")
     logger.info(
         "issue_manual_direct_grab",
         issue_id=issue_id,
-        acquisition_id=attempt.id,
+        acquisition_id=planned.attempt.id,
         artifact_id=planned.selected_artifact.id,
-        provider_id=attempt.provider_identity,
+        provider_id=planned.attempt.provider_identity,
     )
     return DirectGrabResponse(
         issue_id=issue_id,
-        acquisition_id=attempt.id,
+        acquisition_id=planned.attempt.id,
         artifact_id=planned.selected_artifact.id,
         title=title,
         status="queued",

--- a/src/pullbox/providers/artifact_hosts/contract.py
+++ b/src/pullbox/providers/artifact_hosts/contract.py
@@ -93,6 +93,7 @@ class ResolvedTransfer:
     expires_at: datetime | None = None
     filename_hint: str | None = None
     range_supported: bool = False
+    prefer_single_response: bool = False
     allowed_domains: tuple[str, ...] = ()
     transport_protocol: ArtifactTransferProtocol = ArtifactTransferProtocol.HTTPS
     bridge_session: str | None = field(default=None, repr=False)

--- a/src/pullbox/providers/artifact_hosts/generic.py
+++ b/src/pullbox/providers/artifact_hosts/generic.py
@@ -13,6 +13,7 @@ from pullbox.providers.artifact_hosts.contract import (
     ArtifactHostResolutionError,
     HostResolutionRequest,
     ResolvedTransfer,
+    sanitize_provider_headers,
 )
 from pullbox.providers.artifact_hosts.helpers import (
     filename_from_content_disposition,
@@ -38,6 +39,8 @@ _HTML_CONTENT_TYPES = frozenset(
         "text/html",
     }
 )
+_GENERIC_HTTPS_USER_AGENT = "Mozilla/5.0 (compatible; Pullbox/1.1; +https://pullbox.app)"
+_UNRELIABLE_RANGE_HOST_SUFFIXES = ("booksdl.lc",)
 
 
 class GenericHttpsAdapter:
@@ -66,13 +69,22 @@ class GenericHttpsAdapter:
             expected_kind=self.host_kind,
             credentials=credentials,
         )
+        provider_headers = sanitize_provider_headers(request.provider_headers)
+        transfer_headers = {
+            **provider_headers,
+            "User-Agent": _GENERIC_HTTPS_USER_AGENT,
+        }
         response = await request_bounded(
             self._http_client,
             "GET",
             url,
             resolver=self._resolver,
             allowed_domains=None,
-            headers={"Accept": "application/octet-stream", "Range": "bytes=0-0"},
+            headers={
+                **transfer_headers,
+                "Accept": "application/octet-stream",
+                "Range": "bytes=0-0",
+            },
             read_body=False,
         )
         if (
@@ -120,7 +132,7 @@ class GenericHttpsAdapter:
         return ResolvedTransfer(
             host_kind=self.host_kind,
             url=response.url,
-            headers={},
+            headers=transfer_headers,
             expected_size=response_size(response, request.expected_size),
             checksum=request.checksum,
             etag=response.headers.get("etag") or request.etag,
@@ -134,5 +146,13 @@ class GenericHttpsAdapter:
                 response.status_code == 206
                 or response.headers.get("accept-ranges", "").lower() == "bytes"
             ),
+            prefer_single_response=_has_unreliable_range_support(response.url),
             allowed_domains=((urlsplit(response.url).hostname or "").lower().rstrip("."),),
         )
+
+
+def _has_unreliable_range_support(url: object) -> bool:
+    host = (urlsplit(str(url)).hostname or "").lower().rstrip(".")
+    return any(
+        host == suffix or host.endswith(f".{suffix}") for suffix in _UNRELIABLE_RANGE_HOST_SUFFIXES
+    )

--- a/src/pullbox/providers/artifact_hosts/transport.py
+++ b/src/pullbox/providers/artifact_hosts/transport.py
@@ -62,6 +62,7 @@ RefreshTransfer = Callable[[], Awaitable[ResolvedTransfer]]
 _REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 _EXPIRED_URL_STATUSES = frozenset({401, 403, 410})
 _SENSITIVE_HEADER_NAMES = frozenset({"authorization", "cookie", "proxy-authorization"})
+_SINGLE_RESPONSE_CHUNK_SIZE_BYTES = 64 * 1024
 __all__ = [
     "ArtifactTransferCancelledError",
     "ArtifactTransferError",
@@ -184,6 +185,7 @@ class HttpArtifactTransport:
         active = resolved
         refreshed = False
         restarted_bad_range = False
+        stream_retries = 0
 
         while True:
             response = await _await_with_cancel(
@@ -224,16 +226,44 @@ class HttpArtifactTransport:
                 elif resume_offset == 0 and response.status_code != 200:
                     raise _http_status_error(response.status_code)
 
-                return await self._stream_response(
-                    response=response,
-                    resolved=active,
-                    destination=destination,
-                    quarantine_root=quarantine_root,
-                    resume_offset=resume_offset,
-                    progress_callback=progress_callback,
-                    cancel_event=cancel_event,
-                    pause_event=pause_event,
-                )
+                try:
+                    return await self._stream_response(
+                        response=response,
+                        resolved=active,
+                        destination=destination,
+                        quarantine_root=quarantine_root,
+                        resume_offset=resume_offset,
+                        progress_callback=progress_callback,
+                        cancel_event=cancel_event,
+                        pause_event=pause_event,
+                    )
+                except ArtifactTransferError as exc:
+                    if not active.prefer_single_response or not _can_retry_range_failure(
+                        exc,
+                        resolved=active,
+                        retries=stream_retries,
+                        policy=self._policy,
+                    ):
+                        raise
+                    partial_size = destination.stat().st_size if destination.exists() else 0
+                    if partial_size < resume_offset or (
+                        active.expected_size is not None and partial_size > active.expected_size
+                    ):
+                        raise _object_changed_error() from exc
+                    made_progress = partial_size > resume_offset
+                    stream_retries = 0 if made_progress else stream_retries + 1
+                    checkpoint = HttpTransferCheckpoint(
+                        bytes_transferred=partial_size,
+                        expected_size=active.expected_size,
+                        etag=response.headers.get("etag") or active.etag,
+                        last_modified=(
+                            response.headers.get("last-modified") or active.last_modified
+                        ),
+                    )
+                    resume_offset = _eligible_resume_offset(active, checkpoint)
+                    if not made_progress:
+                        await _wait_for_range_retry(self._policy, stream_retries)
+                    continue
             finally:
                 await response.aclose()
 
@@ -542,6 +572,8 @@ class HttpArtifactTransport:
                     break
                 except TimeoutError as exc:
                     raise _timeout_error("artifact_transfer_idle_timeout") from exc
+                except httpx.HTTPError as exc:
+                    raise _artifact_host_unavailable_error() from exc
                 if not chunk:
                     continue
                 if transferred + len(chunk) > range_end + 1:
@@ -627,7 +659,9 @@ class HttpArtifactTransport:
             or filename_from_url(resolved.url)
         )
         handle: BinaryIO | None = None
-        iterator = response.aiter_bytes(self._policy.chunk_size_bytes).__aiter__()
+        iterator = response.aiter_bytes(
+            _stream_chunk_size_bytes(resolved, self._policy)
+        ).__aiter__()
 
         try:
             handle = open_quarantine_file(destination, append=resume_offset > 0)
@@ -656,6 +690,8 @@ class HttpArtifactTransport:
                     break
                 except TimeoutError as exc:
                     raise _timeout_error("artifact_transfer_idle_timeout") from exc
+                except httpx.HTTPError as exc:
+                    raise _artifact_host_unavailable_error() from exc
 
                 _raise_for_control(
                     cancel_event=cancel_event,
@@ -727,10 +763,20 @@ def _use_bounded_ranges(
     policy: ArtifactTransferPolicy,
 ) -> bool:
     return bool(
-        resolved.range_supported
+        not resolved.prefer_single_response
+        and resolved.range_supported
         and resolved.expected_size is not None
         and resolved.expected_size > _range_request_bytes(resolved, policy)
     )
+
+
+def _stream_chunk_size_bytes(
+    resolved: ResolvedTransfer,
+    policy: ArtifactTransferPolicy,
+) -> int:
+    if resolved.prefer_single_response:
+        return min(policy.chunk_size_bytes, _SINGLE_RESPONSE_CHUNK_SIZE_BYTES)
+    return policy.chunk_size_bytes
 
 
 def _range_request_bytes(

--- a/src/pullbox/providers/artifact_hosts/transport.py
+++ b/src/pullbox/providers/artifact_hosts/transport.py
@@ -186,16 +186,25 @@ class HttpArtifactTransport:
         refreshed = False
         restarted_bad_range = False
         stream_retries = 0
+        started_at = time.monotonic()
+        deadline = started_at + self._policy.total_timeout_seconds
 
         while True:
-            response = await _await_with_cancel(
-                partial(
-                    self._open_response,
-                    active,
-                    resume_offset=resume_offset,
-                ),
-                cancel_event,
-            )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise _timeout_error("artifact_transfer_total_timeout")
+            try:
+                response = await _await_with_cancel(
+                    partial(
+                        self._open_response,
+                        active,
+                        resume_offset=resume_offset,
+                    ),
+                    cancel_event,
+                    timeout=remaining,
+                )
+            except TimeoutError as exc:
+                raise _timeout_error("artifact_transfer_total_timeout") from exc
             try:
                 if response.status_code in _EXPIRED_URL_STATUSES and refresh_transfer is not None:
                     if refreshed:
@@ -236,6 +245,8 @@ class HttpArtifactTransport:
                         progress_callback=progress_callback,
                         cancel_event=cancel_event,
                         pause_event=pause_event,
+                        started_at=started_at,
+                        deadline=deadline,
                     )
                 except ArtifactTransferError as exc:
                     if not active.prefer_single_response or not _can_retry_range_failure(
@@ -251,7 +262,7 @@ class HttpArtifactTransport:
                     ):
                         raise _object_changed_error() from exc
                     made_progress = partial_size > resume_offset
-                    stream_retries = 0 if made_progress else stream_retries + 1
+                    stream_retries += 1
                     checkpoint = HttpTransferCheckpoint(
                         bytes_transferred=partial_size,
                         expected_size=active.expected_size,
@@ -364,6 +375,8 @@ class HttpArtifactTransport:
                         progress_callback=progress_callback,
                         cancel_event=cancel_event,
                         pause_event=pause_event,
+                        started_at=started_at,
+                        deadline=deadline,
                     )
                 if not _valid_bounded_response(
                     response,
@@ -623,6 +636,8 @@ class HttpArtifactTransport:
         progress_callback: ProgressCallback | None,
         cancel_event: asyncio.Event | None,
         pause_event: asyncio.Event | None,
+        started_at: float,
+        deadline: float,
     ) -> ArtifactTransferResult:
         total = _response_total(response, resume_offset=resume_offset)
         expected = total if total is not None else resolved.expected_size
@@ -647,10 +662,8 @@ class HttpArtifactTransport:
         )
 
         transferred = resume_offset
-        start_time = time.monotonic()
-        last_progress_at = start_time
+        last_progress_at = time.monotonic()
         last_progress_bytes = transferred
-        deadline = start_time + self._policy.total_timeout_seconds
         etag = response.headers.get("etag") or resolved.etag
         last_modified = response.headers.get("last-modified") or resolved.last_modified
         filename = (
@@ -729,7 +742,7 @@ class HttpArtifactTransport:
                         progress_callback,
                         transferred=transferred,
                         total=expected,
-                        started_at=start_time,
+                        started_at=started_at,
                         now=now,
                     )
                     last_progress_at = now
@@ -744,7 +757,7 @@ class HttpArtifactTransport:
             progress_callback,
             transferred=transferred,
             total=expected,
-            started_at=start_time,
+            started_at=started_at,
             now=time.monotonic(),
         )
         return ArtifactTransferResult(

--- a/src/pullbox/providers/direct/client.py
+++ b/src/pullbox/providers/direct/client.py
@@ -85,7 +85,12 @@ class DirectProviderClient:
         self._provider_id = provider_id
         self._owns_http_client = http_client is None
         self._http_client = http_client or httpx.AsyncClient(
-            timeout=httpx.Timeout(connect=5.0, read=20.0, write=10.0, pool=5.0),
+            timeout=httpx.Timeout(
+                connect=5.0,
+                read=request_timeout_seconds,
+                write=10.0,
+                pool=5.0,
+            ),
             follow_redirects=False,
             trust_env=False,
         )
@@ -331,6 +336,10 @@ def _safe_provider_error(content: bytes) -> tuple[str, str, bool, int | None] | 
         ),
         "source_unavailable": ("Provider source is temporarily unavailable.", True),
         "source_malformed_response": ("Provider source returned an invalid response.", False),
+        "source_contract_changed": (
+            "Provider source layout no longer matches its supported contract.",
+            False,
+        ),
         "candidate_not_found": ("Provider candidate is no longer available.", False),
         "browser_challenge_required": (
             "Provider source access requires browser challenge handling.",

--- a/src/pullbox/services/direct_acquisition_executor.py
+++ b/src/pullbox/services/direct_acquisition_executor.py
@@ -304,7 +304,14 @@ class DirectAcquisitionExecutor:
                     ),
                     cancel_event,
                 )
-                await _enter_downloading(session, attempt, artifact, workspace, progress)
+                await _enter_downloading(
+                    session,
+                    attempt,
+                    artifact,
+                    workspace,
+                    resolved,
+                    progress,
+                )
                 transfer_result = await self._transfer(
                     session=session,
                     attempt=attempt,
@@ -962,6 +969,7 @@ async def _enter_downloading(
     attempt: DirectAcquisitionAttempt,
     artifact: DirectArtifactAttempt,
     workspace: DirectQuarantineWorkspace,
+    resolved: ResolvedTransfer,
     progress: _ProgressWriter,
 ) -> None:
     if attempt.state is DirectAcquisitionState.RESOLVING:
@@ -969,7 +977,27 @@ async def _enter_downloading(
     if artifact.state is DirectArtifactState.RESOLVING:
         transition_artifact(artifact, DirectArtifactState.TRANSFERRING)
     artifact.quarantine_path = str(workspace.partial_path)
-    await progress.write(stage="downloading", force=True)
+    if resolved.expected_size is not None:
+        artifact.expected_size = resolved.expected_size
+    artifact.etag = resolved.etag
+    artifact.last_modified_at = _parse_last_modified(resolved.last_modified)
+    total = artifact.expected_size
+    transferred = artifact.bytes_transferred
+    await progress.write(
+        stage="downloading",
+        snapshot=TransferProgressSnapshot(
+            bytes_transferred=transferred,
+            total_bytes=total,
+            percent=(
+                min(100, int((transferred * 100) / total))
+                if total is not None and total > 0
+                else None
+            ),
+            bytes_per_second=None,
+            eta_seconds=None,
+        ),
+        force=True,
+    )
 
 
 async def _load_host_credentials(

--- a/src/pullbox/services/direct_acquisition_planner_service.py
+++ b/src/pullbox/services/direct_acquisition_planner_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Protocol
@@ -306,6 +306,78 @@ async def plan_direct_acquisition(
             },
         )
         raise
+
+
+async def plan_direct_acquisition_with_provider_fallback(
+    session: AsyncSession,
+    *,
+    acquisition_id: int,
+    pinned_route_identity: str | None = None,
+    planner: Callable[..., Awaitable[DirectAcquisitionPlanningResult]] | None = None,
+    skip_selected_attempt: bool = False,
+) -> DirectAcquisitionPlanningResult:
+    """Plan one logical result, trying its opaque provider alternates in order."""
+    selected_attempt = await _load_attempt(session, acquisition_id)
+    raw_alternate_ids = selected_attempt.candidate_snapshot.get("alternate_attempt_ids", [])
+    alternate_ids = (
+        [value for value in raw_alternate_ids if isinstance(value, int) and value > 0]
+        if isinstance(raw_alternate_ids, list) and pinned_route_identity is None
+        else []
+    )
+    plan = planner or plan_direct_acquisition
+    first_error: DirectAcquisitionPlanningError | None = None
+    candidate_ids = alternate_ids if skip_selected_attempt else [acquisition_id, *alternate_ids]
+
+    for candidate_id in candidate_ids:
+        candidate = await _load_attempt(session, candidate_id)
+        if candidate.issue_id != selected_attempt.issue_id:
+            continue
+        candidate.replace_existing_file = selected_attempt.replace_existing_file
+        try:
+            planned = await plan(
+                session,
+                acquisition_id=candidate.id,
+                pinned_route_identity=(
+                    pinned_route_identity if candidate.id == acquisition_id else None
+                ),
+            )
+        except DirectAcquisitionPlanningError as exc:
+            if first_error is None:
+                first_error = exc
+            continue
+        if candidate.id != acquisition_id:
+            advance_acquisition_progress(
+                selected_attempt,
+                revision=selected_attempt.progress_revision + 1,
+                snapshot={
+                    **selected_attempt.progress_snapshot,
+                    "schema_version": 1,
+                    "stage": "provider_fallback",
+                    "fallback_attempt_id": candidate.id,
+                    "fallback_provider_identity": candidate.provider_identity,
+                },
+            )
+            advance_acquisition_progress(
+                candidate,
+                revision=candidate.progress_revision + 1,
+                snapshot={
+                    **candidate.progress_snapshot,
+                    "schema_version": 1,
+                    "fallback_from_attempt_id": selected_attempt.id,
+                    "fallback_from_provider_identity": selected_attempt.provider_identity,
+                },
+            )
+            await session.flush()
+        return planned
+
+    if first_error is not None:
+        raise first_error
+    raise DirectAcquisitionPlanningError(
+        "provider_fallback_unavailable",
+        "No provider route remains available for this direct result.",
+        failure_class=DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+        intervention=False,
+    )
 
 
 async def resolve_planned_artifact_source(

--- a/src/pullbox/services/direct_search_coordinator.py
+++ b/src/pullbox/services/direct_search_coordinator.py
@@ -269,10 +269,13 @@ async def persist_direct_search_discoveries(
             **primary_attempt.candidate_snapshot,
             "alternate_attempt_ids": [attempt.id for attempt in alternate_attempts],
         }
-        for alternate_attempt in alternate_attempts:
+        for index, alternate_attempt in enumerate(alternate_attempts):
             alternate_attempt.candidate_snapshot = {
                 **alternate_attempt.candidate_snapshot,
                 "primary_attempt_id": primary_attempt.id,
+                "alternate_attempt_ids": [
+                    attempt.id for attempt in alternate_attempts[index + 1 :]
+                ],
             }
     return tuple(
         DirectSearchDiscovery(attempt_id=attempt.id, result=result, visible=visible)

--- a/src/pullbox/services/direct_search_coordinator.py
+++ b/src/pullbox/services/direct_search_coordinator.py
@@ -225,13 +225,17 @@ async def persist_direct_search_discoveries(
 ) -> tuple[DirectSearchDiscovery, ...]:
     """Persist redacted candidate evidence and return server-issued IDs."""
     pending: list[tuple[DirectAcquisitionAttempt, DirectValidatedCandidate, bool]] = []
+    fingerprint_groups: list[tuple[DirectAcquisitionAttempt, list[DirectAcquisitionAttempt]]] = []
     issue_number = f"{target.issue_number:g}"
     volume = _target_volume(target)
     for primary in (*outcome.matched, *outcome.rejected):
+        group_attempts: list[DirectAcquisitionAttempt] = []
         for result, visible in (
             (primary, True),
             *((alternate, False) for alternate in primary.alternate_results),
         ):
+            candidate_snapshot = _candidate_snapshot(result)
+            candidate_snapshot["visible"] = visible
             attempt = DirectAcquisitionAttempt(
                 request_key=f"direct-search:{uuid4().hex}",
                 issue_id=target.issue_id,
@@ -245,7 +249,7 @@ async def persist_direct_search_discoveries(
                     "issue_type": target.issue_type.value,
                     "volume": volume,
                 },
-                candidate_snapshot=_candidate_snapshot(result),
+                candidate_snapshot=candidate_snapshot,
                 plan_snapshot={},
                 progress_snapshot={
                     "schema_version": 1,
@@ -254,8 +258,22 @@ async def persist_direct_search_discoveries(
             )
             session.add(attempt)
             pending.append((attempt, result, visible))
+            group_attempts.append(attempt)
+        fingerprint_groups.append((group_attempts[0], group_attempts[1:]))
     if pending:
         await session.flush()
+    for primary_attempt, alternate_attempts in fingerprint_groups:
+        if not alternate_attempts:
+            continue
+        primary_attempt.candidate_snapshot = {
+            **primary_attempt.candidate_snapshot,
+            "alternate_attempt_ids": [attempt.id for attempt in alternate_attempts],
+        }
+        for alternate_attempt in alternate_attempts:
+            alternate_attempt.candidate_snapshot = {
+                **alternate_attempt.candidate_snapshot,
+                "primary_attempt_id": primary_attempt.id,
+            }
     return tuple(
         DirectSearchDiscovery(attempt_id=attempt.id, result=result, visible=visible)
         for attempt, result, visible in pending
@@ -683,8 +701,8 @@ def _matched_order_key(item: DirectValidatedCandidate) -> tuple[object, ...]:
     return (
         match_confidence_rank(item.validation.confidence),
         -item.validation.series_similarity,
-        item.provider.provider_priority,
         -item.candidate.provider_confidence,
+        item.provider.provider_priority,
         item.provider.provider_identity,
         item.candidate.provider_candidate_id,
     )

--- a/src/pullbox/services/search_scoring.py
+++ b/src/pullbox/services/search_scoring.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 DEFAULT_MIN_SIZE_MB = 50
 DEFAULT_MAX_SIZE_MB = 2000
+DIRECT_PROVIDER_NEUTRAL_PRIORITY = 25
 PREFERRED_FORMATS: dict[str, int] = {"cbz": 100, "cbr": 80, "cb7": 60}
 DEFAULT_SOURCE_PRIORITY: tuple[str, ...] = ("usenet", "torrent", "direct", "dc")
 

--- a/src/pullbox/services/search_source_selection.py
+++ b/src/pullbox/services/search_source_selection.py
@@ -9,6 +9,7 @@ from pullbox.services.search_evaluation import DEFAULT_MIN_SCORE, _select_best_v
 from pullbox.services.search_scoring import (
     DEFAULT_MAX_SIZE_MB,
     DEFAULT_MIN_SIZE_MB,
+    DIRECT_PROVIDER_NEUTRAL_PRIORITY,
     match_confidence_rank,
     normalize_source_priority,
 )
@@ -160,30 +161,46 @@ def rank_search_sources(
         | None
     ):
         direct_items = [item for item in items if item[2] is not None]
-        semantic_provider_keys = sorted(
+        semantic_keys = sorted(
             {
                 (
                     match_confidence_rank(item[1].confidence),
                     -item[1].series_similarity,
-                    item[2].provider.provider_priority,
                 )
                 for item in direct_items
                 if item[2] is not None
             }
         )
-        for key in semantic_provider_keys:
-            group = [
-                item
-                for item in direct_items
-                if item[2] is not None
-                and (
-                    match_confidence_rank(item[1].confidence),
-                    -item[1].series_similarity,
-                    item[2].provider.provider_priority,
-                )
-                == key
-            ]
-            selected = _select([item[1] for item in group])
+        for key in semantic_keys:
+            group = sorted(
+                [
+                    item
+                    for item in direct_items
+                    if item[2] is not None
+                    and (
+                        match_confidence_rank(item[1].confidence),
+                        -item[1].series_similarity,
+                    )
+                    == key
+                ],
+                key=lambda item: item[2].provider.provider_priority if item[2] is not None else 0,
+            )
+            selected = _select_best_validation(
+                [item[1] for item in group],
+                min_score=eval_kwargs.get("min_score", DEFAULT_MIN_SCORE),
+                confidence_blend=eval_kwargs.get("confidence_blend", 0.40),
+                indexer_priority=DIRECT_PROVIDER_NEUTRAL_PRIORITY,
+                min_size_mb=eval_kwargs.get("min_size_mb", DEFAULT_MIN_SIZE_MB),
+                max_size_mb=eval_kwargs.get("max_size_mb", DEFAULT_MAX_SIZE_MB),
+                preferred_format=eval_kwargs.get("preferred_format"),
+                seeder_tiers=eval_kwargs.get("seeder_tiers"),
+                score_weights=eval_kwargs.get("score_weights"),
+                grabs_weight=eval_kwargs.get("grabs_weight", 0),
+                pack_penalty=eval_kwargs.get("pack_penalty", -20),
+                max_file_count=eval_kwargs.get("max_file_count", 5),
+                preferred_language=eval_kwargs.get("preferred_language", "en"),
+                digital_bonus=eval_kwargs.get("digital_bonus", 10),
+            )
             if selected is not None:
                 return next(item for item in group if item[1] is selected)
         return None

--- a/src/pullbox/tasks/direct_acquisition_task.py
+++ b/src/pullbox/tasks/direct_acquisition_task.py
@@ -21,8 +21,14 @@ from pullbox.models.direct_acquisition import (
 )
 from pullbox.providers.artifact_hosts.contract import HostResolutionRequest
 from pullbox.services.blocklist_service import BlocklistService
-from pullbox.services.direct_acquisition_fallback import queue_next_artifact_route
+from pullbox.services.direct_acquisition_fallback import (
+    queue_next_artifact_route,
+    supports_route_fallback,
+)
 from pullbox.services.direct_acquisition_planner_service import (
+    DirectAcquisitionPlanningError,
+    DirectAcquisitionPlanningResult,
+    plan_direct_acquisition_with_provider_fallback,
     resolve_planned_artifact_source,
 )
 from pullbox.services.direct_acquisition_recovery import (
@@ -73,6 +79,7 @@ class DirectExecutor(Protocol):
 
 
 SourceResolver = Callable[..., Awaitable[HostResolutionRequest]]
+ProviderFallbackPlanner = Callable[..., Awaitable[DirectAcquisitionPlanningResult]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -90,10 +97,14 @@ class DirectAcquisitionRunner:
         *,
         executor: DirectExecutor,
         source_resolver: SourceResolver = resolve_planned_artifact_source,
+        provider_fallback_planner: ProviderFallbackPlanner = (
+            plan_direct_acquisition_with_provider_fallback
+        ),
     ) -> None:
         self._session_factory = session_factory
         self._executor = executor
         self._source_resolver = source_resolver
+        self._provider_fallback_planner = provider_fallback_planner
         self._active: dict[tuple[int, int], _ActiveRun] = {}
         self._lock = asyncio.Lock()
 
@@ -490,6 +501,22 @@ class DirectAcquisitionRunner:
                         .execution_options(populate_existing=True)
                     )
                 ).scalar_one()
+                if _supports_provider_fallback(attempt):
+                    try:
+                        planned = await self._provider_fallback_planner(
+                            session,
+                            acquisition_id=attempt.id,
+                            skip_selected_attempt=True,
+                        )
+                    except DirectAcquisitionPlanningError:
+                        return
+                    await session.commit()
+                    await self.dispatch(
+                        planned.attempt.id,
+                        planned.selected_artifact.id,
+                        initial_source=planned.initial_source,
+                    )
+                    return
                 if attempt.state is not DirectAcquisitionState.QUEUED:
                     return
                 selected = [
@@ -554,6 +581,23 @@ class DirectAcquisitionRunner:
                 artifact_id=key[1],
                 error_type=type(error).__name__,
             )
+
+
+def _supports_provider_fallback(attempt: DirectAcquisitionAttempt) -> bool:
+    """Return whether a failed attempt has a safe linked provider alternate."""
+    raw_alternates = attempt.candidate_snapshot.get("alternate_attempt_ids", [])
+    has_alternate = isinstance(raw_alternates, list) and any(
+        isinstance(value, int) and value > 0 for value in raw_alternates
+    )
+    failure_class = attempt.failure_class
+    if attempt.state is not DirectAcquisitionState.FAILED or not has_alternate:
+        return False
+    if failure_class is None:
+        return False
+    return supports_route_fallback(failure_class) or failure_class in {
+        DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+        DirectArtifactFailureClass.CANDIDATE_INVALID,
+    }
 
 
 _runner: DirectAcquisitionRunner | None = None

--- a/tests/api/test_issue_search_results.py
+++ b/tests/api/test_issue_search_results.py
@@ -31,6 +31,7 @@ from pullbox.models import Base
 from pullbox.models.direct_acquisition import (
     DirectAcquisitionAttempt,
     DirectAcquisitionState,
+    DirectArtifactFailureClass,
     DirectProviderConfig,
     DirectProviderState,
     DirectProviderTrustLevel,
@@ -42,6 +43,7 @@ from pullbox.models.user import APIKey, User
 from pullbox.providers.base import ReleaseResult
 from pullbox.providers.direct.contract import DirectCandidate, DirectParsedCandidate
 from pullbox.services.auth_service import AuthService
+from pullbox.services.direct_acquisition_planner_service import DirectAcquisitionPlanningError
 from pullbox.services.direct_search_coordinator import (
     DirectSearchDiscovery,
     DirectSearchOutcome,
@@ -440,7 +442,7 @@ def test_interactive_results_respect_direct_source_priority() -> None:
     assert [item.source_kind for item in ordered] == ["direct", "indexer"]
 
 
-def test_interactive_direct_results_prefer_configured_provider_before_quality() -> None:
+def test_interactive_direct_results_prefer_quality_before_provider_priority() -> None:
     from pullbox.api.v1.issues import (
         build_interactive_results,
         sort_interactive_results_by_source_priority,
@@ -471,19 +473,53 @@ def test_interactive_direct_results_prefer_configured_provider_before_quality() 
         rejected,
         {},
         source_priority=["direct", "usenet", "torrent"],
+        scoring_priority=25,
     )
     direct_items = [item.model_copy(update={"source_kind": "direct"}) for item in items]
 
-    # Anna's richer filename wins the generic quality score, but the user's
-    # explicit direct-provider preference must be authoritative after matching.
+    # Provider priority is a final tie-breaker, so the richer candidate keeps
+    # its lead after semantic and quality scoring.
     assert direct_items[0].indexer_name == "Anna's Archive"
     ordered = sort_interactive_results_by_source_priority(
         direct_items,
         ["direct", "usenet", "torrent"],
     )
 
-    assert [item.indexer_name for item in ordered] == ["GetComics", "Anna's Archive"]
+    assert [item.indexer_name for item in ordered] == ["Anna's Archive", "GetComics"]
     assert "ranking_priority" not in ordered[0].model_dump()
+
+
+def test_interactive_direct_results_use_provider_priority_for_quality_ties() -> None:
+    from pullbox.api.v1.issues import (
+        build_interactive_results,
+        sort_interactive_results_by_source_priority,
+    )
+
+    lower_priority = _make_release(
+        "Batman 001 (2016) (Digital).cbz",
+        "LibGen",
+        ranking_priority=20,
+    )
+    preferred = _make_release(
+        "Batman 001 (2016) (Digital).cbz",
+        "GetComics",
+        ranking_priority=10,
+    )
+    matched, rejected = ReleaseValidator().validate_all_results(
+        [lower_priority, preferred],
+        wanted_series="Batman",
+        wanted_issue=1,
+        wanted_year=2016,
+    )
+    items, _ = build_interactive_results(matched, rejected, {}, scoring_priority=25)
+    direct_items = [item.model_copy(update={"source_kind": "direct"}) for item in items]
+
+    ordered = sort_interactive_results_by_source_priority(
+        direct_items,
+        ["direct", "usenet", "torrent"],
+    )
+
+    assert [item.indexer_name for item in ordered] == ["GetComics", "LibGen"]
 
 
 @pytest.mark.asyncio
@@ -811,6 +847,107 @@ async def test_direct_grab_plans_commits_and_dispatches_ephemeral_source(
     runner.dispatch.assert_awaited_once_with(
         attempt_id,
         77,
+        initial_source=ephemeral_source,
+    )
+
+
+async def test_direct_grab_uses_hidden_provider_fallback_when_primary_cannot_plan(
+    client: AsyncClient,
+    _db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    issue_id = await _create_issue(_db_factory)
+    async with _db_factory() as session:
+        primary_config = DirectProviderConfig(
+            provider_id="pullbox.getcomics",
+            display_name="GetComics",
+            endpoint="http://getcomics-provider:8780",
+            enabled=True,
+            priority=10,
+            state=DirectProviderState.HEALTHY,
+            trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+        )
+        alternate_config = DirectProviderConfig(
+            provider_id="pullbox.libgen",
+            display_name="LibGen",
+            endpoint="http://libgen-provider:8780",
+            enabled=True,
+            priority=20,
+            state=DirectProviderState.HEALTHY,
+            trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+        )
+        session.add_all([primary_config, alternate_config])
+        await session.flush()
+        primary = DirectAcquisitionAttempt(
+            request_key="direct-grab-primary",
+            issue_id=issue_id,
+            provider_config_id=primary_config.id,
+            provider_identity=primary_config.provider_id,
+            provider_candidate_id="candidate-primary",
+            state=DirectAcquisitionState.DISCOVERED,
+            requested_coverage={"issue_numbers": ["1"]},
+            candidate_snapshot={"display_title": "Batman 001 (2016)", "visible": True},
+            plan_snapshot={},
+            progress_snapshot={},
+        )
+        alternate = DirectAcquisitionAttempt(
+            request_key="direct-grab-alternate",
+            issue_id=issue_id,
+            provider_config_id=alternate_config.id,
+            provider_identity=alternate_config.provider_id,
+            provider_candidate_id="candidate-alternate",
+            state=DirectAcquisitionState.DISCOVERED,
+            requested_coverage={"issue_numbers": ["1"]},
+            candidate_snapshot={"display_title": "Batman 001 (2016)", "visible": False},
+            plan_snapshot={},
+            progress_snapshot={},
+        )
+        session.add_all([primary, alternate])
+        await session.flush()
+        primary.candidate_snapshot = {
+            **primary.candidate_snapshot,
+            "alternate_attempt_ids": [alternate.id],
+        }
+        primary_id = primary.id
+        alternate_id = alternate.id
+        await session.commit()
+
+    ephemeral_source = object()
+
+    async def plan(session: AsyncSession, *, acquisition_id: int, **_kwargs: object):
+        planned_attempt = await session.get(DirectAcquisitionAttempt, acquisition_id)
+        assert planned_attempt is not None
+        if acquisition_id == primary_id:
+            planned_attempt.state = DirectAcquisitionState.FAILED
+            raise DirectAcquisitionPlanningError(
+                "provider_resolve_unavailable",
+                "The provider is unavailable.",
+                failure_class=DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+            )
+        planned_attempt.state = DirectAcquisitionState.PLANNED
+        return SimpleNamespace(
+            attempt=planned_attempt,
+            selected_artifact=SimpleNamespace(id=99),
+            initial_source=ephemeral_source,
+        )
+
+    runner = SimpleNamespace(dispatch=AsyncMock(return_value=True))
+    with (
+        patch("pullbox.api.v1.issues.plan_direct_acquisition", side_effect=plan),
+        patch(
+            "pullbox.api.v1.issues.get_direct_acquisition_runner",
+            return_value=runner,
+        ),
+    ):
+        response = await client.post(
+            f"/api/v1/issues/{issue_id}/direct-grab",
+            json={"direct_attempt_id": primary_id},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["acquisition_id"] == alternate_id
+    runner.dispatch.assert_awaited_once_with(
+        alternate_id,
+        99,
         initial_source=ephemeral_source,
     )
 

--- a/tests/unit/test_direct_acquisition_executor.py
+++ b/tests/unit/test_direct_acquisition_executor.py
@@ -289,6 +289,19 @@ class _SuccessfulTransport:
         )
 
 
+class _InitialProgressTransport(_SuccessfulTransport):
+    def __init__(self, attempt: DirectAcquisitionAttempt) -> None:
+        super().__init__()
+        self._attempt = attempt
+        self.initial_progress: dict[str, object] | None = None
+        self.initial_etag: str | None = None
+
+    async def transfer(self, **kwargs: Any) -> ArtifactTransferResult:
+        self.initial_progress = dict(self._attempt.progress_snapshot)
+        self.initial_etag = self._attempt.artifact_attempts[0].etag
+        return await super().transfer(**kwargs)
+
+
 class _FailingTransport:
     def __init__(self, error: BaseException, *, write_partial: bool = False) -> None:
         self.error = error
@@ -492,6 +505,45 @@ async def test_executor_completes_with_durable_redacted_progress(
     assert refreshed_history.final_path == "/library/Issue 1.cbz"
     assert refreshed_history.imported_at == NOW
     assert refreshed_history.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_executor_publishes_known_size_before_first_transfer_byte(
+    session: AsyncSession,
+    tmp_path: Path,
+) -> None:
+    attempt = _attempt()
+    artifact = attempt.artifact_attempts[0]
+    artifact.expected_size = 59_247_008
+    artifact.etag = None
+    session.add(attempt)
+    await session.commit()
+    transport = _InitialProgressTransport(attempt)
+
+    await _executor(
+        tmp_path,
+        transport=transport,
+        post_processor=_successful_post_processor,
+    ).execute(
+        session,
+        acquisition_id=attempt.id,
+        artifact_id=artifact.id,
+        source_factory=_async_source,
+    )
+
+    assert transport.initial_progress == {
+        "schema_version": 1,
+        "stage": "downloading",
+        "artifact_attempt_id": artifact.id,
+        "host_kind": "generic_https",
+        "bytes_transferred": 0,
+        "total_bytes": 59_247_008,
+        "percent": 0,
+        "bytes_per_second": None,
+        "eta_seconds": None,
+        "source_slow": False,
+    }
+    assert transport.initial_etag == '"stable"'
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_direct_acquisition_planner_service.py
+++ b/tests/unit/test_direct_acquisition_planner_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pytest
@@ -39,6 +40,7 @@ from pullbox.services.direct_acquisition_planner_service import (
     DirectAcquisitionPlanningError,
     direct_route_identity,
     plan_direct_acquisition,
+    plan_direct_acquisition_with_provider_fallback,
     resolve_planned_artifact_source,
 )
 from pullbox.services.direct_resolver_service import ProviderResolverOption
@@ -47,6 +49,166 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
 NOW = datetime(2026, 7, 28, 10, 0, tzinfo=UTC)
+
+
+async def test_hidden_provider_alternate_is_planned_after_primary_failure(
+    session: AsyncSession,
+) -> None:
+    alternate_provider = DirectProviderConfig(
+        id=2,
+        provider_id="community.libgen",
+        display_name="LibGen",
+        endpoint="http://libgen:8080",
+        enabled=True,
+        priority=20,
+        state=DirectProviderState.HEALTHY,
+    )
+    primary = DirectAcquisitionAttempt(
+        request_key="primary-fingerprint-result",
+        issue_id=1,
+        provider_config_id=1,
+        provider_identity="community.getcomics",
+        provider_candidate_id="primary-candidate",
+        state=DirectAcquisitionState.DISCOVERED,
+        requested_coverage={"issue_numbers": ["1"]},
+        candidate_snapshot={"display_title": "Planner Series 001", "visible": True},
+        plan_snapshot={},
+        progress_snapshot={},
+    )
+    alternate = DirectAcquisitionAttempt(
+        request_key="alternate-fingerprint-result",
+        issue_id=1,
+        provider_config_id=2,
+        provider_identity="community.libgen",
+        provider_candidate_id="alternate-candidate",
+        state=DirectAcquisitionState.DISCOVERED,
+        requested_coverage={"issue_numbers": ["1"]},
+        candidate_snapshot={"display_title": "Planner Series 001", "visible": False},
+        plan_snapshot={},
+        progress_snapshot={},
+    )
+    session.add_all([alternate_provider, primary, alternate])
+    await session.flush()
+    primary.candidate_snapshot = {
+        **primary.candidate_snapshot,
+        "alternate_attempt_ids": [alternate.id],
+    }
+    alternate.candidate_snapshot = {
+        **alternate.candidate_snapshot,
+        "primary_attempt_id": primary.id,
+    }
+    planned_artifact = SimpleNamespace(id=88)
+    calls: list[int] = []
+
+    async def planner(
+        _session: AsyncSession,
+        *,
+        acquisition_id: int,
+        **_kwargs: object,
+    ) -> object:
+        calls.append(acquisition_id)
+        if acquisition_id == primary.id:
+            primary.state = DirectAcquisitionState.FAILED
+            raise DirectAcquisitionPlanningError(
+                "provider_resolve_unavailable",
+                "The provider is unavailable.",
+                failure_class=DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+            )
+        alternate.state = DirectAcquisitionState.PLANNED
+        return SimpleNamespace(
+            attempt=alternate,
+            selected_artifact=planned_artifact,
+            initial_source=object(),
+        )
+
+    result = await plan_direct_acquisition_with_provider_fallback(
+        session,
+        acquisition_id=primary.id,
+        planner=planner,
+    )
+
+    assert result.attempt is alternate
+    assert calls == [primary.id, alternate.id]
+    assert primary.progress_snapshot["fallback_attempt_id"] == alternate.id
+    assert primary.progress_snapshot["fallback_provider_identity"] == "community.libgen"
+    assert alternate.progress_snapshot["fallback_from_attempt_id"] == primary.id
+    assert alternate.progress_snapshot["fallback_from_provider_identity"] == "community.getcomics"
+
+
+async def test_transfer_recovery_skips_the_already_failed_primary_provider(
+    session: AsyncSession,
+) -> None:
+    alternate_provider = DirectProviderConfig(
+        id=2,
+        provider_id="community.libgen",
+        display_name="LibGen",
+        endpoint="http://libgen:8080",
+        enabled=True,
+        priority=20,
+        state=DirectProviderState.HEALTHY,
+    )
+    primary = DirectAcquisitionAttempt(
+        request_key="failed-primary-fingerprint-result",
+        issue_id=1,
+        provider_config_id=1,
+        provider_identity="community.getcomics",
+        provider_candidate_id="failed-primary-candidate",
+        state=DirectAcquisitionState.FAILED,
+        failure_class=DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+        requested_coverage={"issue_numbers": ["1"]},
+        candidate_snapshot={"display_title": "Planner Series 001", "visible": True},
+        plan_snapshot={},
+        progress_snapshot={},
+    )
+    alternate = DirectAcquisitionAttempt(
+        request_key="recovery-alternate-fingerprint-result",
+        issue_id=1,
+        provider_config_id=2,
+        provider_identity="community.libgen",
+        provider_candidate_id="recovery-alternate-candidate",
+        state=DirectAcquisitionState.DISCOVERED,
+        requested_coverage={"issue_numbers": ["1"]},
+        candidate_snapshot={"display_title": "Planner Series 001", "visible": False},
+        plan_snapshot={},
+        progress_snapshot={},
+    )
+    session.add_all([alternate_provider, primary, alternate])
+    await session.flush()
+    primary.candidate_snapshot = {
+        **primary.candidate_snapshot,
+        "alternate_attempt_ids": [alternate.id],
+    }
+    alternate.candidate_snapshot = {
+        **alternate.candidate_snapshot,
+        "primary_attempt_id": primary.id,
+    }
+    calls: list[int] = []
+
+    async def planner(
+        _session: AsyncSession,
+        *,
+        acquisition_id: int,
+        **_kwargs: object,
+    ) -> object:
+        calls.append(acquisition_id)
+        if acquisition_id == primary.id:
+            raise AssertionError("recovery retried the failed primary provider")
+        alternate.state = DirectAcquisitionState.PLANNED
+        return SimpleNamespace(
+            attempt=alternate,
+            selected_artifact=SimpleNamespace(id=89),
+            initial_source=object(),
+        )
+
+    result = await plan_direct_acquisition_with_provider_fallback(
+        session,
+        acquisition_id=primary.id,
+        planner=planner,
+        skip_selected_attempt=True,
+    )
+
+    assert result.attempt is alternate
+    assert calls == [alternate.id]
 
 
 @pytest.fixture

--- a/tests/unit/test_direct_acquisition_runner.py
+++ b/tests/unit/test_direct_acquisition_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock
 
@@ -252,6 +253,29 @@ class _FallbackExecutor:
 
 
 @dataclass
+class _ProviderFallbackExecutor:
+    acquisition_ids: list[int] = field(default_factory=list)
+
+    async def execute(self, session: AsyncSession, **kwargs: Any) -> None:
+        acquisition_id = kwargs["acquisition_id"]
+        self.acquisition_ids.append(acquisition_id)
+        attempt = await session.get(DirectAcquisitionAttempt, acquisition_id)
+        artifact = await session.get(DirectArtifactAttempt, kwargs["artifact_id"])
+        assert attempt is not None and artifact is not None
+        if acquisition_id == 1:
+            attempt.state = DirectAcquisitionState.FAILED
+            attempt.failure_class = DirectArtifactFailureClass.PERMANENT_MIRROR
+            attempt.failure_code = "artifact_not_found"
+            artifact.state = DirectArtifactState.FAILED
+            artifact.failure_class = DirectArtifactFailureClass.PERMANENT_MIRROR
+            artifact.failure_code = "artifact_not_found"
+        else:
+            attempt.state = DirectAcquisitionState.COMPLETED
+            artifact.state = DirectArtifactState.COMPLETED
+        await session.commit()
+
+
+@dataclass
 class _SourceSwitchExecutor:
     started: asyncio.Event = field(default_factory=asyncio.Event)
     artifact_ids: list[int] = field(default_factory=list)
@@ -446,6 +470,87 @@ async def test_runner_continues_automatically_with_queued_fallback_route(
         attempt = await session.get(DirectAcquisitionAttempt, 1)
         assert attempt is not None
         assert attempt.state is DirectAcquisitionState.COMPLETED
+    await runner.aclose()
+
+
+@pytest.mark.asyncio
+async def test_runner_continues_with_hidden_provider_after_routes_are_exhausted(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        primary = await session.get(DirectAcquisitionAttempt, 1)
+        assert primary is not None
+        alternate = DirectAcquisitionAttempt(
+            id=2,
+            request_key="direct-runner:provider-fallback",
+            issue_id=1,
+            provider_identity="community.libgen",
+            provider_candidate_id="candidate-2",
+            state=DirectAcquisitionState.DISCOVERED,
+            requested_coverage={"issue_numbers": ["1"]},
+            candidate_snapshot={
+                "display_title": "Runner Series 001 (2026)",
+                "visible": False,
+                "primary_attempt_id": 1,
+            },
+            plan_snapshot={},
+            progress_snapshot={"stage": "discovered"},
+        )
+        session.add(alternate)
+        primary.candidate_snapshot = {
+            **primary.candidate_snapshot,
+            "visible": True,
+            "alternate_attempt_ids": [2],
+        }
+        await session.commit()
+
+    executor = _ProviderFallbackExecutor()
+    fallback_calls: list[int] = []
+
+    async def fallback_planner(
+        session: AsyncSession,
+        *,
+        acquisition_id: int,
+        skip_selected_attempt: bool,
+    ) -> object:
+        assert skip_selected_attempt is True
+        fallback_calls.append(acquisition_id)
+        alternate = await session.get(DirectAcquisitionAttempt, 2)
+        assert alternate is not None
+        alternate.state = DirectAcquisitionState.PLANNED
+        artifact = DirectArtifactAttempt(
+            acquisition_attempt_id=alternate.id,
+            sequence_no=0,
+            artifact_identity="route:provider-alternate",
+            route_kind=DirectArtifactRouteKind.DIRECT,
+            host_kind=DirectArtifactHostKind.GENERIC_HTTPS,
+            state=DirectArtifactState.PLANNED,
+            is_selected=True,
+        )
+        session.add(artifact)
+        await session.flush()
+        return SimpleNamespace(
+            attempt=alternate,
+            selected_artifact=artifact,
+            initial_source=_source("provider-alternate"),
+        )
+
+    runner = DirectAcquisitionRunner(
+        session_factory,
+        executor=executor,
+        source_resolver=AsyncMock(),
+        provider_fallback_planner=fallback_planner,
+    )
+
+    assert await runner.dispatch(1, 1, initial_source=_source("primary")) is True
+    await runner.wait_idle()
+
+    assert fallback_calls == [1]
+    assert executor.acquisition_ids == [1, 2]
+    async with session_factory() as session:
+        alternate = await session.get(DirectAcquisitionAttempt, 2)
+        assert alternate is not None
+        assert alternate.state is DirectAcquisitionState.COMPLETED
     await runner.aclose()
 
 

--- a/tests/unit/test_direct_artifact_host_adapters.py
+++ b/tests/unit/test_direct_artifact_host_adapters.py
@@ -58,9 +58,14 @@ def _request(
 
 
 async def test_generic_https_accepts_a_probed_final_file_with_resume_validators() -> None:
+    observed_user_agent: str | None = None
+
     async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal observed_user_agent
         assert request.method == "GET"
         assert request.headers["Range"] == "bytes=0-0"
+        observed_user_agent = request.headers["User-Agent"]
+        assert observed_user_agent.startswith("Mozilla/5.0")
         return httpx.Response(
             206,
             headers={
@@ -89,6 +94,7 @@ async def test_generic_https_accepts_a_probed_final_file_with_resume_validators(
     assert transfer.etag == '"fixture-etag"'
     assert transfer.checksum == "md5:11111111111111111111111111111111"
     assert transfer.range_supported is True
+    assert transfer.headers["User-Agent"] == observed_user_agent
 
 
 async def test_generic_https_accepts_large_files_when_server_ignores_range_probe() -> None:
@@ -118,6 +124,42 @@ async def test_generic_https_accepts_large_files_when_server_ignores_range_probe
     assert transfer.expected_size == file_size
     assert transfer.filename_hint == "large.cbz"
     assert transfer.range_supported is False
+
+
+async def test_generic_https_prefers_one_stream_for_booksdl_ranges() -> None:
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            206,
+            headers={
+                "Content-Type": "application/octet-stream",
+                "Content-Range": "bytes 0-0/59247008",
+                "Content-Length": "1",
+                "ETag": '"stable"',
+                "Last-Modified": "Mon, 24 Aug 2026 00:00:00 GMT",
+            },
+            content=b"P",
+            request=httpx.Request(
+                "GET",
+                "https://cdn4.booksdl.lc/get.php?token=opaque",
+            ),
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        transfer = await GenericHttpsAdapter(client, resolver=_resolve_public).resolve(
+            _request(
+                DirectArtifactHostKind.GENERIC_HTTPS,
+                "https://cdn4.booksdl.lc/get.php?token=opaque",
+                final=True,
+                checksum="md5:11111111111111111111111111111111",
+                expected_size=59_247_008,
+            ),
+            credentials={},
+        )
+
+    assert transfer.expected_size == 59_247_008
+    assert transfer.etag == '"stable"'
+    assert transfer.range_supported is True
+    assert transfer.prefer_single_response is True
 
 
 async def test_generic_https_rejects_an_html_landing_page() -> None:

--- a/tests/unit/test_direct_artifact_transport.py
+++ b/tests/unit/test_direct_artifact_transport.py
@@ -177,6 +177,52 @@ async def test_http_transport_resumes_single_response_after_protocol_disconnect(
 
 
 @pytest.mark.asyncio
+async def test_http_transport_limits_retries_when_single_response_host_restarts_partial(
+    tmp_path: Path,
+) -> None:
+    payload = b"abcdefghijkl"
+    seen_ranges: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen_ranges.append(request.headers.get("range"))
+        return httpx.Response(
+            200,
+            headers={
+                "content-length": str(len(payload)),
+                "etag": '"stable"',
+            },
+            stream=_PartialThenProtocolErrorStream(payload[:4]),
+        )
+
+    root, destination = _quarantine_paths(tmp_path)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(ArtifactTransferError) as captured:
+            async with asyncio.timeout(0.5):
+                await HttpArtifactTransport(
+                    client=client,
+                    resolver=_public_resolver,
+                    policy=ArtifactTransferPolicy(
+                        chunk_size_bytes=4,
+                        range_stall_retries=2,
+                        range_retry_backoff_seconds=0,
+                    ),
+                ).transfer(
+                    resolved=_resolved(
+                        expected_size=len(payload),
+                        etag='"stable"',
+                        checksum=f"md5:{hashlib.md5(payload, usedforsecurity=False).hexdigest()}",
+                        range_supported=True,
+                        prefer_single_response=True,
+                    ),
+                    destination=destination,
+                    quarantine_root=root,
+                )
+
+    assert captured.value.code == "artifact_host_unavailable"
+    assert seen_ranges == [None, "bytes=4-", "bytes=4-"]
+
+
+@pytest.mark.asyncio
 async def test_http_transport_reports_intermediate_progress_for_single_response_host(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/test_direct_artifact_transport.py
+++ b/tests/unit/test_direct_artifact_transport.py
@@ -121,6 +121,100 @@ async def test_http_transport_resumes_only_with_stable_validator(
 
 
 @pytest.mark.asyncio
+async def test_http_transport_resumes_single_response_after_protocol_disconnect(
+    tmp_path: Path,
+) -> None:
+    payload = b"abcdefghijkl"
+    seen_ranges: list[str | None] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requested = request.headers.get("range")
+        seen_ranges.append(requested)
+        if requested is None:
+            return httpx.Response(
+                200,
+                headers={
+                    "content-length": str(len(payload)),
+                    "etag": '"stable"',
+                },
+                stream=_PartialThenProtocolErrorStream(payload[:4]),
+            )
+        assert requested == "bytes=4-"
+        return httpx.Response(
+            206,
+            headers={
+                "content-range": f"bytes 4-{len(payload) - 1}/{len(payload)}",
+                "content-length": str(len(payload) - 4),
+                "etag": '"stable"',
+            },
+            content=payload[4:],
+        )
+
+    root, destination = _quarantine_paths(tmp_path)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        result = await HttpArtifactTransport(
+            client=client,
+            resolver=_public_resolver,
+            policy=ArtifactTransferPolicy(
+                chunk_size_bytes=4,
+                range_retry_backoff_seconds=0,
+            ),
+        ).transfer(
+            resolved=_resolved(
+                expected_size=len(payload),
+                etag='"stable"',
+                checksum=f"md5:{hashlib.md5(payload, usedforsecurity=False).hexdigest()}",
+                range_supported=True,
+                prefer_single_response=True,
+            ),
+            destination=destination,
+            quarantine_root=root,
+        )
+
+    assert seen_ranges == [None, "bytes=4-"]
+    assert destination.read_bytes() == payload
+    assert result.bytes_transferred == len(payload)
+
+
+@pytest.mark.asyncio
+async def test_http_transport_reports_intermediate_progress_for_single_response_host(
+    tmp_path: Path,
+) -> None:
+    payload = b"x" * (128 * 1024)
+    snapshots: list[TransferProgressSnapshot] = []
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "content-length": str(len(payload)),
+                "etag": '"stable"',
+            },
+            content=payload,
+        )
+
+    root, destination = _quarantine_paths(tmp_path)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await HttpArtifactTransport(
+            client=client,
+            resolver=_public_resolver,
+            policy=ArtifactTransferPolicy(progress_interval_seconds=0),
+        ).transfer(
+            resolved=_resolved(
+                expected_size=len(payload),
+                checksum=f"md5:{hashlib.md5(payload, usedforsecurity=False).hexdigest()}",
+                range_supported=True,
+                prefer_single_response=True,
+            ),
+            destination=destination,
+            quarantine_root=root,
+            progress_callback=snapshots.append,
+        )
+
+    assert any(0 < snapshot.bytes_transferred < len(payload) for snapshot in snapshots)
+
+
+@pytest.mark.asyncio
 async def test_http_transport_slices_large_range_capable_artifact(
     tmp_path: Path,
 ) -> None:
@@ -1230,6 +1324,7 @@ def _resolved(
     etag: str | None = None,
     checksum: str | None = None,
     range_supported: bool = False,
+    prefer_single_response: bool = False,
     allowed_domains: tuple[str, ...] = ("example.com",),
 ) -> ResolvedTransfer:
     return ResolvedTransfer(
@@ -1239,6 +1334,7 @@ def _resolved(
         etag=etag,
         checksum=checksum,
         range_supported=range_supported,
+        prefer_single_response=prefer_single_response,
         allowed_domains=allowed_domains,
     )
 
@@ -1296,6 +1392,15 @@ class _PartialThenStalledStream(httpx.AsyncByteStream):
         yield self._partial
         await asyncio.sleep(30)
         yield b"never"
+
+
+class _PartialThenProtocolErrorStream(httpx.AsyncByteStream):
+    def __init__(self, partial: bytes) -> None:
+        self._partial = partial
+
+    async def __aiter__(self):  # type: ignore[no-untyped-def]
+        yield self._partial
+        raise httpx.RemoteProtocolError("peer closed the response early")
 
 
 class _CompleteThenStalledStream(httpx.AsyncByteStream):

--- a/tests/unit/test_direct_provider_client.py
+++ b/tests/unit/test_direct_provider_client.py
@@ -160,6 +160,36 @@ async def test_client_authenticates_and_validates_all_four_operations() -> None:
     assert seen_paths == ["/v1/manifest", "/v1/health", "/v1/search", "/v1/resolve"]
 
 
+async def test_owned_http_client_uses_the_configured_request_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_timeout: httpx.Timeout | None = None
+    real_async_client = httpx.AsyncClient
+
+    def client_factory(**kwargs: object) -> httpx.AsyncClient:
+        nonlocal captured_timeout
+        timeout = kwargs.get("timeout")
+        assert isinstance(timeout, httpx.Timeout)
+        captured_timeout = timeout
+        return real_async_client(
+            transport=httpx.MockTransport(lambda _request: httpx.Response(200, json=_manifest())),
+            **kwargs,
+        )
+
+    monkeypatch.setattr(client_module.httpx, "AsyncClient", client_factory)
+    client = DirectProviderClient(
+        endpoint="https://provider.example",
+        bearer_token=TOKEN,
+        resolver=_resolve_public,
+        request_timeout_seconds=45.0,
+    )
+    try:
+        assert captured_timeout is not None
+        assert captured_timeout.read == 45.0
+    finally:
+        await client.aclose()
+
+
 async def test_client_revalidates_dns_before_every_operation() -> None:
     resolutions = 0
 
@@ -429,6 +459,7 @@ async def test_client_logs_only_classified_failure_details() -> None:
         (401, "source_authentication_required", False),
         (503, "source_unavailable", True),
         (503, "source_malformed_response", False),
+        (503, "source_contract_changed", False),
         (404, "candidate_not_found", False),
     ],
 )

--- a/tests/unit/test_direct_search_coordinator.py
+++ b/tests/unit/test_direct_search_coordinator.py
@@ -85,6 +85,7 @@ def _candidate(
     title: str,
     *,
     content_fingerprint: str | None = None,
+    provider_confidence: float = 0.95,
 ) -> DirectCandidate:
     return DirectCandidate(
         provider_candidate_id=f"candidate:{provider.provider_identity}",
@@ -97,7 +98,7 @@ def _candidate(
             year=2025,
             format="cbz",
         ),
-        provider_confidence=0.95,
+        provider_confidence=provider_confidence,
         content_fingerprint=content_fingerprint,
         provenance={"fixture": True},
     )
@@ -258,6 +259,41 @@ async def test_cross_provider_fingerprint_collapses_to_one_result_with_alternate
     assert len(outcome.matched) == 1
     assert outcome.matched[0].provider is preferred
     assert [item.provider for item in outcome.matched[0].alternate_results] == [alternate]
+
+
+async def test_fingerprint_primary_prefers_candidate_confidence_before_provider_priority() -> None:
+    _reset()
+    configured_first = _provider("pullbox.getcomics", 10)
+    stronger_candidate = _provider("pullbox.libgen", 20)
+    fingerprint = f"md5:{'4' * 32}"
+    _Client.responses = {
+        configured_first.provider_identity: [
+            _candidate(
+                configured_first,
+                "Absolute Superman 009 (2025) (Digital)",
+                content_fingerprint=fingerprint,
+                provider_confidence=0.80,
+            )
+        ],
+        stronger_candidate.provider_identity: [
+            _candidate(
+                stronger_candidate,
+                "Absolute Superman 009 (2025) (Digital)",
+                content_fingerprint=fingerprint,
+                provider_confidence=0.99,
+            )
+        ],
+    }
+
+    outcome = await search_direct_issue_target(
+        _target(),
+        [configured_first, stronger_candidate],
+        client_factory=_factory,
+    )
+
+    assert len(outcome.matched) == 1
+    assert outcome.matched[0].provider is stronger_candidate
+    assert [item.provider for item in outcome.matched[0].alternate_results] == [configured_first]
 
 
 async def test_different_fingerprints_remain_distinct_results() -> None:
@@ -898,3 +934,12 @@ async def test_fingerprint_alternates_are_persisted_but_only_primary_is_visible(
         "pullbox.libgen",
         "pullbox.annas_archive",
     ]
+    primary = await db_session.get(DirectAcquisitionAttempt, discoveries[0].attempt_id)
+    alternate = await db_session.get(DirectAcquisitionAttempt, discoveries[1].attempt_id)
+    assert primary is not None
+    assert alternate is not None
+    assert primary.candidate_snapshot["visible"] is True
+    assert primary.candidate_snapshot["alternate_attempt_ids"] == [alternate.id]
+    assert alternate.candidate_snapshot["visible"] is False
+    assert alternate.candidate_snapshot["primary_attempt_id"] == primary.id
+    assert fingerprint not in json.dumps(primary.candidate_snapshot, sort_keys=True)

--- a/tests/unit/test_direct_search_coordinator.py
+++ b/tests/unit/test_direct_search_coordinator.py
@@ -885,7 +885,11 @@ async def test_fingerprint_alternates_are_persisted_but_only_primary_is_visible(
             status=IssueStatus.WANTED,
         )
     )
-    for provider_id, identity in ((10, "pullbox.libgen"), (20, "pullbox.annas_archive")):
+    for provider_id, identity in (
+        (10, "pullbox.libgen"),
+        (20, "pullbox.annas_archive"),
+        (30, "pullbox.getcomics"),
+    ):
         db_session.add(
             DirectProviderConfig(
                 id=provider_id,
@@ -902,6 +906,7 @@ async def test_fingerprint_alternates_are_persisted_but_only_primary_is_visible(
 
     primary_provider = _provider("pullbox.libgen", 10)
     alternate_provider = _provider("pullbox.annas_archive", 20)
+    final_provider = _provider("pullbox.getcomics", 30)
     fingerprint = f"md5:{'4' * 32}"
     _reset()
     _Client.responses = {
@@ -919,27 +924,41 @@ async def test_fingerprint_alternates_are_persisted_but_only_primary_is_visible(
                 content_fingerprint=fingerprint,
             )
         ],
+        final_provider.provider_identity: [
+            _candidate(
+                final_provider,
+                "Absolute Superman 009 (2025)",
+                content_fingerprint=fingerprint,
+            )
+        ],
     }
     outcome = await search_direct_issue_target(
         _target(),
-        [primary_provider, alternate_provider],
+        [primary_provider, alternate_provider, final_provider],
         client_factory=_factory,
     )
 
     discoveries = await persist_direct_search_discoveries(db_session, _target(), outcome)
 
-    assert len(discoveries) == 2
-    assert [discovery.visible for discovery in discoveries] == [True, False]
+    assert len(discoveries) == 3
+    assert [discovery.visible for discovery in discoveries] == [True, False, False]
     assert [discovery.result.provider.provider_identity for discovery in discoveries] == [
         "pullbox.libgen",
         "pullbox.annas_archive",
+        "pullbox.getcomics",
     ]
     primary = await db_session.get(DirectAcquisitionAttempt, discoveries[0].attempt_id)
     alternate = await db_session.get(DirectAcquisitionAttempt, discoveries[1].attempt_id)
+    final = await db_session.get(DirectAcquisitionAttempt, discoveries[2].attempt_id)
     assert primary is not None
     assert alternate is not None
+    assert final is not None
     assert primary.candidate_snapshot["visible"] is True
-    assert primary.candidate_snapshot["alternate_attempt_ids"] == [alternate.id]
+    assert primary.candidate_snapshot["alternate_attempt_ids"] == [alternate.id, final.id]
     assert alternate.candidate_snapshot["visible"] is False
     assert alternate.candidate_snapshot["primary_attempt_id"] == primary.id
+    assert alternate.candidate_snapshot["alternate_attempt_ids"] == [final.id]
+    assert final.candidate_snapshot["visible"] is False
+    assert final.candidate_snapshot["primary_attempt_id"] == primary.id
+    assert final.candidate_snapshot["alternate_attempt_ids"] == []
     assert fingerprint not in json.dumps(primary.candidate_snapshot, sort_keys=True)

--- a/tests/unit/test_search_acquisition_router.py
+++ b/tests/unit/test_search_acquisition_router.py
@@ -323,6 +323,84 @@ async def test_direct_planning_failure_creates_visible_intervention(
 
 
 @pytest.mark.asyncio
+async def test_automatic_direct_routing_uses_hidden_provider_fallback(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    target, provider, search_log_id = await _seed(db_factory)
+    alternate_provider = replace(
+        provider,
+        provider_config_id=2,
+        provider_identity="pullbox.libgen",
+        display_name="LibGen",
+        endpoint="http://libgen:8780",
+    )
+    outcome = _outcome(target, provider)
+    assert outcome.direct_outcome is not None
+    primary = outcome.direct_outcome.matched[0]
+    alternate = replace(
+        primary,
+        provider=alternate_provider,
+        candidate=primary.candidate.model_copy(update={"provider_candidate_id": "candidate-2"}),
+    )
+    outcome = replace(
+        outcome,
+        direct_outcome=replace(
+            outcome.direct_outcome,
+            matched=(replace(primary, alternate_results=(alternate,)),),
+            providers_searched=2,
+        ),
+    )
+    planner = AsyncMock(
+        side_effect=[
+            DirectAcquisitionPlanningError(
+                "provider_unavailable",
+                "The preferred provider is unavailable.",
+                failure_class=DirectArtifactFailureClass.PROVIDER_UNAVAILABLE,
+                intervention=False,
+            ),
+            SimpleNamespace(
+                attempt=SimpleNamespace(id=2),
+                selected_artifact=SimpleNamespace(id=22),
+                initial_source=None,
+            ),
+        ]
+    )
+    runner = SimpleNamespace(dispatch=AsyncMock())
+
+    async with db_factory() as session:
+        session.add(
+            DirectProviderConfig(
+                id=2,
+                provider_id=alternate_provider.provider_identity,
+                display_name=alternate_provider.display_name,
+                endpoint=alternate_provider.endpoint,
+                enabled=True,
+                priority=20,
+                state=DirectProviderState.HEALTHY,
+                trust_level=DirectProviderTrustLevel.VERIFIED_PULLBOX,
+            )
+        )
+        await session.commit()
+        routed = await route_search_acquisition(
+            session,
+            outcome=outcome,
+            search_log_id=search_log_id,
+            eval_kwargs={},
+            type_thresholds={"issue": "high"},
+            download_service=AsyncMock(),
+            intervention_service=AsyncMock(),
+            runner=runner,
+            source_priority=["direct", "torrent", "usenet"],
+            planner=planner,
+        )
+
+    assert [call.kwargs["acquisition_id"] for call in planner.await_args_list] == [1, 2]
+    runner.dispatch.assert_awaited_once_with(2, 22, initial_source=None)
+    assert routed.action_status == "downloading"
+    assert routed.acquisition_id == 2
+
+
+@pytest.mark.asyncio
 async def test_non_intervention_direct_failure_falls_back_to_ranked_indexer(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/test_unified_search_selection.py
+++ b/tests/unit/test_unified_search_selection.py
@@ -288,7 +288,7 @@ def test_ranked_sources_reuse_existing_scorer_for_fallback_order() -> None:
     assert ranked[1].release is indexer
 
 
-def test_direct_provider_priority_precedes_filename_quality_for_automatic_search() -> None:
+def test_direct_filename_quality_precedes_provider_priority_for_automatic_search() -> None:
     indexer = _release("Batman 001.cbz", "Indexer", size=25_000_000)
     getcomics = _direct_result(
         _release("Batman 001 (2016)", "GetComics", size=100_000_000),
@@ -321,7 +321,39 @@ def test_direct_provider_priority_precedes_filename_quality_for_automatic_search
         source_priority=["direct", "usenet", "torrent"],
     )
 
-    assert [item.direct_result for item in ranked[:2]] == [getcomics, annas]
+    assert [item.direct_result for item in ranked[:2]] == [annas, getcomics]
+
+
+def test_direct_provider_priority_breaks_quality_ties_for_automatic_search() -> None:
+    indexer = _release("Batman 001.cbz", "Indexer", size=25_000_000)
+    preferred = _direct_result(
+        _release("Batman 001 (2016) (Digital).cbz", "GetComics"),
+        provider_identity="pullbox.getcomics",
+        provider_priority=10,
+    )
+    lower_priority = _direct_result(
+        _release("Batman 001 (2016) (Digital).cbz", "LibGen"),
+        provider_identity="pullbox.libgen",
+        provider_priority=20,
+    )
+    outcome = replace(
+        _outcome(indexer, preferred),
+        direct_outcome=DirectSearchOutcome(
+            matched=(lower_priority, preferred),
+            rejected=(),
+            failures=(),
+            providers_searched=2,
+            elapsed_ms=1,
+        ),
+    )
+
+    ranked = rank_search_sources(
+        outcome,
+        {},
+        source_priority=["direct", "usenet", "torrent"],
+    )
+
+    assert [item.direct_result for item in ranked[:2]] == [preferred, lower_priority]
 
 
 def test_fingerprint_alternate_remains_available_for_acquisition_fallback() -> None:


### PR DESCRIPTION
## Summary
- integrate LibGen results into the direct-download search and acquisition pipeline
- preserve provider deadlines and safe artifact-route planning
- resume interrupted LibGen transfers without restarting completed work

## Verification
- `236` focused LibGen, unified-search, and AirDC++ regression tests passed
- `make ci-full` passed, including Chromium, Firefox, accessibility, security, migrations, coverage, and Docker smoke