### PR TITLE
Release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-26
+
+Patch release that makes release notifications and browser validation more reliable.
+
+### Fixed
+
+- Preserve successful Discord release delivery records so later channel posts and
+  workflow reruns do not create duplicate messages.
+- Record Discord delivery state against the exact release commit.
+- Stabilize the utilities export footer check in Firefox by targeting the
+  dedicated fields value.
+
 ## [1.1.1] - 2026-08-23
 
 Patch release improving direct-download reliability for collected issue packs.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)


### PR DESCRIPTION
## Summary
- Bump Pullbox to v1.1.2.
- Add curated release notes for reliable Discord delivery records and Firefox export-footer validation.

## Validation
- `make release-changelog-check VERSION=1.1.2`
- Version import assertion
- Focused Discord notification tests