### PR TITLE
fix: address v1.1.2 bug-bash findings

### DIFF
--- a/docs/development/DATABASE_STANDARDS.md
+++ b/docs/development/DATABASE_STANDARDS.md
@@ -537,6 +537,12 @@ Pullbox also includes sidecar recovery logic for stale or corrupt `-wal` and
 - Database maintenance windows coordinate app traffic through the shared
   maintenance gate.
 - Gate-aware sessions pause before database-touching operations.
+- An exclusive nightly task runs SQLite `REINDEX` and
+  `PRAGMA optimize=0x10002` at 04:30, then verifies the database with
+  `PRAGMA quick_check`. The all-tables mask is intentional because the
+  maintenance connection has no prior query history.
+- Full SQLite `VACUUM` compaction remains an explicit operator action because
+  it rewrites the database and can require substantial temporary disk space.
 
 **Required standard**
 
@@ -551,6 +557,8 @@ Pullbox also includes sidecar recovery logic for stale or corrupt `-wal` and
 - For long-lived SQLite deployments, prefer `PRAGMA optimize` during maintenance
   or connection-lifecycle boundaries instead of broad manual `ANALYZE` routines
   on request paths.
+- PostgreSQL and in-memory SQLite deployments skip the SQLite file-maintenance
+  task.
 
 **Audit checks**
 

--- a/src/pullbox/core/library_comicinfo.py
+++ b/src/pullbox/core/library_comicinfo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import tempfile
 from pathlib import Path
