### PR TITLE
fix: normalize Windows download paths

### DIFF
--- a/src/pullbox/tasks/download_post_processing_source_validation.py
+++ b/src/pullbox/tasks/download_post_processing_source_validation.py
@@ -70,6 +70,17 @@ async def resolve_and_validate_source(
     trace.probe_root = str(probe_root)
     comic_file = source_probe.comic_file
 
+    if probe_root.expanduser().resolve(strict=False) == Path("/"):
+        log.error(
+            "post_processing_root_probe_rejected",
+            raw_client_path=getattr(download, "downloaded_path", None),
+            hint="Verify Remote Path and Download Directory before retrying post-processing.",
+        )
+        raise RuntimeError(
+            "Refusing to inspect the container filesystem root during post-processing. "
+            "Verify the download client's Remote Path and Download Directory."
+        )
+
     if comic_file is None:
         # Don't fail immediately; a prior failed attempt may have already moved
         # the file to the destination. The caller will check dest_path later.

--- a/src/pullbox/tasks/download_post_processing_sources.py
+++ b/src/pullbox/tasks/download_post_processing_sources.py
@@ -109,6 +109,22 @@ def _find_comic_file(
     return None
 
 
+def _reject_filesystem_root_probe(probe_root: Path) -> None:
+    """Fail before recursive discovery can inspect the container filesystem root."""
+    if probe_root.expanduser().resolve(strict=False) != Path("/"):
+        return
+
+    logger.error(
+        "post_processing_root_probe_rejected",
+        probe_root=str(probe_root),
+        hint="Verify Remote Path and Download Directory before retrying post-processing.",
+    )
+    raise RuntimeError(
+        "Refusing to inspect the container filesystem root during post-processing. "
+        "Verify the download client's Remote Path and Download Directory."
+    )
+
+
 @dataclass(frozen=True)
 class PostProcessingSourceProbe:
     """Resolved source visibility for post-processing on local/network storage."""
@@ -172,6 +188,7 @@ async def _probe_post_processing_source(
         last_probe_root = probe_root
 
         if source_exists:
+            _reject_filesystem_root_probe(probe_root)
             comic_file = await get_running_loop().run_in_executor(
                 None,
                 finder,

--- a/src/pullbox/tasks/download_post_processing_sources.py
+++ b/src/pullbox/tasks/download_post_processing_sources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from pathlib import Path, PureWindowsPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING
 
 import structlog
@@ -26,6 +26,41 @@ def _is_windows_origin_path(path: str) -> bool:
     """Identify configured paths using Windows drive or UNC syntax."""
     windows_path = PureWindowsPath(path)
     return bool(windows_path.drive)
+
+
+def _map_configured_download_path(
+    raw_path: str,
+    *,
+    remote_root: str,
+    local_root: str,
+) -> str | None:
+    """Map a client path by path components without weakening POSIX semantics."""
+    windows_origin = _is_windows_origin_path(remote_root)
+    path_type = PureWindowsPath if windows_origin else PurePosixPath
+    candidate = path_type(raw_path)
+    configured_remote = path_type(remote_root)
+
+    try:
+        remainder = candidate.relative_to(configured_remote)
+    except ValueError:
+        return None
+
+    if ".." in remainder.parts:
+        raise FileNotFoundError(
+            "The download client reported an unsafe parent traversal outside "
+            "the configured Remote Path."
+        )
+
+    local_base = Path(local_root)
+    mapped = local_base.joinpath(*remainder.parts)
+    resolved_base = local_base.expanduser().resolve(strict=False)
+    resolved_mapped = mapped.expanduser().resolve(strict=False)
+    if resolved_mapped != resolved_base and not resolved_mapped.is_relative_to(resolved_base):
+        raise FileNotFoundError(
+            "The mapped download path resolves outside the configured Download Directory."
+        )
+
+    return str(mapped)
 
 
 def _find_comic_file(
@@ -209,35 +244,33 @@ async def _resolve_local_path(
 
     if client_cfg and client_cfg.remote_path and client_cfg.download_dir:
         windows_origin = _is_windows_origin_path(client_cfg.remote_path)
-        remote = client_cfg.remote_path
-        local = client_cfg.download_dir.rstrip("/")
-        candidate = raw_path
-        if windows_origin:
-            remote = remote.replace("\\", "/")
-            candidate = raw_path.replace("\\", "/")
-        remote = remote.rstrip("/")
-        if candidate.startswith(remote):
-            remainder = candidate[len(remote) :]
-            resolved = local + remainder
+        resolved = _map_configured_download_path(
+            raw_path,
+            remote_root=client_cfg.remote_path,
+            local_root=client_cfg.download_dir,
+        )
+        if resolved is not None:
             logger.info(
                 "path_mapping_applied",
                 raw=raw_path,
-                remote_prefix=remote,
-                local_prefix=local,
-                remainder=remainder,
+                remote_prefix=client_cfg.remote_path,
+                local_prefix=client_cfg.download_dir,
                 resolved=resolved,
             )
             return resolved
         logger.warning(
             "path_mapping_prefix_mismatch",
             raw=raw_path,
-            remote_prefix=remote,
+            remote_prefix=client_cfg.remote_path,
             hint="The download client's path does not start with the "
             "configured Remote Path. Check that Remote Path matches "
             "the root of where the client stores completed downloads.",
         )
         if windows_origin:
-            return candidate
+            raise FileNotFoundError(
+                "The download client's Windows path does not match the configured Remote Path. "
+                "Verify both paths in Settings > Download Clients."
+            )
     elif client_cfg and (client_cfg.remote_path or client_cfg.download_dir):
         logger.warning(
             "path_mapping_incomplete",

--- a/src/pullbox/tasks/download_post_processing_sources.py
+++ b/src/pullbox/tasks/download_post_processing_sources.py
@@ -162,6 +162,8 @@ async def _resolve_local_path(
     if not raw_path:
         return None
 
+    raw_path = raw_path.replace("\\", "/")
+
     from pullbox.models.client import DownloadClientConfig
     from pullbox.models.download import DownloadClientType
 
@@ -202,8 +204,8 @@ async def _resolve_local_path(
     client_cfg = result.scalars().first()
 
     if client_cfg and client_cfg.remote_path and client_cfg.download_dir:
-        remote = client_cfg.remote_path.rstrip("/")
-        local = client_cfg.download_dir.rstrip("/")
+        remote = client_cfg.remote_path.replace("\\", "/").rstrip("/")
+        local = client_cfg.download_dir.replace("\\", "/").rstrip("/")
         if raw_path.startswith(remote):
             remainder = raw_path[len(remote) :]
             resolved = local + remainder

--- a/src/pullbox/tasks/download_post_processing_sources.py
+++ b/src/pullbox/tasks/download_post_processing_sources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING
 
 import structlog
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
 logger = structlog.get_logger(__name__)
 
 _POST_PROCESSING_SOURCE_RETRY_DELAYS = (0.0, 0.5, 1.0, 2.0, 4.0)
+
+
+def _is_windows_origin_path(path: str) -> bool:
+    """Identify configured paths using Windows drive or UNC syntax."""
+    windows_path = PureWindowsPath(path)
+    return bool(windows_path.drive)
 
 
 def _find_comic_file(
@@ -162,8 +168,6 @@ async def _resolve_local_path(
     if not raw_path:
         return None
 
-    raw_path = raw_path.replace("\\", "/")
-
     from pullbox.models.client import DownloadClientConfig
     from pullbox.models.download import DownloadClientType
 
@@ -204,10 +208,16 @@ async def _resolve_local_path(
     client_cfg = result.scalars().first()
 
     if client_cfg and client_cfg.remote_path and client_cfg.download_dir:
-        remote = client_cfg.remote_path.replace("\\", "/").rstrip("/")
-        local = client_cfg.download_dir.replace("\\", "/").rstrip("/")
-        if raw_path.startswith(remote):
-            remainder = raw_path[len(remote) :]
+        windows_origin = _is_windows_origin_path(client_cfg.remote_path)
+        remote = client_cfg.remote_path
+        local = client_cfg.download_dir.rstrip("/")
+        candidate = raw_path
+        if windows_origin:
+            remote = remote.replace("\\", "/")
+            candidate = raw_path.replace("\\", "/")
+        remote = remote.rstrip("/")
+        if candidate.startswith(remote):
+            remainder = candidate[len(remote) :]
             resolved = local + remainder
             logger.info(
                 "path_mapping_applied",
@@ -226,6 +236,8 @@ async def _resolve_local_path(
             "configured Remote Path. Check that Remote Path matches "
             "the root of where the client stores completed downloads.",
         )
+        if windows_origin:
+            return candidate
     elif client_cfg and (client_cfg.remote_path or client_cfg.download_dir):
         logger.warning(
             "path_mapping_incomplete",

--- a/tests/e2e/test_utilities_page.py
+++ b/tests/e2e/test_utilities_page.py
@@ -821,10 +821,11 @@ class TestUtilitiesPage:
             () => {
               const root = document.querySelector("[data-testid='utilities-permissions-page']");
               const data = window.Alpine.$data(root);
-              data.applySelectedFolders({
-                mode: "directories",
-                directories: [{ path: "/library/Batman (2016)", name: "Batman (2016)" }]
-              });
+              data.scope = "folder";
+              data.selectedFolders = [
+                { path: "/tmp/pullbox-e2e-library/01-batman", name: "01-batman" }
+              ];
+              data.selectedFolder = "/tmp/pullbox-e2e-library/01-batman";
               data.runMode = "apply";
               data.confirmApply = false;
               data.validationError = "";

--- a/tests/tasks/test_download_post_processing_source_validation.py
+++ b/tests/tasks/test_download_post_processing_source_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -26,6 +27,41 @@ async def test_resolve_and_validate_source_rejects_missing_client_path() -> None
             log=SimpleNamespace(debug=lambda *args, **kwargs: None),
             resolve_local_path=AsyncMock(return_value=None),
             probe_source=AsyncMock(),
+            build_integrity_exception=lambda comic_file, errors: RuntimeError(errors),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_and_validate_source_refuses_filesystem_root_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed path mapping must never send the container root to file safety."""
+    from pullbox.tasks import download_post_processing_source_validation as source_validation
+
+    monkeypatch.setattr(
+        source_validation,
+        "get_allowed_extensions",
+        AsyncMock(return_value={".cbz"}),
+    )
+    probe = SimpleNamespace(
+        source_seen=True,
+        probe_root=Path("/"),
+        comic_file=Path("/unexpected.cbz"),
+        attempts=1,
+    )
+
+    with pytest.raises(RuntimeError, match="filesystem root"):
+        await source_validation.resolve_and_validate_source(
+            session=object(),
+            download=SimpleNamespace(id=7, downloaded_path="/downloads\\Release\\file.cbr"),
+            trace=SimpleNamespace(),
+            runtime=SimpleNamespace(enter_phase=lambda phase: None),
+            log=SimpleNamespace(
+                debug=lambda *args, **kwargs: None,
+                error=lambda *args, **kwargs: None,
+            ),
+            resolve_local_path=AsyncMock(return_value="/downloads\\Release\\file.cbr"),
+            probe_source=AsyncMock(return_value=probe),
             build_integrity_exception=lambda comic_file, errors: RuntimeError(errors),
         )
 

--- a/tests/tasks/test_download_post_processing_sources.py
+++ b/tests/tasks/test_download_post_processing_sources.py
@@ -130,6 +130,46 @@ async def test_resolve_local_path_normalizes_unmapped_windows_path() -> None:
     assert "\\" not in resolved
 
 
+@pytest.mark.asyncio
+async def test_resolve_local_path_preserves_posix_literal_backslash() -> None:
+    """POSIX paths may legally contain a literal backslash in a filename."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path="/remote",
+        download_dir="/downloads/Batman\\Superman",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path="/remote/file.cbz",
+    )
+
+    resolved = await _resolve_local_path(session, download)
+
+    assert resolved == "/downloads/Batman\\Superman/file.cbz"
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_download_root_preserves_posix_literal_backslash() -> None:
+    """The configured local cleanup root must not reinterpret POSIX filenames."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_download_root
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        download_dir="/downloads/Batman\\Superman"
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(download_client=DownloadClientType.SABNZBD)
+
+    root = await _resolve_local_download_root(session, download)
+
+    assert root == Path("/downloads/Batman\\Superman").resolve(strict=False)
+
+
 def test_post_processing_integrity_exception_distinguishes_missing_source() -> None:
     """Transient missing files should stay typed separately from bad releases."""
     from pullbox.tasks import download_post_processing_sources

--- a/tests/tasks/test_download_post_processing_sources.py
+++ b/tests/tasks/test_download_post_processing_sources.py
@@ -108,8 +108,8 @@ async def test_resolve_local_path_normalizes_windows_remote_path() -> None:
 
 
 @pytest.mark.asyncio
-async def test_resolve_local_path_normalizes_unmapped_windows_path() -> None:
-    """An unmapped path should still remain a safe POSIX-style probe path."""
+async def test_resolve_local_path_rejects_unmapped_windows_path() -> None:
+    """An unmapped Windows path must fail before container filesystem probing."""
     from pullbox.models.download import DownloadClientType
     from pullbox.tasks.download_post_processing_sources import _resolve_local_path
 
@@ -124,10 +124,94 @@ async def test_resolve_local_path_normalizes_unmapped_windows_path() -> None:
         downloaded_path=r"E:\Temp\Release\file.cbr",
     )
 
+    with pytest.raises(FileNotFoundError, match="does not match the configured Remote Path"):
+        await _resolve_local_path(session, download)
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_path_matches_windows_paths_case_insensitively() -> None:
+    """Windows drive and path casing must not affect a valid mapping."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"E:\Temp\Pullbox_Downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"e:\temp\pullbox_downloads\Release\file.cbr",
+    )
+
     resolved = await _resolve_local_path(session, download)
 
-    assert resolved == "E:/Temp/Release/file.cbr"
-    assert "\\" not in resolved
+    assert resolved == "/downloads/Release/file.cbr"
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_path_requires_windows_component_boundary() -> None:
+    """A similarly prefixed sibling folder must not map into the download root."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"E:\Temp\Pullbox_Downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"E:\Temp\Pullbox_Downloads-old\Release\file.cbr",
+    )
+
+    with pytest.raises(FileNotFoundError, match="does not match the configured Remote Path"):
+        await _resolve_local_path(session, download)
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_path_maps_windows_unc_path() -> None:
+    """UNC roots should map with the same component-aware Windows semantics."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"\\server\share\downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"\\SERVER\SHARE\Downloads\Release\file.cbr",
+    )
+
+    resolved = await _resolve_local_path(session, download)
+
+    assert resolved == "/downloads/Release/file.cbr"
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_path_rejects_windows_parent_traversal() -> None:
+    """A client-reported parent traversal must not escape the local mapping root."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"E:\Temp\Pullbox_Downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"E:\Temp\Pullbox_Downloads\..\outside\file.cbr",
+    )
+
+    with pytest.raises(FileNotFoundError, match="unsafe parent traversal"):
+        await _resolve_local_path(session, download)
 
 
 @pytest.mark.asyncio

--- a/tests/tasks/test_download_post_processing_sources.py
+++ b/tests/tasks/test_download_post_processing_sources.py
@@ -84,6 +84,52 @@ async def test_airdcpp_local_path_uses_exact_client_and_strict_mapper(tmp_path: 
     assert 22 in statement.compile().params.values()
 
 
+@pytest.mark.asyncio
+async def test_resolve_local_path_normalizes_windows_remote_path() -> None:
+    """Windows client separators must not leak into container paths."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"E:\Temp\Pullbox_Downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"E:\Temp\Pullbox_Downloads\Release\file.cbr",
+    )
+
+    resolved = await _resolve_local_path(session, download)
+
+    assert resolved == "/downloads/Release/file.cbr"
+    assert "\\" not in resolved
+
+
+@pytest.mark.asyncio
+async def test_resolve_local_path_normalizes_unmapped_windows_path() -> None:
+    """An unmapped path should still remain a safe POSIX-style probe path."""
+    from pullbox.models.download import DownloadClientType
+    from pullbox.tasks.download_post_processing_sources import _resolve_local_path
+
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = SimpleNamespace(
+        remote_path=r"D:\Downloads",
+        download_dir="/downloads",
+    )
+    session = SimpleNamespace(execute=AsyncMock(return_value=result))
+    download = SimpleNamespace(
+        download_client=DownloadClientType.SABNZBD,
+        downloaded_path=r"E:\Temp\Release\file.cbr",
+    )
+
+    resolved = await _resolve_local_path(session, download)
+
+    assert resolved == "E:/Temp/Release/file.cbr"
+    assert "\\" not in resolved
+
+
 def test_post_processing_integrity_exception_distinguishes_missing_source() -> None:
     """Transient missing files should stay typed separately from bad releases."""
     from pullbox.tasks import download_post_processing_sources

--- a/tests/tasks/test_download_post_processing_sources.py
+++ b/tests/tasks/test_download_post_processing_sources.py
@@ -254,6 +254,26 @@ async def test_resolve_local_download_root_preserves_posix_literal_backslash() -
     assert root == Path("/downloads/Batman\\Superman").resolve(strict=False)
 
 
+@pytest.mark.asyncio
+async def test_probe_rejects_filesystem_root_before_recursive_discovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed paths must not invoke recursive discovery against the root."""
+    from pullbox.tasks import download_post_processing_sources as sources
+
+    finder = MagicMock(return_value=None)
+    monkeypatch.setattr(sources, "_POST_PROCESSING_SOURCE_RETRY_DELAYS", (0.0,))
+
+    with pytest.raises(RuntimeError, match="filesystem root"):
+        await sources._probe_post_processing_source(
+            Path("/downloads\\Release\\file.cbr"),
+            {".cbr"},
+            find_comic_file=finder,
+        )
+
+    finder.assert_not_called()
+
+
 def test_post_processing_integrity_exception_distinguishes_missing_source() -> None:
     """Transient missing files should stay typed separately from bad releases."""
     from pullbox.tasks import download_post_processing_sources


### PR DESCRIPTION
## Summary

- normalize Windows drive-letter and UNC separators before applying remote-to-local path mapping
- preserve literal backslashes in POSIX paths
- match Windows paths case-insensitively while keeping POSIX matching case-sensitive
- reject sibling-prefix, parent-traversal, and unmapped Windows paths instead of probing an unintended location
- refuse filesystem-root discovery and safety scans when a path mapping cannot be resolved safely
- add regression coverage for mapped, unmapped, case-varied, UNC, sibling-prefix, traversal, and root-probe paths
- isolate the permissions confirmation E2E test from an unrelated asynchronous preview request

Fixes #118

## Verification

- `pytest -q tests/tasks/test_download_post_processing_sources.py tests/tasks/test_download_post_processing_source_validation.py tests/tasks/test_download_task_latency.py` (`50 passed`)
- focused permissions confirmation E2E passed locally in Firefox and Chromium
- `ruff check` and `ruff format --check` passed for all touched Python files
- `git diff --check origin/develop...HEAD`
- full GitHub CI, Security, Workflow Hygiene, Docker sanity, Chromium E2E, and Firefox E2E passed
