### PR TITLE
fix: resolve build metadata from linked worktrees

### DIFF
--- a/src/pullbox/core/build_metadata.py
+++ b/src/pullbox/core/build_metadata.py
@@ -60,26 +60,41 @@ def _resolve_git_dir(repo_root: Path) -> Path | None:
 
 def _read_git_ref(git_dir: Path, ref: str) -> str | None:
     """Read a git ref from loose refs or packed-refs."""
-    ref_path = git_dir / ref
-    if ref_path.exists():
+    ref_dirs = [git_dir]
+    commondir_path = git_dir / "commondir"
+    if commondir_path.exists():
         try:
-            value = ref_path.read_text(encoding="utf-8").strip()
+            common_value = commondir_path.read_text(encoding="utf-8").strip()
         except OSError:
-            value = ""
-        return value or None
+            common_value = ""
+        if common_value:
+            common_dir = Path(common_value)
+            if not common_dir.is_absolute():
+                common_dir = (git_dir / common_dir).resolve()
+            if common_dir != git_dir:
+                ref_dirs.append(common_dir)
 
-    packed_refs = git_dir / "packed-refs"
-    if packed_refs.exists():
-        try:
-            for line in packed_refs.read_text(encoding="utf-8").splitlines():
-                line = line.strip()
-                if not line or line.startswith("#") or line.startswith("^"):
-                    continue
-                parts = line.split(" ", 1)
-                if len(parts) == 2 and parts[1] == ref:
-                    return parts[0]
-        except OSError:
-            return None
+    for ref_dir in ref_dirs:
+        ref_path = ref_dir / ref
+        if ref_path.exists():
+            try:
+                value = ref_path.read_text(encoding="utf-8").strip()
+            except OSError:
+                value = ""
+            return value or None
+
+        packed_refs = ref_dir / "packed-refs"
+        if packed_refs.exists():
+            try:
+                for line in packed_refs.read_text(encoding="utf-8").splitlines():
+                    line = line.strip()
+                    if not line or line.startswith("#") or line.startswith("^"):
+                        continue
+                    parts = line.split(" ", 1)
+                    if len(parts) == 2 and parts[1] == ref:
+                        return parts[0]
+            except OSError:
+                return None
     return None
 
 

--- a/tests/unit/test_system_build_metadata.py
+++ b/tests/unit/test_system_build_metadata.py
@@ -156,6 +156,34 @@ def test_resolve_git_dir_supports_linked_worktrees(tmp_path: Path) -> None:
     assert build_metadata._resolve_git_dir(repo_root) == linked_git_dir
 
 
+def test_checkout_metadata_reads_shared_ref_for_linked_worktree(
+    monkeypatch,  # type: ignore[no-untyped-def]
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    common_git_dir = tmp_path / "common.git"
+    linked_git_dir = common_git_dir / "worktrees" / "repo"
+    linked_git_dir.mkdir(parents=True)
+    repo_root.mkdir()
+
+    full_sha = "1234567890abcdef1234567890abcdef12345678"
+    (repo_root / ".git").write_text(
+        f"gitdir: {linked_git_dir}\n",
+        encoding="utf-8",
+    )
+    (linked_git_dir / "HEAD").write_text("ref: refs/heads/develop\n", encoding="utf-8")
+    (linked_git_dir / "commondir").write_text("../..\n", encoding="utf-8")
+    shared_ref = common_git_dir / "refs" / "heads" / "develop"
+    shared_ref.parent.mkdir(parents=True)
+    shared_ref.write_text(f"{full_sha}\n", encoding="utf-8")
+    monkeypatch.setattr(build_metadata, "_repo_root", lambda: repo_root)
+
+    metadata = build_metadata._get_checkout_metadata()
+
+    assert metadata.branch == "develop"
+    assert metadata.commit == "1234567"
+
+
 def test_resolve_git_dir_returns_none_for_invalid_or_unreadable_git_file(
     monkeypatch,  # type: ignore[no-untyped-def]
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- resolve branch refs from the shared Git directory used by linked worktrees
- support both loose refs and packed refs without changing normal checkout behavior
- add a regression covering branch and commit metadata in a linked worktree

## Verification
- focused build-metadata suite: 19 passed
- Ruff check and format check passed