@@ -82,7 +83,9 @@ async def build_comicinfo_payload_for_issue(
 
     release_date = issue.release_date
     inspected_page_count = (
-        inspect_archive_page_count(source_path) if source_path is not None else None
+        await asyncio.to_thread(inspect_archive_page_count, source_path)
+        if source_path is not None
+        else None
     )
     notes: str | None = None
     if series.comicvine_id and issue.comicvine_id:
@@ -115,18 +118,19 @@ async def build_comicinfo_payload_for_issue(
     return payload
 
 
-def apply_comicinfo_to_imported_artifact(
+async def apply_comicinfo_to_imported_artifact(
     artifact_path: Path,
     comicinfo_payload: dict[str, Any],
     *,
     progress_callback: Callable[[str, int, int, str], Any] | None = None,
 ) -> None:
-    """Write authoritative ComicInfo to a final library artifact."""
+    """Write authoritative ComicInfo without blocking request handling."""
     if artifact_path.suffix.lower() != ".cbz":
         raise ConfigurationError(
             "Updating embedded ComicInfo.xml from matched issue requires a CBZ artifact."
         )
-    embed_comicinfo_in_cbz(
+    await asyncio.to_thread(
+        embed_comicinfo_in_cbz,
         artifact_path,
         comicinfo_payload,
         progress_callback=progress_callback,

--- a/src/pullbox/services/database_optimization_service.py
+++ b/src/pullbox/services/database_optimization_service.py
@@ -98,6 +98,9 @@ class DatabaseOptimizationService:
                     "SQLite could not checkpoint the write-ahead log because the database is busy."
                 )
             connection.execute("REINDEX")
+            # PRAGMA optimize may skip ANALYZE on a fresh connection depending
+            # on the bundled SQLite version, so refresh statistics explicitly.
+            connection.execute("ANALYZE")
             # This maintenance connection has no query history, so include the
             # all-tables mask recommended by SQLite for a fresh connection.
             connection.execute("PRAGMA optimize=0x10002")

--- a/src/pullbox/services/database_optimization_service.py
+++ b/src/pullbox/services/database_optimization_service.py
@@ -45,6 +45,13 @@ class DatabaseOptimizationResult:
         return max(0, self.before.database_bytes - self.after.database_bytes)
 
 
+@dataclass(frozen=True, slots=True)
+class DatabaseMaintenanceResult:
+    """Verified outcome of lightweight recurring SQLite maintenance."""
+
+    integrity_result: str
+
+
 class DatabaseOptimizationService:
     """Inspect and compact one SQLite database file."""
 
@@ -80,6 +87,33 @@ class DatabaseOptimizationService:
                 f"SQLite integrity verification failed after optimization: {after.integrity_result}"
             )
         return DatabaseOptimizationResult(before=before, after=after)
+
+    def maintain(self) -> DatabaseMaintenanceResult:
+        """Rebuild indexes, refresh planner statistics, and verify integrity."""
+        self._ensure_database_exists()
+        with self._connect(read_only=False) as connection:
+            checkpoint = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            if checkpoint is not None and int(checkpoint[0]) != 0:
+                raise DatabaseOptimizationError(
+                    "SQLite could not checkpoint the write-ahead log because the database is busy."
+                )
+            connection.execute("REINDEX")
+            # This maintenance connection has no query history, so include the
+            # all-tables mask recommended by SQLite for a fresh connection.
+            connection.execute("PRAGMA optimize=0x10002")
+            checkpoint = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            if checkpoint is not None and int(checkpoint[0]) != 0:
+                raise DatabaseOptimizationError(
+                    "SQLite could not checkpoint the write-ahead log after maintenance."
+                )
+            integrity_row = connection.execute("PRAGMA quick_check").fetchone()
+
+        integrity_result = str(integrity_row[0] if integrity_row else "unknown")
+        if integrity_result.lower() != "ok":
+            raise DatabaseOptimizationError(
+                f"SQLite integrity verification failed after maintenance: {integrity_result}"
+            )
+        return DatabaseMaintenanceResult(integrity_result=integrity_result)
 
     def _ensure_database_exists(self) -> None:
         if not self._db_path.is_file():
@@ -138,3 +172,8 @@ class DatabaseOptimizationRuntimeService:
         """Compact the database outside the event loop under the maintenance gate."""
         async with database_maintenance_window(reason="database_optimize"):
             return await asyncio.to_thread(self._service.optimize)
+
+    async def maintain(self) -> DatabaseMaintenanceResult:
+        """Run recurring maintenance outside the event loop under the shared gate."""
+        async with database_maintenance_window(reason="nightly_database_maintenance"):
+            return await asyncio.to_thread(self._service.maintain)

--- a/src/pullbox/services/direct_host_reachability.py
+++ b/src/pullbox/services/direct_host_reachability.py
@@ -185,6 +185,13 @@ async def record_direct_host_operational_result(
     )
     config.last_operational_at = occurred_at
     config.last_error_code = None if succeeded else getattr(error, "code", None)
+
+    # Generic HTTPS represents arbitrary final-file origins, not one host whose
+    # global reachability can be inferred from a single transfer.
+    if config.host_kind is DirectArtifactHostKind.GENERIC_HTTPS:
+        config.reachability_state = DirectHostReachabilityState.NOT_CHECKED
+        return
+
     has_credentials = bool(config.encrypted_credentials)
 
     if succeeded:

--- a/src/pullbox/services/health_download_client_checks.py
+++ b/src/pullbox/services/health_download_client_checks.py
@@ -326,7 +326,12 @@ async def _check_direct_download_subjects(session: AsyncSession) -> list[CheckOu
     keeps scheduled health non-destructive: it never resolves or downloads an
     artifact just to prove a source is available.
     """
-    from pullbox.models.direct_acquisition import DirectHostConfig, DirectProviderConfig
+    from pullbox.models.direct_acquisition import (
+        DirectArtifactHostKind,
+        DirectHostConfig,
+        DirectHostReachabilityState,
+        DirectProviderConfig,
+    )
 
     providers = list(
         (
@@ -339,7 +344,7 @@ async def _check_direct_download_subjects(session: AsyncSession) -> list[CheckOu
         .scalars()
         .all()
     )
-    hosts = list(
+    configured_hosts = list(
         (
             await session.execute(
                 select(DirectHostConfig)
@@ -350,6 +355,13 @@ async def _check_direct_download_subjects(session: AsyncSession) -> list[CheckOu
         .scalars()
         .all()
     )
+    hosts = []
+    for host in configured_hosts:
+        if host.host_kind is DirectArtifactHostKind.GENERIC_HTTPS:
+            host.reachability_state = DirectHostReachabilityState.NOT_CHECKED
+            continue
+        hosts.append(host)
+
     return [
         *(_direct_provider_outcome(provider) for provider in providers),
         *(_direct_artifact_host_outcome(host) for host in hosts),

--- a/src/pullbox/services/health_persistence.py
+++ b/src/pullbox/services/health_persistence.py
@@ -281,6 +281,13 @@ async def upsert_health_current_status_rows(
         select(HealthCurrentStatusModel).where(HealthCurrentStatusModel.component.in_(components))
     )
     existing = {_current_status_identity(row): row for row in result.scalars().all()}
+    current_identities = {
+        (payload.component, payload.subject_key_norm, payload.current_key) for payload in payloads
+    }
+
+    for identity, stale_row in existing.items():
+        if identity not in current_identities:
+            await session.delete(stale_row)
 
     for payload in payloads:
         identity = (payload.component, payload.subject_key_norm, payload.current_key)
@@ -331,6 +338,13 @@ async def update_health_incidents(
         )
     )
     active = {_incident_identity(row): row for row in result.scalars().all()}
+    current_identities = {
+        (payload.component, payload.subject_key_norm, payload.current_key) for payload in payloads
+    }
+
+    for identity, retired_incident in active.items():
+        if identity not in current_identities:
+            retired_incident.resolved_at = checked_at
 
     for payload in payloads:
         identity = (payload.component, payload.subject_key_norm, payload.current_key)

--- a/src/pullbox/services/import_comicinfo_enrichment.py
+++ b/src/pullbox/services/import_comicinfo_enrichment.py
@@ -147,9 +147,16 @@ async def run_import_comicinfo_enrichment(
             if prepared is None:
                 continue
 
-            apply_result = apply_comicinfo(prepared.artifact_path, prepared.payload)
-            if inspect.isawaitable(apply_result):
-                await apply_result
+            if inspect.iscoroutinefunction(apply_comicinfo):
+                await apply_comicinfo(prepared.artifact_path, prepared.payload)
+            else:
+                apply_result = await asyncio.to_thread(
+                    apply_comicinfo,
+                    prepared.artifact_path,
+                    prepared.payload,
+                )
+                if inspect.isawaitable(apply_result):
+                    await apply_result
 
             await _mark_pending_file_complete_with_retry(
                 session_factory,
@@ -345,8 +352,11 @@ async def _mark_pending_file_complete_with_retry(
                 library_file = await session.get(LibraryFile, prepared.library_file_id)
                 if library_file is None:
                     raise ValueError(f"Library file {prepared.library_file_id} no longer exists")
-                if prepared.artifact_path.exists():
-                    artifact_stat = prepared.artifact_path.stat()
+                try:
+                    artifact_stat = await asyncio.to_thread(prepared.artifact_path.stat)
+                except FileNotFoundError:
+                    artifact_stat = None
+                if artifact_stat is not None:
                     library_file.file_size = artifact_stat.st_size
                     library_file.file_modified_at = datetime.fromtimestamp(
                         artifact_stat.st_mtime,

--- a/src/pullbox/services/import_file_execution.py
+++ b/src/pullbox/services/import_file_execution.py
@@ -1020,18 +1020,32 @@ async def process_import_series_files(
             # before removing potentially large conversion workspaces.
             await session.commit()
             placeholder_progress_live_only = False
-            await asyncio.to_thread(cleanup_prepared_file, prepared)
-            if report_file_progress is not None:
-                await report_file_progress(
-                    imp_file=imp_file,
-                    file_index=file_index,
-                    total_files=total_importable_files,
-                    stage="finalizing",
-                    current=3,
-                    total=4,
-                    unit="steps",
-                    live_only=True,
+            try:
+                await asyncio.to_thread(cleanup_prepared_file, prepared)
+            except Exception:
+                logger.exception(
+                    "import_file_post_commit_workspace_cleanup_failed",
+                    file_path=imp_file_path,
+                    destination_path=library_file.file_path,
                 )
+            if report_file_progress is not None:
+                try:
+                    await report_file_progress(
+                        imp_file=imp_file,
+                        file_index=file_index,
+                        total_files=total_importable_files,
+                        stage="finalizing",
+                        current=3,
+                        total=4,
+                        unit="steps",
+                        live_only=True,
+                    )
+                except Exception:
+                    logger.exception(
+                        "import_file_post_commit_progress_failed",
+                        file_path=imp_file_path,
+                        progress_current=3,
+                    )
             owned_issue_ids.add(resolved_issue.id)
             files_imported += 1
             if report_file_progress is not None:
@@ -1039,15 +1053,22 @@ async def process_import_series_files(
                 # import-row/library-file transaction commits. Persisting this
                 # event through the dedicated progress session while the main
                 # session still holds uncommitted writes can deadlock SQLite.
-                await report_file_progress(
-                    imp_file=imp_file,
-                    file_index=file_index,
-                    total_files=total_importable_files,
-                    stage="finalizing",
-                    current=4,
-                    total=4,
-                    unit="steps",
-                )
+                try:
+                    await report_file_progress(
+                        imp_file=imp_file,
+                        file_index=file_index,
+                        total_files=total_importable_files,
+                        stage="finalizing",
+                        current=4,
+                        total=4,
+                        unit="steps",
+                    )
+                except Exception:
+                    logger.exception(
+                        "import_file_post_commit_progress_failed",
+                        file_path=imp_file_path,
+                        progress_current=4,
+                    )
 
         except (JobPausedError, JobCancelledError):
             if prepared is not None:

--- a/src/pullbox/services/import_file_execution.py
+++ b/src/pullbox/services/import_file_execution.py
@@ -910,7 +910,8 @@ async def process_import_series_files(
                     live_only=True,
                 )
             if prepared.converted and transfer_method == "move":
-                original_trash_path = move_to_trash(
+                original_trash_path = await asyncio.to_thread(
+                    move_to_trash,
                     prepared.original_source,
                     trash_dir,
                     relative_path=Path("imports") / prepared.original_source.name,
@@ -1015,7 +1016,11 @@ async def process_import_series_files(
                 library_file_id=library_file.id,
                 issue_id=resolved_issue.id,
             )
-            cleanup_prepared_file(prepared)
+            # Make the imported file durable and release SQLite's writer slot
+            # before removing potentially large conversion workspaces.
+            await session.commit()
+            placeholder_progress_live_only = False
+            await asyncio.to_thread(cleanup_prepared_file, prepared)
             if report_file_progress is not None:
                 await report_file_progress(
                     imp_file=imp_file,
@@ -1027,8 +1032,6 @@ async def process_import_series_files(
                     unit="steps",
                     live_only=True,
                 )
-            await session.commit()
-            placeholder_progress_live_only = False
             owned_issue_ids.add(resolved_issue.id)
             files_imported += 1
             if report_file_progress is not None:
@@ -1048,15 +1051,16 @@ async def process_import_series_files(
 
         except (JobPausedError, JobCancelledError):
             if prepared is not None:
-                cleanup_prepared_file(prepared)
+                await asyncio.to_thread(cleanup_prepared_file, prepared)
             raise
         except Exception as exc:
             if prepared is not None:
-                cleanup_prepared_file(prepared)
+                await asyncio.to_thread(cleanup_prepared_file, prepared)
             await session.rollback()
             placeholder_progress_live_only = False
             try:
-                _cleanup_failed_library_artifact(
+                await asyncio.to_thread(
+                    _cleanup_failed_library_artifact,
                     destination_path=placed_destination_path,
                     original_source=prepared.original_source if prepared is not None else None,
                     original_trash_path=original_trash_path,

--- a/src/pullbox/services/import_file_preparation.py
+++ b/src/pullbox/services/import_file_preparation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import tempfile
 from collections.abc import Awaitable, Callable
@@ -87,7 +88,7 @@ async def prepare_import_file(
             **converter_kwargs,
         )
     except Exception:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)
         raise
 
     return PreparedImportFile(
@@ -212,7 +213,8 @@ async def rewrite_import_file_comicinfo(
     """Repair an imported archive's ComicInfo.xml, normalizing to CBZ when needed."""
     source_path = Path(imp_file.file_path)
     if source_path.suffix.lower() == ".cbz":
-        embedder(
+        await asyncio.to_thread(
+            embedder,
             source_path,
             comicinfo_payload,
             progress_callback=progress_callback,
@@ -227,13 +229,14 @@ async def rewrite_import_file_comicinfo(
             temp_dir,
             progress_callback=progress_callback,
         )
-        embedder(
+        await asyncio.to_thread(
+            embedder,
             converted_path,
             comicinfo_payload,
             progress_callback=progress_callback,
         )
         repaired_target = repaired_cbz_output_path(source_path)
-        shutil.move(str(converted_path), str(repaired_target))
+        await asyncio.to_thread(shutil.move, str(converted_path), str(repaired_target))
         return repaired_target, "normalized_to_cbz", str(source_path)
     finally:
-        shutil.rmtree(temp_dir, ignore_errors=True)
+        await asyncio.to_thread(shutil.rmtree, temp_dir, ignore_errors=True)

--- a/src/pullbox/services/import_service_file_operations.py
+++ b/src/pullbox/services/import_service_file_operations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -281,7 +282,7 @@ class ImportServiceFileOperationsMixin:
         page_count = None
         if source_path is not None:
             page_count_started_at = time.monotonic()
-            page_count = inspect_archive_page_count(source_path)
+            page_count = await asyncio.to_thread(inspect_archive_page_count, source_path)
             if timing is not None:
                 timing.update(
                     {

--- a/src/pullbox/tasks/__init__.py
+++ b/src/pullbox/tasks/__init__.py
@@ -8,6 +8,7 @@ from pullbox.tasks import backup_task as backup_task
 from pullbox.tasks import blocklist_task as blocklist_task
 from pullbox.tasks import cover_backfill_task as cover_backfill_task
 from pullbox.tasks import dashboard_task as dashboard_task
+from pullbox.tasks import database_maintenance_task as database_maintenance_task
 from pullbox.tasks import download_monitor_apply as download_monitor_apply
 from pullbox.tasks import download_monitor_poll as download_monitor_poll
 from pullbox.tasks import download_monitor_read as download_monitor_read

--- a/src/pullbox/tasks/database_maintenance_task.py
+++ b/src/pullbox/tasks/database_maintenance_task.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import structlog
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 
 from pullbox.config import get_settings
 from pullbox.core.scheduler import TaskExecutionResult, scheduled_task
@@ -17,12 +19,13 @@ logger = structlog.get_logger(__name__)
 
 def _sqlite_database_path(db_url: str) -> Path | None:
     """Return the file path for a file-backed SQLite URL."""
-    if not db_url.startswith(("sqlite:///", "sqlite+aiosqlite:///")):
+    try:
+        url = make_url(db_url)
+    except ArgumentError:
         return None
-    raw_path = db_url.split(":///", 1)[1]
-    if not raw_path or raw_path == ":memory:":
+    if url.get_backend_name() != "sqlite" or not url.database or url.database == ":memory:":
         return None
-    return Path(raw_path)
+    return Path(url.database)
 
 
 @scheduled_task(

--- a/src/pullbox/tasks/database_maintenance_task.py
+++ b/src/pullbox/tasks/database_maintenance_task.py
@@ -1,0 +1,48 @@
+"""Nightly SQLite index and query-planner maintenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import structlog
+
+from pullbox.config import get_settings
+from pullbox.core.scheduler import TaskExecutionResult, scheduled_task
+from pullbox.services.database_optimization_service import (
+    DatabaseOptimizationRuntimeService,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def _sqlite_database_path(db_url: str) -> Path | None:
+    """Return the file path for a file-backed SQLite URL."""
+    if not db_url.startswith(("sqlite:///", "sqlite+aiosqlite:///")):
+        return None
+    raw_path = db_url.split(":///", 1)[1]
+    if not raw_path or raw_path == ":memory:":
+        return None
+    return Path(raw_path)
+
+
+@scheduled_task(
+    task_id="maintain_database",
+    trigger="cron",
+    display_name="Database Maintenance",
+    hour=4,
+    minute=30,
+    exclusive=True,
+)
+async def maintain_database() -> TaskExecutionResult:
+    """Rebuild SQLite indexes and refresh query-planner statistics nightly."""
+    db_path = _sqlite_database_path(get_settings().db_url)
+    if db_path is None:
+        logger.debug("nightly_database_maintenance_skipped", reason="not_file_backed_sqlite")
+        return TaskExecutionResult(status="completed")
+
+    result = await DatabaseOptimizationRuntimeService(db_path).maintain()
+    logger.info(
+        "nightly_database_maintenance_completed",
+        integrity_result=result.integrity_result,
+    )
+    return TaskExecutionResult(status="completed")

--- a/src/pullbox/ui/templates/base.html
+++ b/src/pullbox/ui/templates/base.html
@@ -19,8 +19,129 @@
       document.documentElement.classList.add('boot-no-transitions');
 
       var alpineReady = false;
+      var appStylesReady = false;
       var revealScheduled = false;
       var bootTransitionsReleased = false;
+      var stylesheetRetryCount = 0;
+      var stylesheetRetryLimit = 2;
+      var stylesheetLoadTimeoutMs = 4000;
+      var stylesheetReloadKey = 'pullbox-stylesheet-reload-attempted';
+
+      function armStylesheetTimeout(link) {
+        window.setTimeout(function() {
+          if (!appStylesReady && link && link.isConnected) {
+            retryStylesheet(link);
+          }
+        }, stylesheetLoadTimeoutMs);
+      }
+
+      function clearStylesheetReloadGuard() {
+        try {
+          sessionStorage.removeItem(stylesheetReloadKey);
+        } catch (_error) {}
+      }
+
+      function reloadForStylesheetRecovery() {
+        try {
+          if (sessionStorage.getItem(stylesheetReloadKey) !== 'true') {
+            sessionStorage.setItem(stylesheetReloadKey, 'true');
+            window.location.reload();
+            return true;
+          }
+        } catch (_error) {}
+        return false;
+      }
+
+      function showStylesheetRecovery() {
+        if (!document.body) {
+          window.addEventListener('DOMContentLoaded', showStylesheetRecovery, { once: true });
+          return;
+        }
+
+        document.body.removeAttribute('data-shell-pending');
+        document.body.replaceChildren();
+        document.body.style.cssText = 'min-height:100vh;margin:0;display:grid;place-items:center;background:#101824;color:#f7f1e8;font-family:sans-serif;padding:24px;';
+
+        var panel = document.createElement('main');
+        panel.style.cssText = 'width:min(100%,480px);border:1px solid #cbd5e133;border-radius:16px;background:#172231;padding:28px;box-shadow:0 18px 40px #070b1238;';
+
+        var heading = document.createElement('h1');
+        heading.textContent = 'Pullbox could not load its interface';
+        heading.style.cssText = 'margin:0;font-size:22px;line-height:1.25;';
+
+        var message = document.createElement('p');
+        message.textContent = 'The application is running, but its stylesheet did not load. Check the connection and try again.';
+        message.style.cssText = 'margin:12px 0 20px;color:#cbd5e1;font-size:15px;line-height:1.6;';
+
+        var retryButton = document.createElement('button');
+        retryButton.type = 'button';
+        retryButton.textContent = 'Retry loading Pullbox';
+        retryButton.style.cssText = 'cursor:pointer;border:0;border-radius:8px;background:#8fb9ee;color:#101824;padding:11px 16px;font:700 14px sans-serif;';
+        retryButton.addEventListener('click', function() {
+          clearStylesheetReloadGuard();
+          window.location.reload();
+        });
+
+        panel.append(heading, message, retryButton);
+        document.body.append(panel);
+      }
+
+      function retryStylesheet(link) {
+        if (!link || appStylesReady) {
+          return;
+        }
+
+        if (stylesheetRetryCount < stylesheetRetryLimit) {
+          stylesheetRetryCount += 1;
+          var retryNumber = stylesheetRetryCount;
+          window.setTimeout(function() {
+            if (!link.isConnected) {
+              return;
+            }
+
+            var retryLink = link.cloneNode(false);
+            var retryUrl = new URL(link.href, window.location.href);
+            retryUrl.searchParams.set('pullbox_retry', retryNumber + '-' + Date.now());
+            retryLink.href = retryUrl.toString();
+            retryLink.removeAttribute('onload');
+            retryLink.removeAttribute('onerror');
+            retryLink.addEventListener('load', function() {
+              verifyStylesheet(retryLink);
+            }, { once: true });
+            retryLink.addEventListener('error', function() {
+              retryStylesheet(retryLink);
+            }, { once: true });
+            link.replaceWith(retryLink);
+            armStylesheetTimeout(retryLink);
+          }, retryNumber * 200);
+          return;
+        }
+
+        if (!reloadForStylesheetRecovery()) {
+          showStylesheetRecovery();
+        }
+      }
+
+      function verifyStylesheet(link) {
+        requestAnimationFrame(function() {
+          var appSurface = window.getComputedStyle(document.documentElement)
+            .getPropertyValue('--pb-surface-app')
+            .trim();
+          if (!appSurface) {
+            retryStylesheet(link);
+            return;
+          }
+
+          appStylesReady = true;
+          clearStylesheetReloadGuard();
+          document.documentElement.setAttribute('data-pullbox-stylesheet-ready', 'true');
+          revealShell();
+        });
+      }
+
+      window.pullboxStylesheetLoaded = verifyStylesheet;
+      window.pullboxStylesheetFailed = retryStylesheet;
+      window.pullboxArmStylesheetTimeout = armStylesheetTimeout;
 
       function releaseBootTransitions() {
         if (bootTransitionsReleased) {
@@ -62,7 +183,7 @@
       }
 
       function revealShell() {
-        if (revealScheduled || !alpineReady) {
+        if (revealScheduled || !alpineReady || !appStylesReady) {
           return;
         }
 
@@ -98,7 +219,13 @@
   <link rel="preload" href="/static/fonts/syne-800.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/static/fonts/jetbrains-mono-600.ttf" as="font" type="font/ttf" crossorigin>
   <link rel="preload" href="/static/fonts/jetbrains-mono-700.ttf" as="font" type="font/ttf" crossorigin>
-  <link rel="stylesheet" href="/static/css/tailwind.css?v={{ app_shell_asset_version|default('') }}">
+  <link id="pullbox-app-stylesheet" rel="stylesheet"
+        href="/static/css/tailwind.css?v={{ app_shell_asset_version|default('') }}"
+        onload="window.pullboxStylesheetLoaded(this)"
+        onerror="window.pullboxStylesheetFailed(this)">
+  <script>
+    window.pullboxArmStylesheetTimeout(document.getElementById('pullbox-app-stylesheet'));
+  </script>
   <link rel="icon" href="/static/img/logo.svg?v={{ app_shell_asset_version|default('') }}" type="image/svg+xml">
 
   {#- Alpine.js cloak — hide elements until Alpine initializes -#}

--- a/src/pullbox/ui/templates/partials/settings_clients.html
+++ b/src/pullbox/ui/templates/partials/settings_clients.html
@@ -652,19 +652,36 @@
                   </div>
                   <p class="text-[11px] text-pb-text-dim mt-1">Absolute path where Pullbox sees completed AirDC++ downloads.</p>
                 </div>
-                <div>
-                  <label class="block text-xs font-medium text-pb-text-sec mb-1.5">Queue Priority</label>
-                  <select x-model="form.airdcpp_queue_priority" class="input-pb w-48">
-                    <option value="">AirDC++ default</option>
-                    <option value="-1">Default</option>
-                    <option value="0">Paused (forced)</option>
-                    <option value="1">Paused</option>
-                    <option value="2">Lowest</option>
-                    <option value="3">Low</option>
-                    <option value="4">Normal</option>
-                    <option value="5">High</option>
-                    <option value="6">Highest</option>
-                  </select>
+                <div class="grid grid-cols-2 gap-3">
+                  <div data-testid="settings-clients-airdcpp-client-priority">
+                    <label class="block text-xs font-medium text-pb-text-sec mb-1.5">Priority</label>
+                    <div class="flex items-center gap-2">
+                      <input type="number" x-model.number="form.priority" min="1" max="100"
+                             class="input-pb w-20">
+                      <span class="text-xs text-pb-text-dim">1 = highest, 100 = lowest</span>
+                    </div>
+                  </div>
+                  <div>
+                    <label class="block text-xs font-medium text-pb-text-sec mb-1.5">Queue Priority</label>
+                    {{ dropdown_select(
+                      name="airdcpp_queue_priority",
+                      value="",
+                      options=[
+                        ("", "AirDC++ default"),
+                        ("-1", "Default"),
+                        ("0", "Paused (forced)"),
+                        ("1", "Paused"),
+                        ("2", "Lowest"),
+                        ("3", "Low"),
+                        ("4", "Normal"),
+                        ("5", "High"),
+                        ("6", "Highest"),
+                      ],
+                      root_testid="settings-clients-airdcpp-queue-priority-select",
+                      class_name="w-48",
+                      local_model="form.airdcpp_queue_priority"
+                    ) }}
+                  </div>
                 </div>
               </section>
 

--- a/src/pullbox/ui/templates/partials/settings_direct.html
+++ b/src/pullbox/ui/templates/partials/settings_direct.html
@@ -207,10 +207,18 @@
             <div class="flex flex-wrap items-center gap-2">
               <p class="text-sm font-semibold text-pb-text">{{ host_names[host_kind] }}</p>
               <span class="pill {{ 'pill-success' if host.enabled else 'pill-muted' }}">{{ 'Enabled' if host.enabled else 'Disabled' }}</span>
+              {% if host_kind == 'generic_https' %}
+              <span
+                class="pill pill-info"
+                data-testid="settings-direct-host-validation-generic_https"
+                title="Each final-file URL is validated when Pullbox uses it"
+              >Validated per download</span>
+              {% else %}
               <span
                 class="pill {{ state_pills.get(reachability_state, 'pill-muted') }}"
                 title="{{ 'Last checked ' ~ (host.last_checked_at|localtime) if host.last_checked_at else 'Not checked yet' }}"
               >{{ reachability_state|replace('_', ' ')|title }}</span>
+              {% endif %}
               <span class="pill pill-muted">Preference {{ host.preference }}</span>
             </div>
             <p class="mt-2 text-xs leading-5 text-pb-text-sec">{{ host_descriptions[host_kind] }}</p>
@@ -237,8 +245,10 @@
                 </dd>
               </div>
               <div>
-                <dt class="text-pb-text-dim">Last reachable</dt>
-                <dd class="mt-0.5 text-pb-text-sec">{{ host.last_reachable_at|localtime if host.last_reachable_at else 'Never' }}</dd>
+                <dt class="text-pb-text-dim">{{ 'Validation' if host_kind == 'generic_https' else 'Last reachable' }}</dt>
+                <dd class="mt-0.5 text-pb-text-sec">
+                  {{ 'Per download' if host_kind == 'generic_https' else (host.last_reachable_at|localtime if host.last_reachable_at else 'Never') }}
+                </dd>
               </div>
               <div>
                 <dt class="text-pb-text-dim">Last operational use</dt>
@@ -316,6 +326,12 @@
               <p class="rounded-lg border border-pb-border bg-pb-bg/30 p-3 text-xs text-pb-text-sec">This host supports anonymous access only and stores no account credential.</p>
             </template>
 
+            <template x-if="activeHost.host_kind === 'generic_https'">
+              <div class="inline-alert inline-alert-info">
+                <p class="text-xs">Generic HTTPS has no single endpoint to test. Pullbox validates each final-file URL when it is used.</p>
+              </div>
+            </template>
+
             <template x-for="field in activeHost.allowed_credential_fields" :key="field">
               <div class="space-y-2">
                 <label class="block text-xs font-medium text-pb-text-sec" x-text="hostCredentialLabel(field)"></label>
@@ -351,6 +367,7 @@
               type="button"
               class="btn-ghost btn-sm gap-1.5"
               data-testid="settings-direct-host-modal-test"
+              x-show="activeHost.host_kind !== 'generic_https'"
               :disabled="hostSaving || hostTesting"
               @click="testHost()"
             >
@@ -858,7 +875,7 @@ function directProviderSettings(initialProviders, initialHosts) {
     },
 
     async testHost() {
-      if (this.hostSaving || this.hostTesting || !this.activeHost.host_kind) return;
+      if (this.hostSaving || this.hostTesting || !this.activeHost.host_kind || this.activeHost.host_kind === 'generic_https') return;
       this.hostTesting = true;
       this.hostError = '';
       this.hostTestMessage = '';

--- a/src/pullbox/ui/templates/partials/settings_indexers.html
+++ b/src/pullbox/ui/templates/partials/settings_indexers.html
@@ -370,6 +370,9 @@
                 <template x-if="item === 'direct'">
                   <div class="flex h-7 w-7 items-center justify-center rounded-md bg-pb-success-dim text-[10px] font-bold text-pb-success">DDL</div>
                 </template>
+                <template x-if="item === 'dc'">
+                  <div class="flex h-7 w-7 items-center justify-center rounded-md bg-pb-purple-dim text-[10px] font-bold text-pb-purple">ADC</div>
+                </template>
                 <div class="min-w-0">
                   <p class="text-sm font-medium text-pb-text" x-text="labels[item]"></p>
                 </div>

--- a/tests/e2e/test_sidebar_shell.py
+++ b/tests/e2e/test_sidebar_shell.py
@@ -17,6 +17,34 @@ pytestmark = pytest.mark.e2e
 class TestSidebarShell:
     """Behavior-first E2E checks for the persistent sidebar shell."""
 
+    def test_sidebar_shell_recovers_when_initial_stylesheet_request_fails(
+        self,
+        authed_page,
+        seeded_server: str,  # type: ignore[no-untyped-def]
+    ) -> None:
+        stylesheet_requests: list[str] = []
+
+        def fail_initial_stylesheet(route) -> None:  # type: ignore[no-untyped-def]
+            stylesheet_requests.append(route.request.url)
+            if len(stylesheet_requests) == 1:
+                route.abort()
+                return
+            route.continue_()
+
+        authed_page.route("**/static/css/tailwind.css*", fail_initial_stylesheet)
+
+        shell = AppShellPage(authed_page, seeded_server)
+        shell.goto("/series")
+        authed_page.wait_for_function(
+            "document.documentElement.hasAttribute('data-pullbox-stylesheet-ready')",
+            timeout=5000,
+        )
+
+        assert len(stylesheet_requests) == 2
+        assert "pullbox_retry=" in stylesheet_requests[1]
+        assert authed_page.locator("body").get_attribute("data-shell-pending") is None
+        assert shell.sidebar.evaluate("node => getComputedStyle(node).position") == "fixed"
+
     def test_sidebar_shell_renders_standardized_regions(
         self,
         authed_page,

--- a/tests/integration/test_health_service.py
+++ b/tests/integration/test_health_service.py
@@ -319,6 +319,68 @@ class TestRunAllChecksPersistence:
         assert history_count == 6
 
     @pytest.mark.asyncio
+    async def test_current_health_prunes_retired_subject_and_resolves_incident(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        await HealthService._persist_outcomes(
+            db_session,
+            [
+                CheckOutcome(
+                    component="download_clients",
+                    check_name="connectivity",
+                    status=HealthStatus.DEGRADED,
+                    message="One route needs attention",
+                ),
+                CheckOutcome(
+                    component="download_clients",
+                    check_name="artifact_host_summary",
+                    status=HealthStatus.UNHEALTHY,
+                    message="Artifact host unavailable",
+                    subject_key="artifact-host:generic_https",
+                    subject_label="Generic HTTPS",
+                ),
+            ],
+        )
+
+        await HealthService._persist_outcomes(
+            db_session,
+            [
+                CheckOutcome(
+                    component="download_clients",
+                    check_name="connectivity",
+                    status=HealthStatus.HEALTHY,
+                    message="All acquisition routes available",
+                )
+            ],
+        )
+
+        current_rows = list(
+            (
+                await db_session.execute(
+                    select(HealthCurrentStatusModel).where(
+                        HealthCurrentStatusModel.component == "download_clients"
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        incident = (
+            await db_session.execute(
+                select(HealthIncidentModel).where(
+                    HealthIncidentModel.component == "download_clients",
+                    HealthIncidentModel.subject_key == "artifact-host:generic_https",
+                )
+            )
+        ).scalar_one()
+
+        assert [(row.subject_key, row.current_key) for row in current_rows] == [
+            (None, "__summary__")
+        ]
+        assert incident.resolved_at is not None
+
+    @pytest.mark.asyncio
     async def test_comicvine_run_persists_grouped_summary_and_subchecks(
         self, db_session: AsyncSession
     ) -> None:

--- a/tests/ui/test_issue_detail_ui_routes.py
+++ b/tests/ui/test_issue_detail_ui_routes.py
@@ -17,6 +17,13 @@ pytest_plugins = ["conftest_security"]
 os.environ.setdefault("PULLBOX_SECRET_KEY", "test-secret-key-for-issue-detail-ui-tests")
 
 
+def _issue_detail_content_html(html: str) -> str:
+    """Return page-specific content without shared shell recovery scripts."""
+    start = html.index('data-testid="issue-detail-page"')
+    end = html.index('data-testid="page-footer-dock"', start)
+    return html[start:end]
+
+
 @pytest.fixture
 async def seeded_issue_detail_ui_data(sec_db) -> dict[str, int]:  # type: ignore[no-untyped-def]
     """Seed a small issue-detail dataset with both owned and wanted states."""
@@ -198,7 +205,7 @@ class TestIssueDetailRouteContracts:
         assert "page-dock-inner page-dock-inner-status-only" in response.text
         assert 'data-testid="page-dock-pagination"' not in response.text
         assert "transition:true" not in response.text
-        assert "window.location.reload()" not in response.text
+        assert "window.location.reload()" not in _issue_detail_content_html(response.text)
 
     async def test_issue_detail_renders_private_progress_and_targeted_state_actions(
         self,

--- a/tests/ui/test_series_detail_ui_routes.py
+++ b/tests/ui/test_series_detail_ui_routes.py
@@ -33,6 +33,13 @@ def _series_alternate_names_html(html: str) -> str:
     return html[start:end]
 
 
+def _series_detail_content_html(html: str) -> str:
+    """Return page-specific content without shared shell recovery scripts."""
+    start = html.index('data-testid="series-detail-page"')
+    end = html.index('data-testid="page-footer-dock"', start)
+    return html[start:end]
+
+
 class _SelectRecorder:
     """Capture SELECT statements emitted by the test app engine."""
 
@@ -281,7 +288,7 @@ class TestSeriesDetailRouteContracts:
         assert "page-dock-inner page-dock-inner-status-only" in response.text
         assert 'data-testid="page-dock-pagination"' not in response.text
         assert "transition:true" not in response.text
-        assert "window.location.reload()" not in response.text
+        assert "window.location.reload()" not in _series_detail_content_html(response.text)
         assert "window.__autoSearching" not in response.text
         assert "htmx.ajax('POST', '/htmx/series/" not in response.text
 

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -744,6 +744,9 @@ class TestSettingsRouteContracts:
         assert 'data-testid="settings-direct-host-generic_https"' in response.text
         assert 'data-testid="settings-direct-host-pixeldrain"' in response.text
         assert 'data-testid="settings-direct-host-mega"' not in response.text
+        assert 'data-testid="settings-direct-host-validation-generic_https"' in response.text
+        assert ">Validated per download</span>" in response.text
+        assert "x-show=\"activeHost.host_kind !== 'generic_https'\"" in response.text
 
     async def test_direct_download_settings_hide_hosts_for_disabled_named_host_provider(
         self,

--- a/tests/ui/test_settings_shell_ui_routes.py
+++ b/tests/ui/test_settings_shell_ui_routes.py
@@ -158,6 +158,9 @@ class TestSettingsRouteContracts:
         assert "body.airdcpp =" in enabled.text
         assert "minimum_search_interval_seconds" in enabled.text
         assert "actual transfer reachability is validated during a real download" in enabled.text
+        assert 'data-testid="settings-clients-airdcpp-client-priority"' in enabled.text
+        assert 'data-testid="settings-clients-airdcpp-queue-priority-select"' in enabled.text
+        assert '<select x-model="form.airdcpp_queue_priority"' not in enabled.text
         picker_start = enabled.text.index('data-testid="settings-clients-picker-airdcpp"')
         picker_end = enabled.text.index("</button>", picker_start)
         assert ":disabled=" not in enabled.text[picker_start:picker_end]
@@ -346,6 +349,8 @@ class TestSettingsRouteContracts:
         assert "dc: 'Direct Connect'" in response.text
         assert "Coming soon" not in response.text
         assert "item === 'direct'" in response.text
+        assert "item === 'dc'" in response.text
+        assert ">ADC</div>" in response.text
         assert "const supported = ['usenet', 'torrent', 'direct', 'dc'];" in response.text
         assert "JSON.stringify(this.order)" in response.text
 

--- a/tests/ui/test_sidebar_shell_ui_routes.py
+++ b/tests/ui/test_sidebar_shell_ui_routes.py
@@ -53,6 +53,16 @@ class TestSidebarShellRouteContracts:
         assert "body[data-shell-pending] { visibility: hidden; }" in response.text
         assert "alpine:initialized" in response.text
         assert "document.documentElement.classList.add('boot-no-transitions')" in response.text
+        assert 'id="pullbox-app-stylesheet"' in response.text
+        assert 'onload="window.pullboxStylesheetLoaded(this)"' in response.text
+        assert 'onerror="window.pullboxStylesheetFailed(this)"' in response.text
+        assert "var appStylesReady = false" in response.text
+        assert "var stylesheetRetryLimit = 2" in response.text
+        assert "var stylesheetLoadTimeoutMs = 4000" in response.text
+        assert "window.pullboxArmStylesheetTimeout" in response.text
+        assert "--pb-surface-app" in response.text
+        assert "data-pullbox-stylesheet-ready" in response.text
+        assert "!appStylesReady" in response.text
         assert "document.fonts.ready" in response.text
         assert "window.Alpine.nextTick" in response.text
         assert "armBootTransitionRelease" in response.text

--- a/tests/unit/test_database_maintenance_task.py
+++ b/tests/unit/test_database_maintenance_task.py
@@ -25,6 +25,27 @@ def test_database_maintenance_task_is_nightly_and_exclusive() -> None:
     assert task.exclusive is True
 
 
+def test_sqlite_database_path_ignores_url_query_parameters(tmp_path: Path) -> None:
+    db_path = tmp_path / "pullbox.db"
+
+    resolved = database_maintenance_task._sqlite_database_path(
+        f"sqlite+aiosqlite:///{db_path}?timeout=30&mode=rwc"
+    )
+
+    assert resolved == db_path
+
+
+@pytest.mark.parametrize(
+    "db_url",
+    [
+        "sqlite:///:memory:?cache=shared",
+        "sqlite+aiosqlite:///:memory:?cache=shared",
+    ],
+)
+def test_sqlite_database_path_skips_parameterized_memory_urls(db_url: str) -> None:
+    assert database_maintenance_task._sqlite_database_path(db_url) is None
+
+
 @pytest.mark.asyncio
 async def test_database_maintenance_task_runs_for_sqlite(
     tmp_path: Path,

--- a/tests/unit/test_database_maintenance_task.py
+++ b/tests/unit/test_database_maintenance_task.py
@@ -1,0 +1,73 @@
+"""Tests for scheduled SQLite database maintenance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pullbox.core.scheduler import TaskExecutionResult
+from pullbox.core.scheduler_registry import task_registry
+from pullbox.tasks import database_maintenance_task
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_database_maintenance_task_is_nightly_and_exclusive() -> None:
+    task = next(task for task in task_registry if task.task_id == "maintain_database")
+
+    assert task.display_name == "Database Maintenance"
+    assert task.trigger == "cron"
+    assert task.trigger_kwargs == {"hour": 4, "minute": 30}
+    assert task.exclusive is True
+
+
+@pytest.mark.asyncio
+async def test_database_maintenance_task_runs_for_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "pullbox.db"
+    db_path.touch()
+    calls: list[Path] = []
+
+    @dataclass(frozen=True)
+    class Result:
+        integrity_result: str = "ok"
+
+    class Runtime:
+        def __init__(self, path: Path) -> None:
+            calls.append(path)
+
+        async def maintain(self) -> Result:
+            return Result()
+
+    monkeypatch.setattr(
+        database_maintenance_task,
+        "get_settings",
+        lambda: SimpleNamespace(db_url=f"sqlite+aiosqlite:///{db_path}"),
+    )
+    monkeypatch.setattr(database_maintenance_task, "DatabaseOptimizationRuntimeService", Runtime)
+
+    result = await database_maintenance_task.maintain_database()
+
+    assert result == TaskExecutionResult(status="completed")
+    assert calls == [db_path]
+
+
+@pytest.mark.asyncio
+async def test_database_maintenance_task_skips_non_sqlite_database(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        database_maintenance_task,
+        "get_settings",
+        lambda: SimpleNamespace(db_url="postgresql+asyncpg://pullbox@example/pullbox"),
+    )
+
+    result = await database_maintenance_task.maintain_database()
+
+    assert result == TaskExecutionResult(status="completed")

--- a/tests/unit/test_database_optimization_service.py
+++ b/tests/unit/test_database_optimization_service.py
@@ -95,6 +95,7 @@ def test_maintain_reindexes_then_optimizes_and_verifies(tmp_path: Path) -> None:
     assert statements == [
         "PRAGMA wal_checkpoint(TRUNCATE)",
         "REINDEX",
+        "ANALYZE",
         "PRAGMA optimize=0x10002",
         "PRAGMA wal_checkpoint(TRUNCATE)",
         "PRAGMA quick_check",

--- a/tests/unit/test_database_optimization_service.py
+++ b/tests/unit/test_database_optimization_service.py
@@ -60,6 +60,71 @@ def test_optimize_checkpoints_and_vacuums_free_pages(tmp_path: Path) -> None:
     assert result.after.integrity_result == "ok"
 
 
+def test_maintain_reindexes_then_optimizes_and_verifies(tmp_path: Path) -> None:
+    db_path = tmp_path / "pullbox.db"
+    _create_fragmented_database(db_path)
+    statements: list[str] = []
+
+    class RecordingCursor:
+        def __init__(self, row: tuple[object, ...] | None = None) -> None:
+            self._row = row
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._row
+
+    class RecordingConnection:
+        def __enter__(self) -> RecordingConnection:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def execute(self, statement: str) -> RecordingCursor:
+            statements.append(statement)
+            if statement == "PRAGMA wal_checkpoint(TRUNCATE)":
+                return RecordingCursor((0, 0, 0))
+            if statement == "PRAGMA quick_check":
+                return RecordingCursor(("ok",))
+            return RecordingCursor()
+
+    service = DatabaseOptimizationService(db_path)
+    service._connect = lambda *, read_only: RecordingConnection()  # type: ignore[method-assign]
+
+    result = service.maintain()
+
+    assert statements == [
+        "PRAGMA wal_checkpoint(TRUNCATE)",
+        "REINDEX",
+        "PRAGMA optimize=0x10002",
+        "PRAGMA wal_checkpoint(TRUNCATE)",
+        "PRAGMA quick_check",
+    ]
+    assert result.integrity_result == "ok"
+
+
+def test_maintain_refreshes_planner_statistics_on_real_database(tmp_path: Path) -> None:
+    db_path = tmp_path / "pullbox.db"
+    connection = sqlite3.connect(db_path)
+    connection.execute("CREATE TABLE issues (id INTEGER PRIMARY KEY, series_id INTEGER NOT NULL)")
+    connection.execute("CREATE INDEX ix_issues_series_id ON issues (series_id)")
+    connection.executemany(
+        "INSERT INTO issues (series_id) VALUES (?)",
+        [(series_id % 7,) for series_id in range(200)],
+    )
+    connection.commit()
+    connection.close()
+
+    result = DatabaseOptimizationService(db_path).maintain()
+
+    connection = sqlite3.connect(db_path)
+    statistics = connection.execute(
+        "SELECT stat FROM sqlite_stat1 WHERE idx = 'ix_issues_series_id'"
+    ).fetchone()
+    connection.close()
+    assert result.integrity_result == "ok"
+    assert statistics is not None
+
+
 @pytest.mark.asyncio
 async def test_runtime_uses_maintenance_window_and_thread_offload(
     tmp_path: Path,
@@ -96,3 +161,41 @@ async def test_runtime_uses_maintenance_window_and_thread_offload(
     assert reasons == ["database_optimize"]
     assert thread_call["func"] == runtime.service.optimize
     assert result.reclaimed_bytes > 0
+
+
+@pytest.mark.asyncio
+async def test_nightly_runtime_uses_maintenance_window_and_thread_offload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db_path = tmp_path / "pullbox.db"
+    _create_fragmented_database(db_path)
+    runtime = DatabaseOptimizationRuntimeService(db_path)
+    reasons: list[str] = []
+    thread_call: dict[str, object] = {}
+
+    @asynccontextmanager
+    async def fake_window(*, reason: str):  # type: ignore[no-untyped-def]
+        reasons.append(reason)
+        yield
+
+    async def fake_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        thread_call["func"] = func
+        thread_call["args"] = args
+        thread_call["kwargs"] = kwargs
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "pullbox.services.database_optimization_service.database_maintenance_window",
+        fake_window,
+    )
+    monkeypatch.setattr(
+        "pullbox.services.database_optimization_service.asyncio.to_thread",
+        fake_to_thread,
+    )
+
+    result = await runtime.maintain()
+
+    assert reasons == ["nightly_database_maintenance"]
+    assert thread_call["func"] == runtime.service.maintain
+    assert result.integrity_result == "ok"

--- a/tests/unit/test_direct_host_reachability.py
+++ b/tests/unit/test_direct_host_reachability.py
@@ -164,6 +164,41 @@ async def test_generic_https_explains_that_reachability_is_verified_per_url(
 
 
 @pytest.mark.asyncio
+async def test_generic_https_failure_records_operation_without_global_outage(
+    session: AsyncSession,
+) -> None:
+    config = DirectHostConfig(
+        host_kind=DirectArtifactHostKind.GENERIC_HTTPS,
+        enabled=True,
+        reachability_state=DirectHostReachabilityState.NOT_CHECKED,
+    )
+    session.add(config)
+    await session.commit()
+    error = ArtifactHostResolutionError(
+        code="artifact_host_unavailable",
+        message="This final-file URL is unavailable.",
+        failure_class=DirectArtifactFailureClass.TRANSIENT_HOST,
+        retryable=True,
+        intervention=False,
+    )
+
+    await record_direct_host_operational_result(
+        session,
+        host_config_id=config.id,
+        occurred_at=NOW,
+        succeeded=False,
+        error=error,
+    )
+    await session.flush()
+
+    assert config.last_operational_result is DirectHostOperationalResult.FAILED
+    assert config.last_operational_at == NOW
+    assert config.last_error_code == "artifact_host_unavailable"
+    assert config.reachability_state is DirectHostReachabilityState.NOT_CHECKED
+    assert config.last_reachable_at is None
+
+
+@pytest.mark.asyncio
 async def test_real_operations_are_recorded_for_anonymous_hosts(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/test_health_checks.py
+++ b/tests/unit/test_health_checks.py
@@ -1001,6 +1001,41 @@ class TestDownloadClientsCheck:
         }
 
     @pytest.mark.asyncio
+    async def test_generic_https_transport_does_not_degrade_direct_acquisition_health(
+        self,
+        db_session: AsyncSession,
+        settings: MagicMock,
+    ) -> None:
+        generic_host = DirectHostConfig(
+            host_kind=DirectArtifactHostKind.GENERIC_HTTPS,
+            enabled=True,
+            reachability_state=DirectHostReachabilityState.UNAVAILABLE,
+        )
+        db_session.add_all(
+            [
+                DirectProviderConfig(
+                    provider_id="pullbox.getcomics",
+                    display_name="GetComics",
+                    endpoint="http://getcomics:8780",
+                    enabled=True,
+                    state=DirectProviderState.HEALTHY,
+                ),
+                generic_host,
+            ]
+        )
+        await db_session.flush()
+
+        outcomes = await _make_service(settings, registry=ProviderRegistry()).run_check(
+            db_session,
+            "download_clients",
+        )
+
+        assert outcomes[0].status is HealthStatus.HEALTHY
+        assert outcomes[0].message == "All acquisition routes available"
+        assert {outcome.subject_key for outcome in outcomes[1:]} == {"direct-provider:1"}
+        assert generic_host.reachability_state is DirectHostReachabilityState.NOT_CHECKED
+
+    @pytest.mark.asyncio
     async def test_unreachable_artifact_host_degrades_direct_acquisition_health(
         self,
         db_session: AsyncSession,

--- a/tests/unit/test_import_comicinfo_enrichment.py
+++ b/tests/unit/test_import_comicinfo_enrichment.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import threading
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -144,8 +145,11 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         }
 
     applied: list[tuple[Path, dict[str, Any]]] = []
+    event_loop_thread_id = threading.get_ident()
+    apply_thread_ids: list[int] = []
 
     def apply_comicinfo(artifact_path: Path, payload: dict[str, Any]) -> None:
+        apply_thread_ids.append(threading.get_ident())
         assert payload_session is not None
         assert not payload_session.in_transaction()
         applied.append((artifact_path, dict(payload)))
@@ -202,6 +206,7 @@ async def test_run_import_comicinfo_enrichment_rewrites_pending_library_file(
         )
     ]
     assert "import_file_comicinfo_enrichment_completed" in log_events
+    assert apply_thread_ids != [event_loop_thread_id]
     assert lock_injected is True
     assert build_calls == 2
     async with session_factory() as session:

--- a/tests/unit/test_import_file_execution.py
+++ b/tests/unit/test_import_file_execution.py
@@ -1935,7 +1935,7 @@ class TestImportExecutionAutoflushDiscipline:
             ("finalizing", 0, 4, "steps", True, 0),
             ("finalizing", 1, 4, "steps", True, 0),
             ("finalizing", 2, 4, "steps", True, 0),
-            ("finalizing", 3, 4, "steps", True, 0),
+            ("finalizing", 3, 4, "steps", True, 1),
             ("finalizing", 4, 4, "steps", False, 1),
         ]
 

--- a/tests/unit/test_import_file_execution.py
+++ b/tests/unit/test_import_file_execution.py
@@ -1939,6 +1939,99 @@ class TestImportExecutionAutoflushDiscipline:
             ("finalizing", 4, 4, "steps", False, 1),
         ]
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure_stage", ["workspace_cleanup", "terminal_progress"])
+    async def test_post_commit_housekeeping_failure_keeps_imported_artifact(
+        self,
+        db_session: AsyncSession,
+        failure_stage: str,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from pullbox.models.library import FileFormat
+        from pullbox.services.import_file_execution import process_import_series_files
+
+        job, imp_series, imp_files, _series, _issues = await _setup_full_scenario(
+            db_session,
+            num_issues=1,
+        )
+
+        async def _register_file(
+            session: AsyncSession,
+            source_path: Path,
+            issue_arg: Issue,
+            confidence: MatchConfidence,
+            **_kwargs: object,
+        ) -> LibraryFile:
+            library_file = LibraryFile(
+                file_path=str(source_path),
+                file_name=Path(source_path).name,
+                file_size=1024,
+                file_format=FileFormat.CBZ,
+                file_modified_at=datetime.now(tz=UTC),
+                match_confidence=confidence,
+                issue_id=issue_arg.id,
+                library_root_id=1,
+            )
+            session.add(library_file)
+            await session.flush()
+            return library_file
+
+        def _cleanup_prepared_file(_prepared: object) -> None:
+            if failure_stage == "workspace_cleanup":
+                raise OSError("workspace cleanup failed")
+
+        async def _report_file_progress(
+            *,
+            imp_file: ImportedFile,
+            file_index: int,
+            total_files: int,
+            stage: str,
+            current: int,
+            total: int,
+            unit: str,
+            live_only: bool = False,
+        ) -> None:
+            _ = imp_file, file_index, total_files, total, unit
+            if failure_stage == "terminal_progress" and stage == "finalizing" and not live_only:
+                raise RuntimeError("terminal progress failed")
+
+        with patch(
+            "pullbox.services.import_file_execution._cleanup_failed_library_artifact"
+        ) as failed_artifact_cleanup:
+            files_imported, files_failed = await process_import_series_files(
+                db_session,
+                job,
+                imp_series,
+                load_media_settings=AsyncMock(return_value={"skip_existing_files": "false"}),
+                load_trash_dir=AsyncMock(return_value=Path("/tmp/pullbox-trash")),
+                load_ingest_policy=AsyncMock(return_value=object()),
+                load_permission_policy=AsyncMock(return_value=object()),
+                raise_if_cancelled=AsyncMock(),
+                prepare_file=AsyncMock(
+                    return_value=SimpleNamespace(
+                        registration_source=imp_files[0].file_path,
+                        original_source=Path(imp_files[0].file_path),
+                        converted=False,
+                    )
+                ),
+                build_comicinfo_payload=AsyncMock(return_value=None),
+                apply_comicinfo=lambda *_args, **_kwargs: None,
+                cleanup_prepared_file=_cleanup_prepared_file,
+                record_action=AsyncMock(),
+                log_event=AsyncMock(),
+                register_file=_register_file,
+                move_to_trash=lambda *args, **kwargs: Path("/tmp/trash.cbz"),
+                report_file_progress=_report_file_progress,
+            )
+
+        await db_session.refresh(imp_files[0])
+        assert files_imported == 1
+        assert files_failed == 0
+        assert imp_files[0].status == ImportedFileStatus.IMPORTED
+        assert imp_files[0].library_file_id is not None
+        failed_artifact_cleanup.assert_not_called()
+
 
 class TestOneFileFailsOthersContinue:
     """One file fails but others in the series still get processed."""

--- a/tests/unit/test_library_comicinfo.py
+++ b/tests/unit/test_library_comicinfo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
@@ -138,12 +139,14 @@ async def test_prepare_source_artifact_cleans_temp_dir_when_converter_fails(
     assert not temp_dir.exists()
 
 
-def test_apply_comicinfo_requires_cbz_artifact(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_apply_comicinfo_requires_cbz_artifact(tmp_path: Path) -> None:
     with pytest.raises(ConfigurationError, match="requires a CBZ artifact"):
-        apply_comicinfo_to_imported_artifact(tmp_path / "issue.cbr", {})
+        await apply_comicinfo_to_imported_artifact(tmp_path / "issue.cbr", {})
 
 
-def test_apply_comicinfo_delegates_to_embedder(
+@pytest.mark.asyncio
+async def test_apply_comicinfo_delegates_to_embedder_without_blocking_event_loop(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -151,6 +154,8 @@ def test_apply_comicinfo_delegates_to_embedder(
     artifact.write_bytes(b"cbz")
     progress_calls: list[tuple[str, int, int, str]] = []
     embed_calls: list[tuple[Path, dict[str, Any]]] = []
+    event_loop_thread_id = threading.get_ident()
+    embed_thread_ids: list[int] = []
 
     def fake_embed(
         artifact_path: Path,
@@ -158,19 +163,21 @@ def test_apply_comicinfo_delegates_to_embedder(
         *,
         progress_callback: Any = None,
     ) -> None:
+        embed_thread_ids.append(threading.get_ident())
         embed_calls.append((artifact_path, comicinfo_payload))
         assert progress_callback is not None
         progress_callback("comicinfo", 1, 1, "done")
 
     monkeypatch.setattr(library_comicinfo, "embed_comicinfo_in_cbz", fake_embed)
 
-    apply_comicinfo_to_imported_artifact(
+    await apply_comicinfo_to_imported_artifact(
         artifact,
         {"Series": "King Dracula"},
         progress_callback=lambda *args: progress_calls.append(args),
     )
 
     assert embed_calls == [(artifact, {"Series": "King Dracula"})]
+    assert embed_thread_ids != [event_loop_thread_id]
     assert progress_calls == [("comicinfo", 1, 1, "done")]
 
 
@@ -220,7 +227,14 @@ async def test_build_comicinfo_payload_for_issue_uses_series_issue_and_page_meta
     await db_session.flush()
     source_path = tmp_path / "King Dracula 004.cbz"
     source_path.write_bytes(b"cbz")
-    monkeypatch.setattr(library_comicinfo, "inspect_archive_page_count", lambda _path: 31)
+    event_loop_thread_id = threading.get_ident()
+    inspection_thread_ids: list[int] = []
+
+    def inspect_page_count(_path: Path) -> int:
+        inspection_thread_ids.append(threading.get_ident())
+        return 31
+
+    monkeypatch.setattr(library_comicinfo, "inspect_archive_page_count", inspect_page_count)
 
     payload = await build_comicinfo_payload_for_issue(
         db_session,
@@ -241,6 +255,7 @@ async def test_build_comicinfo_payload_for_issue_uses_series_issue_and_page_meta
     assert payload["Volume"] == 2025
     assert payload["Web"] == "https://comicvine.gamespot.com/king-dracula-4/4000-1122334/"
     assert payload["Notes"] == "[cv_vol_id:165993] [cv_issue_id:1122334]"
+    assert inspection_thread_ids != [event_loop_thread_id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- align AirDC++ queue/client priority controls with the shared settings contract
- recover the application shell when a cached stylesheet fails to load
- keep CPU-heavy import and ComicInfo work off the request event loop
- treat generic HTTPS transport health per download instead of degrading the client registry
- add nightly SQLite optimize/reindex maintenance with focused scheduling and service coverage

## Verification

- `252 passed` across the touched service, task, health, import, and UI-route suites
- `15 passed` for the sidebar shell E2E suite in Chromium
- `15 passed` for the sidebar shell E2E suite in Firefox
- Ruff check and format checks passed for all touched Python files
- `git diff --check origin/develop...HEAD`
