### PR TITLE
chore: sync develop after v1.1.2 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     permissions:
       actions: read
       contents: write
+      deployments: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -80,6 +81,12 @@ jobs:
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "announcement=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "announcement=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract version info
@@ -257,11 +264,20 @@ jobs:
           draft: false
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
 
-      - name: Post release notifications to Discord
+      - name: Reserve changelog Discord delivery
         if: steps.release.outputs.skip != 'true' && steps.version.outputs.prerelease != 'true'
+        id: reserve-changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=src python3 -m pullbox.release_discord_delivery reserve \
+            --channel changelog \
+            --version "${{ steps.release.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Post changelog to Discord
+        if: steps.reserve-changelog.outputs.skip != 'true'
         env:
           DISCORD_WEBHOOK_CHANGELOG: ${{ secrets.DISCORD_WEBHOOK_CHANGELOG }}
-          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_WEBHOOK_CHANGELOG}" ]; then
@@ -271,7 +287,7 @@ jobs:
           release_url="https://github.com/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag }}"
           PYTHONPATH=src python3 -m pullbox.release_discord_notifications \
             --kind changelog \
-            --version "${{ steps.version.outputs.version }}" \
+            --version "${{ steps.release.outputs.version }}" \
             --changelog curated_changelog.md \
             --release-url "${release_url}" > discord-changelog.json
           curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
@@ -279,18 +295,53 @@ jobs:
             --data @discord-changelog.json \
             "${DISCORD_WEBHOOK_CHANGELOG}?wait=true"
 
-          if [[ "${{ steps.version.outputs.version }}" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
-            if [ -z "${DISCORD_WEBHOOK_ANNOUNCEMENTS}" ]; then
-              echo "::error::DISCORD_WEBHOOK_ANNOUNCEMENTS is required for major and minor releases."
-              exit 1
-            fi
-            PYTHONPATH=src python3 -m pullbox.release_discord_notifications \
-              --kind announcement \
-              --version "${{ steps.version.outputs.version }}" \
-              --changelog curated_changelog.md \
-              --release-url "${release_url}" > discord-announcement.json
-            curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
-              --header 'Content-Type: application/json' \
-              --data @discord-announcement.json \
-              "${DISCORD_WEBHOOK_ANNOUNCEMENTS}?wait=true"
+      - name: Record changelog Discord delivery
+        if: success() && steps.reserve-changelog.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=src python3 -m pullbox.release_discord_delivery success \
+            --channel changelog \
+            --version "${{ steps.release.outputs.version }}" \
+            --deployment-id "${{ steps.reserve-changelog.outputs.deployment_id }}"
+
+      - name: Reserve announcement Discord delivery
+        if: steps.release.outputs.skip != 'true' && steps.version.outputs.prerelease != 'true' && steps.release.outputs.announcement == 'true'
+        id: reserve-announcement
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=src python3 -m pullbox.release_discord_delivery reserve \
+            --channel announcements \
+            --version "${{ steps.release.outputs.version }}" >> "$GITHUB_OUTPUT"
+
+      - name: Post announcement to Discord
+        if: steps.reserve-announcement.outputs.skip != 'true'
+        env:
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK_ANNOUNCEMENTS}" ]; then
+            echo "::error::DISCORD_WEBHOOK_ANNOUNCEMENTS is required for major and minor releases."
+            exit 1
           fi
+          release_url="https://github.com/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag }}"
+          PYTHONPATH=src python3 -m pullbox.release_discord_notifications \
+            --kind announcement \
+            --version "${{ steps.release.outputs.version }}" \
+            --changelog curated_changelog.md \
+            --release-url "${release_url}" > discord-announcement.json
+          curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
+            --header 'Content-Type: application/json' \
+            --data @discord-announcement.json \
+            "${DISCORD_WEBHOOK_ANNOUNCEMENTS}?wait=true"
+
+      - name: Record announcement Discord delivery
+        if: success() && steps.reserve-announcement.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          PYTHONPATH=src python3 -m pullbox.release_discord_delivery success \
+            --channel announcements \
+            --version "${{ steps.release.outputs.version }}" \
+            --deployment-id "${{ steps.reserve-announcement.outputs.deployment_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,7 @@ jobs:
             --version "${{ steps.release.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Post changelog to Discord
-        if: steps.reserve-changelog.outputs.skip != 'true'
+        if: steps.reserve-changelog.outcome == 'success' && steps.reserve-changelog.outputs.skip != 'true'
         env:
           DISCORD_WEBHOOK_CHANGELOG: ${{ secrets.DISCORD_WEBHOOK_CHANGELOG }}
         run: |
@@ -290,13 +290,13 @@ jobs:
             --version "${{ steps.release.outputs.version }}" \
             --changelog curated_changelog.md \
             --release-url "${release_url}" > discord-changelog.json
-          curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
+          curl --fail-with-body \
             --header 'Content-Type: application/json' \
             --data @discord-changelog.json \
             "${DISCORD_WEBHOOK_CHANGELOG}?wait=true"
 
       - name: Record changelog Discord delivery
-        if: success() && steps.reserve-changelog.outputs.skip != 'true'
+        if: success() && steps.reserve-changelog.outcome == 'success' && steps.reserve-changelog.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -316,7 +316,7 @@ jobs:
             --version "${{ steps.release.outputs.version }}" >> "$GITHUB_OUTPUT"
 
       - name: Post announcement to Discord
-        if: steps.reserve-announcement.outputs.skip != 'true'
+        if: steps.reserve-announcement.outcome == 'success' && steps.reserve-announcement.outputs.skip != 'true'
         env:
           DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
         run: |
@@ -331,13 +331,13 @@ jobs:
             --version "${{ steps.release.outputs.version }}" \
             --changelog curated_changelog.md \
             --release-url "${release_url}" > discord-announcement.json
-          curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
+          curl --fail-with-body \
             --header 'Content-Type: application/json' \
             --data @discord-announcement.json \
             "${DISCORD_WEBHOOK_ANNOUNCEMENTS}?wait=true"
 
       - name: Record announcement Discord delivery
-        if: success() && steps.reserve-announcement.outputs.skip != 'true'
+        if: success() && steps.reserve-announcement.outcome == 'success' && steps.reserve-announcement.outputs.skip != 'true'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,7 @@ jobs:
         id: reserve-changelog
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          PULLBOX_RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           PYTHONPATH=src python3 -m pullbox.release_discord_delivery reserve \
             --channel changelog \
@@ -310,6 +311,7 @@ jobs:
         id: reserve-announcement
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          PULLBOX_RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           PYTHONPATH=src python3 -m pullbox.release_discord_delivery reserve \
             --channel announcements \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,3 +256,41 @@ jobs:
           body_path: release_notes.md
           draft: false
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
+
+      - name: Post release notifications to Discord
+        if: steps.release.outputs.skip != 'true' && steps.version.outputs.prerelease != 'true'
+        env:
+          DISCORD_WEBHOOK_CHANGELOG: ${{ secrets.DISCORD_WEBHOOK_CHANGELOG }}
+          DISCORD_WEBHOOK_ANNOUNCEMENTS: ${{ secrets.DISCORD_WEBHOOK_ANNOUNCEMENTS }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DISCORD_WEBHOOK_CHANGELOG}" ]; then
+            echo "::error::DISCORD_WEBHOOK_CHANGELOG is required for final releases."
+            exit 1
+          fi
+          release_url="https://github.com/${{ github.repository }}/releases/tag/${{ steps.release.outputs.tag }}"
+          PYTHONPATH=src python3 -m pullbox.release_discord_notifications \
+            --kind changelog \
+            --version "${{ steps.version.outputs.version }}" \
+            --changelog curated_changelog.md \
+            --release-url "${release_url}" > discord-changelog.json
+          curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
+            --header 'Content-Type: application/json' \
+            --data @discord-changelog.json \
+            "${DISCORD_WEBHOOK_CHANGELOG}?wait=true"
+
+          if [[ "${{ steps.version.outputs.version }}" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            if [ -z "${DISCORD_WEBHOOK_ANNOUNCEMENTS}" ]; then
+              echo "::error::DISCORD_WEBHOOK_ANNOUNCEMENTS is required for major and minor releases."
+              exit 1
+            fi
+            PYTHONPATH=src python3 -m pullbox.release_discord_notifications \
+              --kind announcement \
+              --version "${{ steps.version.outputs.version }}" \
+              --changelog curated_changelog.md \
+              --release-url "${release_url}" > discord-announcement.json
+            curl --fail-with-body --retry 3 --retry-all-errors --retry-delay 2 \
+              --header 'Content-Type: application/json' \
+              --data @discord-announcement.json \
+              "${DISCORD_WEBHOOK_ANNOUNCEMENTS}?wait=true"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-08-26
+
+Patch release that makes release notifications and browser validation more reliable.
+
+### Fixed
+
+- Preserve successful Discord release delivery records so later channel posts and
+  workflow reruns do not create duplicate messages.
+- Record Discord delivery state against the exact release commit.
+- Stabilize the utilities export footer check in Firefox by targeting the
+  dedicated fields value.
+
 ## [1.1.1] - 2026-08-23
 
 Patch release improving direct-download reliability for collected issue packs.

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/release_discord_delivery.py
+++ b/src/pullbox/release_discord_delivery.py
@@ -1,0 +1,172 @@
+"""Record Discord release deliveries so workflow retries never repost them."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+def delivery_task(channel: str) -> str:
+    """Return the stable GitHub Deployment task for a Discord channel."""
+    if channel not in {"changelog", "announcements"}:
+        raise ValueError(f"Unsupported Discord channel: {channel}")
+    return f"pullbox-discord-{channel}"
+
+
+def _request(
+    method: str,
+    url: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    data = json.dumps(payload).encode() if payload is not None else None
+    request = Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urlopen(request) as response:
+        return json.load(response)
+
+
+def reserve_delivery(
+    *,
+    api_url: str,
+    repository: str,
+    token: str,
+    ref: str,
+    run_url: str,
+    version: str,
+    channel: str,
+) -> int | None:
+    """Reserve a delivery, or return ``None`` after a prior successful post.
+
+    Any incomplete prior delivery stays blocked for human review. This is safer
+    than automatically retrying an operation whose Discord result is unknown.
+    """
+    task = delivery_task(channel)
+    deployments_url = f"{api_url}/repos/{repository}/deployments?" + urlencode(
+        {"environment": "pullbox-discord", "task": task, "per_page": 100}
+    )
+    for deployment in _request("GET", deployments_url, token):
+        payload = deployment.get("payload") or {}
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        if payload.get("version") != version:
+            continue
+        statuses_url = (
+            f"{api_url}/repos/{repository}/deployments/{deployment['id']}/statuses?per_page=1"
+        )
+        statuses = _request("GET", statuses_url, token)
+        if statuses and statuses[0].get("state") == "success":
+            return None
+        message = f"Discord {channel} delivery for v{version} is already pending or failed"
+        raise RuntimeError(f"{message}; review it before retrying.")
+
+    deployment = _request(
+        "POST",
+        f"{api_url}/repos/{repository}/deployments",
+        token,
+        {
+            "ref": ref,
+            "task": task,
+            "environment": "pullbox-discord",
+            "description": f"Discord {channel} delivery for v{version}",
+            "auto_merge": False,
+            "required_contexts": [],
+            "payload": {"version": version},
+            "production_environment": False,
+        },
+    )
+    record_delivery(
+        api_url=api_url,
+        repository=repository,
+        token=token,
+        deployment_id=deployment["id"],
+        state="in_progress",
+        run_url=run_url,
+        description=f"Sending Discord {channel}",
+    )
+    return int(deployment["id"])
+
+
+def record_delivery(
+    *,
+    api_url: str,
+    repository: str,
+    token: str,
+    deployment_id: int,
+    state: str,
+    run_url: str,
+    description: str,
+) -> None:
+    """Record the final state of a reserved Discord delivery."""
+    _request(
+        "POST",
+        f"{api_url}/repos/{repository}/deployments/{deployment_id}/statuses",
+        token,
+        {
+            "state": state,
+            "environment": "pullbox-discord",
+            "log_url": run_url,
+            "description": description,
+        },
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Reserve or record a Discord release delivery.")
+    parser.add_argument("action", choices=("reserve", "success"))
+    parser.add_argument("--channel", required=True, choices=("changelog", "announcements"))
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--deployment-id", type=int)
+    args = parser.parse_args(argv)
+
+    token = os.environ["GITHUB_TOKEN"]
+    api_url = os.environ["GITHUB_API_URL"]
+    repository = os.environ["GITHUB_REPOSITORY"]
+    run_url = (
+        f"{os.environ['GITHUB_SERVER_URL']}/{repository}/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+    )
+    if args.action == "reserve":
+        deployment_id = reserve_delivery(
+            api_url=api_url,
+            repository=repository,
+            token=token,
+            ref=os.environ["GITHUB_SHA"],
+            run_url=run_url,
+            version=args.version,
+            channel=args.channel,
+        )
+        if deployment_id is None:
+            print("skip=true")
+        else:
+            print(f"deployment_id={deployment_id}")
+        return 0
+
+    if args.deployment_id is None:
+        parser.error("--deployment-id is required for success")
+    record_delivery(
+        api_url=api_url,
+        repository=repository,
+        token=token,
+        deployment_id=args.deployment_id,
+        state="success",
+        run_url=run_url,
+        description=f"Posted Discord {args.channel}",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pullbox/release_discord_delivery.py
+++ b/src/pullbox/release_discord_delivery.py
@@ -120,6 +120,7 @@ def record_delivery(
             "environment": "pullbox-discord",
             "log_url": run_url,
             "description": description,
+            "auto_inactive": False,
         },
     )
 
@@ -143,7 +144,7 @@ def main(argv: list[str] | None = None) -> int:
             api_url=api_url,
             repository=repository,
             token=token,
-            ref=os.environ["GITHUB_SHA"],
+            ref=os.environ["PULLBOX_RELEASE_SHA"],
             run_url=run_url,
             version=args.version,
             channel=args.channel,

--- a/src/pullbox/release_discord_notifications.py
+++ b/src/pullbox/release_discord_notifications.py
@@ -1,0 +1,93 @@
+"""Build safe Discord webhook payloads for completed Pullbox releases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+_FINAL_VERSION = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$"
+)
+_BULLET = re.compile(r"^\s*-\s+(?P<text>.+?)\s*$", re.MULTILINE)
+_EMBED_COLOR = 0xF07A2C
+
+
+def notification_channels(version: str) -> tuple[str, ...]:
+    """Return public Discord channels appropriate for a final semantic release."""
+    match = _FINAL_VERSION.fullmatch(version)
+    if match is None:
+        return ()
+    if int(match.group("patch")) == 0:
+        return ("changelog", "announcements")
+    return ("changelog",)
+
+
+def changelog_payload(version: str, changelog: str, release_url: str) -> dict[str, Any]:
+    """Build the full, mention-safe changelog embed."""
+    return _payload(
+        title=f"Pullbox v{version} changelog",
+        description=_truncate(changelog.strip(), 4096),
+        release_url=release_url,
+    )
+
+
+def announcement_payload(version: str, changelog: str, release_url: str) -> dict[str, Any]:
+    """Build the short announcement embed for major and minor releases."""
+    highlights = [match.group("text") for match in _BULLET.finditer(changelog)][:2]
+    description = "\n".join(f"• {highlight}" for highlight in highlights)
+    if description:
+        description += "\n\n"
+    description += f"[Read the full release notes]({release_url})"
+    return _payload(
+        title=f"Pullbox v{version} is out",
+        description=_truncate(description, 4096),
+        release_url=release_url,
+    )
+
+
+def _payload(*, title: str, description: str, release_url: str) -> dict[str, Any]:
+    return {
+        "allowed_mentions": {"parse": []},
+        "embeds": [
+            {
+                "title": title,
+                "description": description,
+                "url": release_url,
+                "color": _EMBED_COLOR,
+                "footer": {"text": "Pullbox release"},
+            }
+        ],
+    }
+
+
+def _truncate(value: str, maximum: int) -> str:
+    if len(value) <= maximum:
+        return value
+    return f"{value[: maximum - 1].rstrip()}…"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Write one validated Discord payload to standard output."""
+    parser = argparse.ArgumentParser(description="Build a Pullbox Discord release payload.")
+    parser.add_argument("--kind", choices=("announcement", "changelog"), required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--changelog", type=Path, required=True)
+    parser.add_argument("--release-url", required=True)
+    args = parser.parse_args(argv)
+
+    changelog = args.changelog.read_text(encoding="utf-8")
+    payload = (
+        announcement_payload(args.version, changelog, args.release_url)
+        if args.kind == "announcement"
+        else changelog_payload(args.version, changelog, args.release_url)
+    )
+    json.dump(payload, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/pullbox/ui/templates/partials/utilities_export_footer_dock.html
+++ b/src/pullbox/ui/templates/partials/utilities_export_footer_dock.html
@@ -19,7 +19,11 @@
       </span>
       <span class="page-dock-status-item">
         <span class="page-dock-status-label">fields</span>
-        <strong class="page-dock-status-value" x-text="fields">{{ export_default_fields|length }}</strong>
+        <strong
+          class="page-dock-status-value"
+          data-testid="utilities-export-footer-fields"
+          x-text="fields"
+        >{{ export_default_fields|length }}</strong>
       </span>
       <span class="page-dock-status-item">
         <span class="page-dock-status-label">dest</span>

--- a/tests/e2e/test_utilities_page.py
+++ b/tests/e2e/test_utilities_page.py
@@ -3689,7 +3689,11 @@ class TestUtilitiesPage:
         page.choose_format("csv")
 
         assert footer.get_by_text("CSV", exact=False).is_visible()
-        assert footer.get_by_text(str(page.selected_field_count()), exact=False).is_visible()
+        assert (
+            footer.locator("[data-testid='utilities-export-footer-fields']")
+            .get_by_text(str(page.selected_field_count()), exact=True)
+            .is_visible()
+        )
 
     def test_export_json_multi_value_controls_select_and_clear_all(
         self,

--- a/tests/unit/test_release_discord_notifications.py
+++ b/tests/unit/test_release_discord_notifications.py
@@ -1,0 +1,52 @@
+"""Release notification payload contracts."""
+
+from __future__ import annotations
+
+from pullbox.release_discord_notifications import (
+    announcement_payload,
+    changelog_payload,
+    notification_channels,
+)
+
+CHANGELOG = """### Added
+
+- Added one important capability.
+- Added a second important capability.
+
+### Fixed
+
+- Fixed a frustrating edge case.
+"""
+
+
+def test_final_releases_always_send_a_changelog_notification() -> None:
+    assert notification_channels("1.2.3") == ("changelog",)
+    assert notification_channels("1.2.0") == ("changelog", "announcements")
+    assert notification_channels("2.0.0") == ("changelog", "announcements")
+
+
+def test_prereleases_never_send_public_notifications() -> None:
+    assert notification_channels("1.2.0-rc.1") == ()
+
+
+def test_changelog_payload_is_an_embed_with_mentions_disabled() -> None:
+    payload = changelog_payload(
+        "1.2.3", CHANGELOG, "https://github.com/pullboxapp/pullbox/releases/tag/v1.2.3"
+    )
+
+    assert payload["allowed_mentions"] == {"parse": []}
+    assert payload["embeds"][0]["title"] == "Pullbox v1.2.3 changelog"
+    assert "Added one important capability." in payload["embeds"][0]["description"]
+    assert payload["embeds"][0]["url"].endswith("v1.2.3")
+
+
+def test_announcement_payload_is_short_and_links_to_the_release() -> None:
+    payload = announcement_payload(
+        "1.2.0", CHANGELOG, "https://github.com/pullboxapp/pullbox/releases/tag/v1.2.0"
+    )
+
+    assert payload["allowed_mentions"] == {"parse": []}
+    assert payload["embeds"][0]["title"] == "Pullbox v1.2.0 is out"
+    assert "Added one important capability." in payload["embeds"][0]["description"]
+    assert "Fixed a frustrating edge case." not in payload["embeds"][0]["description"]
+    assert "Read the full release notes" in payload["embeds"][0]["description"]

--- a/tests/unit/test_release_discord_notifications.py
+++ b/tests/unit/test_release_discord_notifications.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from pullbox.release_discord_delivery import delivery_task
 from pullbox.release_discord_notifications import (
     announcement_payload,
@@ -33,6 +35,14 @@ def test_prereleases_never_send_public_notifications() -> None:
 def test_delivery_tasks_are_stable_per_channel() -> None:
     assert delivery_task("changelog") == "pullbox-discord-changelog"
     assert delivery_task("announcements") == "pullbox-discord-announcements"
+
+
+def test_release_workflow_only_posts_after_a_successful_reservation() -> None:
+    workflow = Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+
+    assert "steps.reserve-changelog.outcome == 'success'" in workflow
+    assert "steps.reserve-announcement.outcome == 'success'" in workflow
+    assert "--retry-all-errors" not in workflow
 
 
 def test_changelog_payload_is_an_embed_with_mentions_disabled() -> None:

--- a/tests/unit/test_release_discord_notifications.py
+++ b/tests/unit/test_release_discord_notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pullbox import release_discord_delivery as delivery
 from pullbox.release_discord_delivery import delivery_task
 from pullbox.release_discord_notifications import (
     announcement_payload,
@@ -43,6 +44,35 @@ def test_release_workflow_only_posts_after_a_successful_reservation() -> None:
     assert "steps.reserve-changelog.outcome == 'success'" in workflow
     assert "steps.reserve-announcement.outcome == 'success'" in workflow
     assert "--retry-all-errors" not in workflow
+    assert "PULLBOX_RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}" in workflow
+
+
+def test_successful_delivery_does_not_inactivate_prior_discord_records(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request(method, url, token, payload=None):
+        captured.update({"method": method, "url": url, "payload": payload})
+        return {}
+
+    monkeypatch.setattr(delivery, "_request", fake_request)
+
+    delivery.record_delivery(
+        api_url="https://api.github.test",
+        repository="pullboxapp/pullbox",
+        token="token",
+        deployment_id=42,
+        state="success",
+        run_url="https://github.test/run/1",
+        description="Posted Discord changelog",
+    )
+
+    assert captured["payload"] == {
+        "state": "success",
+        "environment": "pullbox-discord",
+        "log_url": "https://github.test/run/1",
+        "description": "Posted Discord changelog",
+        "auto_inactive": False,
+    }
 
 
 def test_changelog_payload_is_an_embed_with_mentions_disabled() -> None:

--- a/tests/unit/test_release_discord_notifications.py
+++ b/tests/unit/test_release_discord_notifications.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pullbox.release_discord_delivery import delivery_task
 from pullbox.release_discord_notifications import (
     announcement_payload,
     changelog_payload,
@@ -27,6 +28,11 @@ def test_final_releases_always_send_a_changelog_notification() -> None:
 
 def test_prereleases_never_send_public_notifications() -> None:
     assert notification_channels("1.2.0-rc.1") == ()
+
+
+def test_delivery_tasks_are_stable_per_channel() -> None:
+    assert delivery_task("changelog") == "pullbox-discord-changelog"
+    assert delivery_task("announcements") == "pullbox-discord-announcements"
 
 
 def test_changelog_payload_is_an_embed_with_mentions_disabled() -> None:


### PR DESCRIPTION
## Summary

- synchronize the finalized v1.1.2 release and Discord notification changes from `main` back into `develop`
- preserve current Unreleased reader work
- reopen development at `1.1.3-dev`

## Validation

- `pytest tests/unit/test_release_discord_notifications.py -q` (7 passed)
- `pytest tests/unit/ -x -q -m "not slow" --no-header` (5,215 passed, 3 skipped, 87 deselected, 1 xfailed)
- `make workflow-hygiene`
- `git diff --check`

This is a normal post-release merge rather than the lightweight sync fast path because `develop` advanced after v1.1.2 was released.