### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Kept transient AirDC++ queue lookup failures from consuming the bounded queue
   mutation retry budget or prematurely failing an active remote download.
+- Prevented AirDC++ reconciliation from racing an initial queue mutation or
+  resurrecting a download cancelled while recovery was in flight.
 
 ## [1.2.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-28
+
+Patch release hardening AirDC++ acquisition recovery so retries, cancellation,
+and merged queue bundles remain race-safe.
+
 ### Fixed
 
 - Kept transient AirDC++ queue lookup failures from consuming the bounded queue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Kept transient AirDC++ queue lookup failures from consuming the bounded queue
   mutation retry budget or prematurely failing an active remote download.
-- Prevented AirDC++ reconciliation from racing an initial queue mutation or
-  resurrecting a download cancelled while recovery was in flight.
+- Prevented AirDC++ acquisition and reconciliation from racing cancellation,
+  including pre-bundle requests and remote mutations already in flight.
 - Claimed missing AirDC++ bundle retries atomically so overlapping requests
   cannot create duplicate remote bundles.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevented AirDC++ acquisition and reconciliation from racing cancellation,
   including pre-bundle requests and remote mutations already in flight.
 - Claimed missing AirDC++ bundle retries atomically, bound completion to the
-  exact claim, and preserved remote bundles merged with existing queue work.
+  exact claim, preserved remote bundles merged with existing queue work, and
+  prevented duplicate intents from taking ownership of the same bundle.
 
 ## [1.2.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and merged queue bundles remain race-safe.
 - Claimed missing AirDC++ bundle retries atomically, bound completion to the
   exact claim, preserved remote bundles merged with existing queue work, and
   prevented duplicate intents from taking ownership of the same bundle.
+- Rechecked AirDC++ bundle ownership immediately before stale recovery cleanup
+  so cancellation cannot delete a bundle adopted by another Pullbox download.
 
 ## [1.2.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mutation retry budget or prematurely failing an active remote download.
 - Prevented AirDC++ acquisition and reconciliation from racing cancellation,
   including pre-bundle requests and remote mutations already in flight.
-- Claimed missing AirDC++ bundle retries atomically so overlapping requests
-  cannot create duplicate remote bundles.
+- Claimed missing AirDC++ bundle retries atomically, bound completion to the
+  exact claim, and preserved remote bundles merged with existing queue work.
 
 ## [1.2.0] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Kept transient AirDC++ queue lookup failures from consuming the bounded queue
+  mutation retry budget or prematurely failing an active remote download.
+
 ## [1.2.0] - 2026-08-28
 
 Minor release adding native Direct Connect acquisition, LibGen direct-download

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mutation retry budget or prematurely failing an active remote download.
 - Prevented AirDC++ reconciliation from racing an initial queue mutation or
   resurrecting a download cancelled while recovery was in flight.
+- Claimed missing AirDC++ bundle retries atomically so overlapping requests
+  cannot create duplicate remote bundles.
 
 ## [1.2.0] - 2026-08-28
 

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.2.1-dev"
+__version__ = "1.2.1"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.2.0"
+__version__ = "1.2.1-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/api/v1/downloads.py
+++ b/src/pullbox/api/v1/downloads.py
@@ -268,9 +268,36 @@ async def _cancel_on_client(download: DownloadHistory, session: DbSession) -> No
                 )
             )
         ).scalar_one_or_none()
-        if acquisition is None or acquisition.bundle_id is None:
+        if acquisition is None:
             logger.warning("cancel_airdcpp_reference_invalid", download_id=download.id)
             return
+        if acquisition.bundle_id is None:
+            cancellation = await session.execute(
+                update(AirDcppAcquisition)
+                .where(
+                    AirDcppAcquisition.id == acquisition.id,
+                    AirDcppAcquisition.bundle_id.is_(None),
+                )
+                .values(
+                    client_state="cancelled",
+                    next_retry_at=None,
+                    reconciliation_error=None,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            await session.commit()
+            if cancellation.rowcount == 1:  # type: ignore[attr-defined]
+                await session.refresh(acquisition)
+                logger.info(
+                    "airdcpp_pre_bundle_cancelled",
+                    download_id=download.id,
+                    client_config_id=acquisition.client_config_id,
+                )
+                return
+            await session.refresh(acquisition)
+            if acquisition.bundle_id is None:
+                logger.warning("cancel_airdcpp_reference_invalid", download_id=download.id)
+                return
         air_registry = get_airdcpp_supervisor_registry()
         supervisor = (
             air_registry.get(acquisition.client_config_id)

--- a/src/pullbox/api/v1/downloads.py
+++ b/src/pullbox/api/v1/downloads.py
@@ -731,6 +731,8 @@ async def retry_download(
                 if (
                     acquisition.client_state == "retry_mutation_pending"
                     and download.state is DownloadState.RETRY_PENDING
+                    and acquisition.next_retry_at == claim_deadline
+                    and download.next_retry_at == claim_deadline
                 ):
                     acquisition.client_state = previous_client_state
                     acquisition.next_retry_at = None
@@ -755,6 +757,8 @@ async def retry_download(
                 if (
                     acquisition.client_state == "retry_mutation_pending"
                     and download.state is DownloadState.RETRY_PENDING
+                    and acquisition.next_retry_at == claim_deadline
+                    and download.next_retry_at == claim_deadline
                 ):
                     acquisition.client_state = previous_client_state
                     acquisition.next_retry_at = None
@@ -772,17 +776,20 @@ async def retry_download(
             if (
                 acquisition.client_state != "retry_mutation_pending"
                 or download.state is not DownloadState.RETRY_PENDING
+                or acquisition.next_retry_at != claim_deadline
+                or download.next_retry_at != claim_deadline
             ):
                 await session.commit()
-                try:
-                    await supervisor.api_client.remove_queue_bundle(added.id)
-                except AirDcppError as exc:
-                    logger.warning(
-                        "airdcpp_superseded_retry_cleanup_failed",
-                        download_id=download.id,
-                        bundle_id=added.id,
-                        error_code=exc.code,
-                    )
+                if not added.merged:
+                    try:
+                        await supervisor.api_client.remove_queue_bundle(added.id)
+                    except AirDcppError as exc:
+                        logger.warning(
+                            "airdcpp_superseded_retry_cleanup_failed",
+                            download_id=download.id,
+                            bundle_id=added.id,
+                            error_code=exc.code,
+                        )
                 raise HTTPException(
                     status_code=409,
                     detail="The AirDC++ retry was superseded before it completed.",

--- a/src/pullbox/api/v1/downloads.py
+++ b/src/pullbox/api/v1/downloads.py
@@ -2,7 +2,7 @@
 
 import structlog
 from fastapi import APIRouter, HTTPException, Query
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.orm import joinedload, selectinload
 
 from pullbox.api.deps import AuthenticatedUser, DbSession
@@ -566,7 +566,7 @@ async def retry_download(
     Re-sends the original download URL to the download client and resets
     the download state to SENT.
     """
-    from datetime import UTC, datetime
+    from datetime import UTC, datetime, timedelta
 
     from pullbox.composition.providers import register_download_clients, register_indexers
     from pullbox.composition.services import build_download_service
@@ -664,6 +664,32 @@ async def retry_download(
                 )
             )
             queue_priority = settings.queue_priority if settings is not None else None
+            previous_client_state = acquisition.client_state
+            previous_reconciliation_error = acquisition.reconciliation_error
+            previous_error_message = download.error_message
+            claim_deadline = now + timedelta(minutes=5)
+            claim_result = await session.execute(
+                update(AirDcppAcquisition)
+                .where(
+                    AirDcppAcquisition.id == acquisition.id,
+                    AirDcppAcquisition.client_state == previous_client_state,
+                    AirDcppAcquisition.reconciliation_error == previous_reconciliation_error,
+                )
+                .values(
+                    client_state="retry_mutation_pending",
+                    next_retry_at=claim_deadline,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            if claim_result.rowcount != 1:  # type: ignore[attr-defined]
+                await session.rollback()
+                raise HTTPException(
+                    status_code=409,
+                    detail="This AirDC++ download is already being retried.",
+                )
+            download.state = DownloadState.RETRY_PENDING
+            download.next_retry_at = claim_deadline
+            download.error_message = "Recreating the missing AirDC++ queue item."
             await session.commit()
             try:
                 added = await supervisor.api_client.create_file_bundle(
@@ -673,6 +699,19 @@ async def retry_download(
                     priority=queue_priority,
                 )
             except AirDcppError as exc:
+                await session.refresh(acquisition)
+                await session.refresh(download)
+                if (
+                    acquisition.client_state == "retry_mutation_pending"
+                    and download.state is DownloadState.RETRY_PENDING
+                ):
+                    acquisition.client_state = previous_client_state
+                    acquisition.next_retry_at = None
+                    acquisition.reconciliation_error = previous_reconciliation_error
+                    download.state = DownloadState.FAILED
+                    download.next_retry_at = None
+                    download.error_message = previous_error_message
+                    await session.commit()
                 raise HTTPException(
                     status_code=502,
                     detail="AirDC++ could not recreate the missing queue item.",
@@ -684,10 +723,43 @@ async def retry_download(
                     client_config_id=client_config_id,
                     exc_info=True,
                 )
+                await session.refresh(acquisition)
+                await session.refresh(download)
+                if (
+                    acquisition.client_state == "retry_mutation_pending"
+                    and download.state is DownloadState.RETRY_PENDING
+                ):
+                    acquisition.client_state = previous_client_state
+                    acquisition.next_retry_at = None
+                    acquisition.reconciliation_error = previous_reconciliation_error
+                    download.state = DownloadState.FAILED
+                    download.next_retry_at = None
+                    download.error_message = previous_error_message
+                    await session.commit()
                 raise HTTPException(
                     status_code=502,
                     detail="AirDC++ could not recreate the missing queue item.",
                 ) from exc
+            await session.refresh(acquisition)
+            await session.refresh(download)
+            if (
+                acquisition.client_state != "retry_mutation_pending"
+                or download.state is not DownloadState.RETRY_PENDING
+            ):
+                await session.commit()
+                try:
+                    await supervisor.api_client.remove_queue_bundle(added.id)
+                except AirDcppError as exc:
+                    logger.warning(
+                        "airdcpp_superseded_retry_cleanup_failed",
+                        download_id=download.id,
+                        bundle_id=added.id,
+                        error_code=exc.code,
+                    )
+                raise HTTPException(
+                    status_code=409,
+                    detail="The AirDC++ retry was superseded before it completed.",
+                )
             acquisition.bundle_id = added.id
             acquisition.remote_target = None
             acquisition.last_reconciled_at = None

--- a/src/pullbox/services/airdcpp_acquisition.py
+++ b/src/pullbox/services/airdcpp_acquisition.py
@@ -7,7 +7,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Protocol
 
-from sqlalchemy import select
+import structlog
+from sqlalchemy import select, update
 
 from pullbox.core.acquisition import AcquisitionProtocol
 from pullbox.models.airdcpp import AirDcppAcquisition
@@ -20,6 +21,13 @@ from pullbox.providers.airdcpp.errors import (
 )
 
 _INITIAL_MUTATION_RECOVERY_DELAY = timedelta(minutes=5)
+_TERMINAL_STATES = {
+    DownloadState.COMPLETED,
+    DownloadState.FAILED,
+    DownloadState.IMPORTED,
+}
+
+logger = structlog.get_logger(__name__)
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -51,6 +59,8 @@ class AirDcppQueueApi(Protocol):
         target_name: str,
         priority: int | None,
     ) -> AirDcppQueueBundleAddInfo: ...
+
+    async def remove_queue_bundle(self, bundle_id: int) -> None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -88,17 +98,33 @@ class AirDcppQueueAcquisitionService:
             history = await session.get(DownloadHistory, existing.download_history_id)
             if history is None:  # pragma: no cover - protected by the foreign key
                 raise RuntimeError("Direct Connect history is unavailable")
+            expected_client_state = existing.client_state
+            expected_history_state = DownloadState(history.state)
+            expected_retry_count = existing.retry_count
             await session.commit()
-            if existing.bundle_id is None:
+            if (
+                existing.bundle_id is None
+                and expected_history_state not in _TERMINAL_STATES
+                and expected_client_state in {"mutation_pending", "reconcile_pending"}
+            ):
                 adopted = await self._find_adoptable(api_client, existing, history.title)
                 if adopted is not None:
-                    await self._record_bundle(
+                    recorded = await self._record_bundle_if_current(
                         session,
                         existing,
                         history,
                         adopted.bundle_id,
+                        expected_client_state=expected_client_state,
+                        expected_history_state=expected_history_state,
+                        expected_retry_count=expected_retry_count,
                         remote_target=adopted.target.get_secret_value(),
                     )
+                    if not recorded:
+                        await self._remove_superseded_bundle(
+                            api_client,
+                            existing,
+                            adopted.bundle_id,
+                        )
             return _result(existing, history, merged=None)
 
         issue = await session.get(Issue, issue_id)
@@ -155,7 +181,9 @@ class AirDcppQueueAcquisitionService:
         await session.commit()
 
         merged: bool | None = None
-        bundle_id: int | None
+        bundle_id: int | None = None
+        remote_target: str | None = None
+        mutation_error: str | None = None
         source_search_pending = False
         try:
             added = await api_client.download_search_result(
@@ -174,9 +202,9 @@ class AirDcppQueueAcquisitionService:
             )
             bundle_id = adopted.bundle_id if adopted is not None else None
             if adopted is not None:
-                acquisition.remote_target = adopted.target.get_secret_value()
+                remote_target = adopted.target.get_secret_value()
             elif recovery_error is not None:
-                acquisition.reconciliation_error = recovery_error
+                mutation_error = recovery_error
         except AirDcppEntityNotFoundError:
             try:
                 added = await api_client.create_file_bundle(
@@ -186,35 +214,37 @@ class AirDcppQueueAcquisitionService:
                     priority=queue_priority,
                 )
             except AirDcppError as exc:
-                bundle_id = None
-                acquisition.reconciliation_error = exc.code
+                mutation_error = exc.code
             else:
                 bundle_id = added.id
                 merged = added.merged
                 source_search_pending = True
         except AirDcppError as exc:
-            bundle_id = None
-            acquisition.reconciliation_error = exc.code
+            mutation_error = exc.code
 
         if bundle_id is not None:
-            await self._record_bundle(
+            recorded = await self._record_bundle_if_current(
                 session,
                 acquisition,
                 history,
                 bundle_id,
+                expected_client_state="mutation_pending",
+                expected_history_state=DownloadState.QUEUED,
+                expected_retry_count=0,
+                remote_target=remote_target,
                 client_state=("source_search_pending" if source_search_pending else "queued"),
                 next_retry_at=(now if source_search_pending else None),
             )
+            if not recorded:
+                await self._remove_superseded_bundle(api_client, acquisition, bundle_id)
         else:
-            acquisition.client_state = "reconcile_pending"
-            acquisition.retry_count = min(acquisition.retry_count + 1, acquisition.max_retries)
-            acquisition.next_retry_at = now + timedelta(seconds=30)
-            if acquisition.reconciliation_error is None:
-                acquisition.reconciliation_error = "queue_outcome_ambiguous"
-            history.state = DownloadState.RETRY_PENDING
-            history.next_retry_at = acquisition.next_retry_at
-            history.error_message = "Waiting to reconcile the AirDC++ queue request."
-            await session.commit()
+            await self._record_retry_if_current(
+                session,
+                acquisition,
+                history,
+                now=now,
+                mutation_error=mutation_error,
+            )
         return _result(acquisition, history, merged=merged)
 
     async def _find_adoptable(
@@ -247,28 +277,145 @@ class AirDcppQueueAcquisitionService:
         except AirDcppError as exc:
             return None, exc.code
 
-    async def _record_bundle(
+    async def _record_bundle_if_current(
         self,
         session: AsyncSession,
         acquisition: AirDcppAcquisition,
         history: DownloadHistory,
         bundle_id: int,
         *,
+        expected_client_state: str,
+        expected_history_state: DownloadState,
+        expected_retry_count: int,
         remote_target: str | None = None,
         client_state: str = "queued",
         next_retry_at: datetime | None = None,
-    ) -> None:
-        acquisition.bundle_id = bundle_id
-        acquisition.client_state = client_state
-        acquisition.remote_target = remote_target or acquisition.remote_target
-        acquisition.next_retry_at = next_retry_at
-        acquisition.reconciliation_error = None
-        acquisition.last_reconciled_at = datetime.now(UTC)
-        history.external_id = f"airdcpp:{acquisition.client_config_id}:bundle:{bundle_id}"
-        history.state = DownloadState.SENT
-        history.next_retry_at = None
-        history.error_message = None
+    ) -> bool:
+        values: dict[str, object] = {
+            "bundle_id": bundle_id,
+            "client_state": client_state,
+            "next_retry_at": next_retry_at,
+            "reconciliation_error": None,
+            "last_reconciled_at": datetime.now(UTC),
+        }
+        if remote_target is not None:
+            values["remote_target"] = remote_target
+        acquisition_result = await session.execute(
+            update(AirDcppAcquisition)
+            .where(
+                AirDcppAcquisition.id == acquisition.id,
+                AirDcppAcquisition.bundle_id.is_(None),
+                AirDcppAcquisition.client_state == expected_client_state,
+                AirDcppAcquisition.retry_count == expected_retry_count,
+            )
+            .values(**values)
+            .execution_options(synchronize_session=False)
+        )
+        if acquisition_result.rowcount != 1:  # type: ignore[attr-defined]
+            await self._refresh_after_claim_loss(session, acquisition, history)
+            return False
+        history_result = await session.execute(
+            update(DownloadHistory)
+            .where(
+                DownloadHistory.id == history.id,
+                DownloadHistory.state == expected_history_state,
+            )
+            .values(
+                external_id=f"airdcpp:{acquisition.client_config_id}:bundle:{bundle_id}",
+                state=DownloadState.SENT,
+                next_retry_at=None,
+                error_message=None,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if history_result.rowcount != 1:  # type: ignore[attr-defined]
+            await self._refresh_after_claim_loss(session, acquisition, history)
+            return False
         await session.commit()
+        await session.refresh(acquisition)
+        await session.refresh(history)
+        return True
+
+    async def _record_retry_if_current(
+        self,
+        session: AsyncSession,
+        acquisition: AirDcppAcquisition,
+        history: DownloadHistory,
+        *,
+        now: datetime,
+        mutation_error: str | None,
+    ) -> bool:
+        next_retry_at = now + timedelta(seconds=30)
+        acquisition_result = await session.execute(
+            update(AirDcppAcquisition)
+            .where(
+                AirDcppAcquisition.id == acquisition.id,
+                AirDcppAcquisition.bundle_id.is_(None),
+                AirDcppAcquisition.client_state == "mutation_pending",
+                AirDcppAcquisition.retry_count == 0,
+            )
+            .values(
+                client_state="reconcile_pending",
+                retry_count=1,
+                next_retry_at=next_retry_at,
+                reconciliation_error=mutation_error or "queue_outcome_ambiguous",
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if acquisition_result.rowcount != 1:  # type: ignore[attr-defined]
+            await self._refresh_after_claim_loss(session, acquisition, history)
+            return False
+        history_result = await session.execute(
+            update(DownloadHistory)
+            .where(
+                DownloadHistory.id == history.id,
+                DownloadHistory.state == DownloadState.QUEUED,
+            )
+            .values(
+                state=DownloadState.RETRY_PENDING,
+                next_retry_at=next_retry_at,
+                error_message="Waiting to reconcile the AirDC++ queue request.",
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if history_result.rowcount != 1:  # type: ignore[attr-defined]
+            await self._refresh_after_claim_loss(session, acquisition, history)
+            return False
+        await session.commit()
+        await session.refresh(acquisition)
+        await session.refresh(history)
+        return True
+
+    async def _refresh_after_claim_loss(
+        self,
+        session: AsyncSession,
+        acquisition: AirDcppAcquisition,
+        history: DownloadHistory,
+    ) -> None:
+        await session.rollback()
+        await session.refresh(acquisition)
+        await session.refresh(history)
+        await session.commit()
+
+    async def _remove_superseded_bundle(
+        self,
+        api_client: AirDcppQueueApi,
+        acquisition: AirDcppAcquisition,
+        bundle_id: int,
+    ) -> None:
+        if acquisition.bundle_id == bundle_id:
+            return
+        try:
+            await api_client.remove_queue_bundle(bundle_id)
+        except AirDcppEntityNotFoundError:
+            return
+        except AirDcppError as exc:
+            logger.warning(
+                "airdcpp_superseded_acquisition_cleanup_failed",
+                acquisition_id=acquisition.id,
+                bundle_id=bundle_id,
+                error_code=exc.code,
+            )
 
 
 def _safe_target_name(value: str) -> str:

--- a/src/pullbox/services/airdcpp_acquisition.py
+++ b/src/pullbox/services/airdcpp_acquisition.py
@@ -19,6 +19,8 @@ from pullbox.providers.airdcpp.errors import (
     AirDcppUnavailableError,
 )
 
+_INITIAL_MUTATION_RECOVERY_DELAY = timedelta(minutes=5)
+
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -145,6 +147,7 @@ class AirDcppQueueAcquisitionService:
             },
             retry_count=0,
             max_retries=3,
+            next_retry_at=now + _INITIAL_MUTATION_RECOVERY_DELAY,
         )
         session.add(acquisition)
         issue.status = IssueStatus.DOWNLOADING

--- a/src/pullbox/services/airdcpp_acquisition.py
+++ b/src/pullbox/services/airdcpp_acquisition.py
@@ -109,7 +109,7 @@ class AirDcppQueueAcquisitionService:
             ):
                 adopted = await self._find_adoptable(api_client, existing, history.title)
                 if adopted is not None:
-                    recorded = await self._record_bundle_if_current(
+                    await self._record_bundle_if_current(
                         session,
                         existing,
                         history,
@@ -119,12 +119,6 @@ class AirDcppQueueAcquisitionService:
                         expected_retry_count=expected_retry_count,
                         remote_target=adopted.target.get_secret_value(),
                     )
-                    if not recorded:
-                        await self._remove_superseded_bundle(
-                            api_client,
-                            existing,
-                            adopted.bundle_id,
-                        )
             return _result(existing, history, merged=None)
 
         issue = await session.get(Issue, issue_id)
@@ -184,6 +178,7 @@ class AirDcppQueueAcquisitionService:
         bundle_id: int | None = None
         remote_target: str | None = None
         mutation_error: str | None = None
+        bundle_created = False
         source_search_pending = False
         try:
             added = await api_client.download_search_result(
@@ -194,6 +189,7 @@ class AirDcppQueueAcquisitionService:
             )
             bundle_id = added.id
             merged = added.merged
+            bundle_created = not added.merged
         except AirDcppUnavailableError:
             adopted, recovery_error = await self._try_find_adoptable(
                 api_client,
@@ -218,6 +214,7 @@ class AirDcppQueueAcquisitionService:
             else:
                 bundle_id = added.id
                 merged = added.merged
+                bundle_created = not added.merged
                 source_search_pending = True
         except AirDcppError as exc:
             mutation_error = exc.code
@@ -235,7 +232,7 @@ class AirDcppQueueAcquisitionService:
                 client_state=("source_search_pending" if source_search_pending else "queued"),
                 next_retry_at=(now if source_search_pending else None),
             )
-            if not recorded:
+            if not recorded and bundle_created:
                 await self._remove_superseded_bundle(api_client, acquisition, bundle_id)
         else:
             await self._record_retry_if_current(

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -279,7 +279,7 @@ class AirDcppReconciler:
                     )
                 elif snapshot.acquisition_id in recovered:
                     recovered_mutation = recovered[snapshot.acquisition_id]
-                    if _recovery_snapshot_is_current(acquisition, snapshot):
+                    if _active_snapshot_is_current(acquisition, snapshot):
                         changed += int(
                             _apply_recovered_mutation(
                                 acquisition,
@@ -290,7 +290,7 @@ class AirDcppReconciler:
                     elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
                         stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
                 elif snapshot.acquisition_id in retry_failures:
-                    if _recovery_snapshot_is_current(acquisition, snapshot):
+                    if _active_snapshot_is_current(acquisition, snapshot):
                         changed += int(
                             _apply_pre_id_retry_failure(
                                 acquisition,
@@ -303,8 +303,9 @@ class AirDcppReconciler:
                     and complete_snapshot
                     and _missing_bundle_state_is_actionable(snapshot, now=now)
                 ):
-                    missing += 1
-                    changed += int(_apply_missing_bundle(acquisition, at=now))
+                    if _active_snapshot_is_current(acquisition, snapshot):
+                        missing += 1
+                        changed += int(_apply_missing_bundle(acquisition, at=now))
                 await project_download_operation_progress(
                     session,
                     acquisition.download_history,
@@ -405,7 +406,7 @@ def _pre_id_retry_due(snapshot: _ActiveSnapshot, *, now: datetime) -> bool:
     return False
 
 
-def _recovery_snapshot_is_current(
+def _active_snapshot_is_current(
     acquisition: AirDcppAcquisition,
     snapshot: _ActiveSnapshot,
 ) -> bool:

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -93,6 +93,7 @@ class AirDcppReconciliationResult:
 @dataclass(frozen=True, slots=True)
 class _ActiveSnapshot:
     acquisition_id: int
+    client_identity: str
     bundle_id: int | None
     client_state: str | None
     tth: str
@@ -179,6 +180,7 @@ class AirDcppReconciler:
             snapshots = tuple(
                 _ActiveSnapshot(
                     row.id,
+                    row.client_identity,
                     row.bundle_id,
                     row.client_state,
                     row.tth,
@@ -256,6 +258,40 @@ class AirDcppReconciler:
                 .where(AirDcppAcquisition.id.in_(snapshot.acquisition_id for snapshot in snapshots))
             )
             acquisitions = {item.id: item for item in result.unique().scalars()}
+            ownership_candidates = {
+                (snapshot.client_identity, adopted[snapshot.acquisition_id].bundle_id)
+                for snapshot in snapshots
+                if snapshot.acquisition_id in adopted
+            }
+            ownership_candidates.update(
+                (snapshot.client_identity, recovered[snapshot.acquisition_id].bundle_id)
+                for snapshot in snapshots
+                if snapshot.acquisition_id in recovered
+                and not recovered[snapshot.acquisition_id].created_bundle
+            )
+            existing_bundle_owners: dict[tuple[str, int], int] = {}
+            if ownership_candidates:
+                owner_identities = tuple(
+                    {identity for identity, _bundle_id in ownership_candidates}
+                )
+                owner_bundle_ids = tuple(
+                    {bundle_id for _identity, bundle_id in ownership_candidates}
+                )
+                owner_rows = await session.execute(
+                    select(
+                        AirDcppAcquisition.client_identity,
+                        AirDcppAcquisition.bundle_id,
+                        AirDcppAcquisition.id,
+                    ).where(
+                        AirDcppAcquisition.client_identity.in_(owner_identities),
+                        AirDcppAcquisition.bundle_id.in_(owner_bundle_ids),
+                    )
+                )
+                existing_bundle_owners = {
+                    (identity, bundle_id): owner_id
+                    for identity, bundle_id, owner_id in owner_rows
+                    if bundle_id is not None
+                }
             for snapshot in snapshots:
                 acquisition = acquisitions.get(snapshot.acquisition_id)
                 if acquisition is None:
@@ -271,23 +307,49 @@ class AirDcppReconciler:
                         and acquisition.download_history.state is DownloadState.COMPLETED
                     )
                 elif snapshot.acquisition_id in adopted:
-                    changed += int(
-                        _apply_adopted_file(
-                            acquisition,
-                            adopted[snapshot.acquisition_id],
-                            at=now,
+                    adopted_file = adopted[snapshot.acquisition_id]
+                    if _active_snapshot_is_current(acquisition, snapshot):
+                        owner_id = existing_bundle_owners.get(
+                            (snapshot.client_identity, adopted_file.bundle_id)
                         )
-                    )
+                        if owner_id is not None and owner_id != acquisition.id:
+                            changed += int(
+                                _apply_existing_bundle_owner(
+                                    acquisition,
+                                    owner_acquisition_id=owner_id,
+                                    at=now,
+                                )
+                            )
+                        else:
+                            changed += int(
+                                _apply_adopted_file(
+                                    acquisition,
+                                    adopted_file,
+                                    at=now,
+                                )
+                            )
                 elif snapshot.acquisition_id in recovered:
                     recovered_mutation = recovered[snapshot.acquisition_id]
                     if _active_snapshot_is_current(acquisition, snapshot):
-                        changed += int(
-                            _apply_recovered_mutation(
-                                acquisition,
-                                recovered_mutation,
-                                at=now,
-                            )
+                        owner_id = existing_bundle_owners.get(
+                            (snapshot.client_identity, recovered_mutation.bundle_id)
                         )
+                        if owner_id is not None and owner_id != acquisition.id:
+                            changed += int(
+                                _apply_existing_bundle_owner(
+                                    acquisition,
+                                    owner_acquisition_id=owner_id,
+                                    at=now,
+                                )
+                            )
+                        else:
+                            changed += int(
+                                _apply_recovered_mutation(
+                                    acquisition,
+                                    recovered_mutation,
+                                    at=now,
+                                )
+                            )
                     elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
                         stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
                 elif snapshot.acquisition_id in retry_failures:
@@ -506,6 +568,27 @@ def _apply_recovered_mutation(
     history.next_retry_at = None
     history.error_message = None
     history.completed_at = None
+    return True
+
+
+def _apply_existing_bundle_owner(
+    acquisition: AirDcppAcquisition,
+    *,
+    owner_acquisition_id: int,
+    at: datetime,
+) -> bool:
+    history = acquisition.download_history
+    route_snapshot = dict(acquisition.route_snapshot or {})
+    route_snapshot["existing_bundle_owner_acquisition_id"] = owner_acquisition_id
+    acquisition.route_snapshot = route_snapshot
+    acquisition.client_state = "duplicate"
+    acquisition.next_retry_at = None
+    acquisition.last_reconciled_at = at
+    acquisition.reconciliation_error = "queue_bundle_already_owned"
+    history.state = DownloadState.FAILED
+    history.next_retry_at = None
+    history.completed_at = at
+    history.error_message = "AirDC++ merged this request into an existing Pullbox download."
     return True
 
 

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -203,7 +203,7 @@ class AirDcppReconciler:
         adopted: dict[int, AirDcppQueueFile] = {}
         recovered: dict[int, _RecoveredMutation] = {}
         retry_failures: dict[int, str] = {}
-        stale_recovered_bundle_ids: set[int] = set()
+        stale_recovered_bundles: set[tuple[str, int]] = set()
         pre_id = [snapshot for snapshot in snapshots if snapshot.bundle_id is None]
         now = datetime.now(UTC)
         for snapshot in pre_id[:_MAX_PRE_ID_LOOKUPS]:
@@ -351,7 +351,9 @@ class AirDcppReconciler:
                                 )
                             )
                     elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
-                        stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
+                        stale_recovered_bundles.add(
+                            (snapshot.client_identity, recovered_mutation.bundle_id)
+                        )
                 elif snapshot.acquisition_id in retry_failures:
                     if _active_snapshot_is_current(acquisition, snapshot):
                         changed += int(
@@ -376,7 +378,23 @@ class AirDcppReconciler:
                 )
             await session.commit()
 
-        for bundle_id in stale_recovered_bundle_ids:
+        for client_identity, bundle_id in stale_recovered_bundles:
+            async with self._session_factory() as session:
+                owner_id = await session.scalar(
+                    select(AirDcppAcquisition.id)
+                    .where(
+                        AirDcppAcquisition.client_identity == client_identity,
+                        AirDcppAcquisition.bundle_id == bundle_id,
+                    )
+                    .limit(1)
+                )
+            if owner_id is not None:
+                logger.info(
+                    "airdcpp_stale_recovery_cleanup_skipped_owned_bundle",
+                    bundle_id=bundle_id,
+                    owner_acquisition_id=owner_id,
+                )
+                continue
             try:
                 await api_client.remove_queue_bundle(bundle_id)
             except AirDcppEntityNotFoundError:

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -111,6 +111,7 @@ class _ActiveSnapshot:
 class _RecoveredMutation:
     bundle_id: int
     client_state: str
+    created_bundle: bool
 
 
 class AirDcppReconciler:
@@ -424,7 +425,7 @@ def _stale_recovery_requires_cleanup(
     recovered: _RecoveredMutation,
 ) -> bool:
     history = acquisition.download_history
-    return (
+    return recovered.created_bundle and (
         DownloadState(history.state) in _TERMINAL_STATES
         or acquisition.bundle_id != recovered.bundle_id
     )
@@ -466,7 +467,11 @@ async def _retry_pre_id_mutation(
         except AirDcppEntityNotFoundError:
             pass
         else:
-            return _RecoveredMutation(added.id, "queued")
+            return _RecoveredMutation(
+                bundle_id=added.id,
+                client_state="queued",
+                created_bundle=not added.merged,
+            )
 
     added = await api_client.create_file_bundle(
         tth=snapshot.tth,
@@ -474,7 +479,11 @@ async def _retry_pre_id_mutation(
         target_name=snapshot.target_name,
         priority=snapshot.queue_priority,
     )
-    return _RecoveredMutation(added.id, "source_search_pending")
+    return _RecoveredMutation(
+        bundle_id=added.id,
+        client_state="source_search_pending",
+        created_bundle=not added.merged,
+    )
 
 
 def _apply_recovered_mutation(

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -290,14 +290,19 @@ class AirDcppReconciler:
                     elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
                         stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
                 elif snapshot.acquisition_id in retry_failures:
-                    changed += int(
-                        _apply_pre_id_retry_failure(
-                            acquisition,
-                            error_code=retry_failures[snapshot.acquisition_id],
-                            at=now,
+                    if _recovery_snapshot_is_current(acquisition, snapshot):
+                        changed += int(
+                            _apply_pre_id_retry_failure(
+                                acquisition,
+                                error_code=retry_failures[snapshot.acquisition_id],
+                                at=now,
+                            )
                         )
-                    )
-                elif snapshot.bundle_id is not None and complete_snapshot:
+                elif (
+                    snapshot.bundle_id is not None
+                    and complete_snapshot
+                    and _missing_bundle_state_is_actionable(snapshot, now=now)
+                ):
                     missing += 1
                     changed += int(_apply_missing_bundle(acquisition, at=now))
                 await project_download_operation_progress(
@@ -422,6 +427,16 @@ def _stale_recovery_requires_cleanup(
         DownloadState(history.state) in _TERMINAL_STATES
         or acquisition.bundle_id != recovered.bundle_id
     )
+
+
+def _missing_bundle_state_is_actionable(
+    snapshot: _ActiveSnapshot,
+    *,
+    now: datetime,
+) -> bool:
+    if snapshot.client_state != "retry_mutation_pending":
+        return True
+    return snapshot.next_retry_at is not None and snapshot.next_retry_at <= now
 
 
 async def _retry_pre_id_mutation(

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Protocol
 
+import structlog
 from sqlalchemy import or_, select
 from sqlalchemy.orm import joinedload
 
@@ -32,6 +33,7 @@ _PAGE_SIZE = 100
 _MAX_PAGES = 10
 _MAX_PRE_ID_LOOKUPS = 10
 _PROGRESS_WRITE_INTERVAL = timedelta(seconds=5)
+logger = structlog.get_logger(__name__)
 _TERMINAL_STATES = frozenset(
     {
         DownloadState.COMPLETED,
@@ -69,6 +71,8 @@ class AirDcppReconciliationApi(Protocol):
         priority: int | None,
     ) -> AirDcppQueueBundleAddInfo: ...
 
+    async def remove_queue_bundle(self, bundle_id: int) -> None: ...
+
     async def search_queue_bundle(self, bundle_id: int) -> None: ...
 
 
@@ -90,6 +94,7 @@ class AirDcppReconciliationResult:
 class _ActiveSnapshot:
     acquisition_id: int
     bundle_id: int | None
+    client_state: str | None
     tth: str
     size_bytes: int
     target_name: str
@@ -174,6 +179,7 @@ class AirDcppReconciler:
                 _ActiveSnapshot(
                     row.id,
                     row.bundle_id,
+                    row.client_state,
                     row.tth,
                     row.size_bytes,
                     row.original_name,
@@ -194,6 +200,7 @@ class AirDcppReconciler:
         adopted: dict[int, AirDcppQueueFile] = {}
         recovered: dict[int, _RecoveredMutation] = {}
         retry_failures: dict[int, str] = {}
+        stale_recovered_bundle_ids: set[int] = set()
         pre_id = [snapshot for snapshot in snapshots if snapshot.bundle_id is None]
         now = datetime.now(UTC)
         for snapshot in pre_id[:_MAX_PRE_ID_LOOKUPS]:
@@ -271,13 +278,17 @@ class AirDcppReconciler:
                         )
                     )
                 elif snapshot.acquisition_id in recovered:
-                    changed += int(
-                        _apply_recovered_mutation(
-                            acquisition,
-                            recovered[snapshot.acquisition_id],
-                            at=now,
+                    recovered_mutation = recovered[snapshot.acquisition_id]
+                    if _recovery_snapshot_is_current(acquisition, snapshot):
+                        changed += int(
+                            _apply_recovered_mutation(
+                                acquisition,
+                                recovered_mutation,
+                                at=now,
+                            )
                         )
-                    )
+                    elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
+                        stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
                 elif snapshot.acquisition_id in retry_failures:
                     changed += int(
                         _apply_pre_id_retry_failure(
@@ -295,6 +306,18 @@ class AirDcppReconciler:
                     _shared_progress_snapshot(acquisition),
                 )
             await session.commit()
+
+        for bundle_id in stale_recovered_bundle_ids:
+            try:
+                await api_client.remove_queue_bundle(bundle_id)
+            except AirDcppEntityNotFoundError:
+                pass
+            except AirDcppError as exc:
+                logger.warning(
+                    "airdcpp_stale_recovery_cleanup_failed",
+                    bundle_id=bundle_id,
+                    error_code=exc.code,
+                )
 
         return AirDcppReconciliationResult(
             processed=len(snapshots),
@@ -370,7 +393,35 @@ def _queue_priority(route_snapshot: dict[str, object] | None) -> int | None:
 
 
 def _pre_id_retry_due(snapshot: _ActiveSnapshot, *, now: datetime) -> bool:
-    return snapshot.next_retry_at is None or snapshot.next_retry_at <= now
+    if snapshot.client_state == "reconcile_pending":
+        return snapshot.next_retry_at is None or snapshot.next_retry_at <= now
+    if snapshot.client_state == "mutation_pending":
+        return snapshot.next_retry_at is not None and snapshot.next_retry_at <= now
+    return False
+
+
+def _recovery_snapshot_is_current(
+    acquisition: AirDcppAcquisition,
+    snapshot: _ActiveSnapshot,
+) -> bool:
+    history = acquisition.download_history
+    return (
+        DownloadState(history.state) not in _TERMINAL_STATES
+        and acquisition.bundle_id == snapshot.bundle_id
+        and acquisition.client_state == snapshot.client_state
+        and acquisition.retry_count == snapshot.retry_count
+    )
+
+
+def _stale_recovery_requires_cleanup(
+    acquisition: AirDcppAcquisition,
+    recovered: _RecoveredMutation,
+) -> bool:
+    history = acquisition.download_history
+    return (
+        DownloadState(history.state) in _TERMINAL_STATES
+        or acquisition.bundle_id != recovered.bundle_id
+    )
 
 
 async def _retry_pre_id_mutation(

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -199,9 +199,7 @@ class AirDcppReconciler:
         for snapshot in pre_id[:_MAX_PRE_ID_LOOKUPS]:
             try:
                 files = await api_client.get_queue_files_by_tth(snapshot.tth)
-            except AirDcppError as exc:
-                if _pre_id_retry_due(snapshot, now=now):
-                    retry_failures[snapshot.acquisition_id] = exc.code
+            except AirDcppError:
                 continue
             exact = [
                 item

--- a/tests/api/test_downloads_api.py
+++ b/tests/api/test_downloads_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -33,6 +33,7 @@ from pullbox.models.indexer import IndexerConfig, IndexerSource, IndexerType
 from pullbox.models.issue import Issue, IssueStatus
 from pullbox.models.series import Series
 from pullbox.models.user import APIKey, User
+from pullbox.providers.airdcpp.errors import AirDcppUnavailableError
 from pullbox.providers.airdcpp.supervisor import AirDcppSupervisorState
 from pullbox.providers.download.qbittorrent import QBittorrentError
 from pullbox.providers.indexer.newznab import NewznabError
@@ -1444,6 +1445,103 @@ class TestDownloadRouteFunctions:
         conflicts = [result for result in results if isinstance(result, HTTPException)]
         assert len(conflicts) == 1
         assert conflicts[0].status_code == 409
+
+    @pytest.mark.parametrize("mutation_fails", [False, True])
+    @pytest.mark.asyncio
+    async def test_retry_missing_airdcpp_download_preserves_newer_claim(
+        self,
+        db_factory: async_sessionmaker[AsyncSession],
+        mutation_fails: bool,
+    ) -> None:
+        issue_id = await _seed_issue(db_factory, status=IssueStatus.WANTED)
+        config_id = 82
+        await _seed_client_config(
+            db_factory,
+            config_id=config_id,
+            client_type=DownloadClientType.AIRDCPP,
+        )
+        download_id = await _seed_download(
+            db_factory,
+            issue_id,
+            state=DownloadState.FAILED,
+            client_type=DownloadClientType.AIRDCPP,
+            external_id=f"airdcpp:{config_id}:bundle:96",
+            download_client_config_id=config_id,
+            error_message="The AirDC++ queue item was removed outside Pullbox.",
+        )
+        async with db_factory() as session:
+            acquisition = AirDcppAcquisition(
+                download_history_id=download_id,
+                request_key=f"retry-missing-airdcpp-newer-{mutation_fails}",
+                client_config_id=config_id,
+                client_identity=f"airdcpp:{config_id}",
+                tth="CUO74LMZUQMQCBR5UKTIFJPO32LVUH5VZBOL54Y",
+                size_bytes=100_000_000,
+                original_name="Batman 004 (2025).cbz",
+                bundle_id=96,
+                client_state="missing",
+                reconciliation_error="external_bundle_missing",
+            )
+            session.add(acquisition)
+            await session.flush()
+            acquisition_id = acquisition.id
+            await session.commit()
+
+        newer_deadline = datetime.now(UTC) + timedelta(minutes=10)
+
+        async def _create_file_bundle(**_kwargs: object) -> SimpleNamespace:
+            async with db_factory() as newer_session:
+                current_acquisition = await newer_session.get(
+                    AirDcppAcquisition,
+                    acquisition_id,
+                )
+                current_download = await newer_session.get(DownloadHistory, download_id)
+                assert current_acquisition is not None and current_download is not None
+                current_acquisition.client_state = "retry_mutation_pending"
+                current_acquisition.next_retry_at = newer_deadline
+                current_download.state = DownloadState.RETRY_PENDING
+                current_download.next_retry_at = newer_deadline
+                current_download.error_message = "A newer retry owns this claim."
+                await newer_session.commit()
+            if mutation_fails:
+                raise AirDcppUnavailableError()
+            return SimpleNamespace(id=98, merged=False)
+
+        api = AsyncMock()
+        api.create_file_bundle.side_effect = _create_file_bundle
+        supervisor = SimpleNamespace(
+            state=AirDcppSupervisorState.READY,
+            api_client=api,
+        )
+        registry = SimpleNamespace(
+            get=lambda selected: supervisor if selected == config_id else None
+        )
+
+        with (
+            patch(
+                "pullbox.composition.airdcpp.get_airdcpp_supervisor_registry",
+                return_value=registry,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            async with db_factory() as session:
+                await downloads_api.retry_download(download_id, object(), session)  # type: ignore[arg-type]
+
+        assert exc_info.value.status_code == (502 if mutation_fails else 409)
+        if mutation_fails:
+            api.remove_queue_bundle.assert_not_awaited()
+        else:
+            api.remove_queue_bundle.assert_awaited_once_with(98)
+        async with db_factory() as session:
+            acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+            download = await session.get(DownloadHistory, download_id)
+            assert acquisition is not None and download is not None
+            assert acquisition.bundle_id == 96
+            assert acquisition.client_state == "retry_mutation_pending"
+            assert acquisition.next_retry_at == newer_deadline
+            assert download.state is DownloadState.RETRY_PENDING
+            assert download.next_retry_at == newer_deadline
+            assert download.error_message == "A newer retry owns this claim."
 
     @pytest.mark.asyncio
     async def test_direct_download_sources_list_only_verified_equivalent_routes(

--- a/tests/api/test_downloads_api.py
+++ b/tests/api/test_downloads_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import os
 from datetime import UTC, datetime
@@ -1305,6 +1306,89 @@ class TestDownloadRouteFunctions:
             assert "queue" not in acquisition.route_snapshot
             assert acquisition.next_retry_at is not None
             assert issue.status is IssueStatus.DOWNLOADING
+
+    @pytest.mark.asyncio
+    async def test_retry_missing_airdcpp_download_claims_before_remote_mutation(
+        self,
+        db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        issue_id = await _seed_issue(db_factory, status=IssueStatus.WANTED)
+        config_id = 81
+        await _seed_client_config(
+            db_factory,
+            config_id=config_id,
+            client_type=DownloadClientType.AIRDCPP,
+        )
+        download_id = await _seed_download(
+            db_factory,
+            issue_id,
+            state=DownloadState.FAILED,
+            client_type=DownloadClientType.AIRDCPP,
+            external_id=f"airdcpp:{config_id}:bundle:96",
+            download_client_config_id=config_id,
+            error_message="The AirDC++ queue item was removed outside Pullbox.",
+        )
+        async with db_factory() as session:
+            session.add(
+                AirDcppAcquisition(
+                    download_history_id=download_id,
+                    request_key="retry-missing-airdcpp-concurrent",
+                    client_config_id=config_id,
+                    client_identity=f"airdcpp:{config_id}",
+                    tth="CUO74LMZUQMQCBR5UKTIFJPO32LVUH5VZBOL54Y",
+                    size_bytes=100_000_000,
+                    original_name="Batman 004 (2025).cbz",
+                    bundle_id=96,
+                    client_state="missing",
+                    reconciliation_error="external_bundle_missing",
+                )
+            )
+            await session.commit()
+
+        mutation_started = asyncio.Event()
+        release_mutation = asyncio.Event()
+
+        async def _create_file_bundle(**_kwargs: object) -> SimpleNamespace:
+            mutation_started.set()
+            await release_mutation.wait()
+            return SimpleNamespace(id=97, merged=False)
+
+        api = AsyncMock()
+        api.create_file_bundle.side_effect = _create_file_bundle
+        supervisor = SimpleNamespace(
+            state=AirDcppSupervisorState.READY,
+            api_client=api,
+        )
+        registry = SimpleNamespace(
+            get=lambda selected: supervisor if selected == config_id else None
+        )
+
+        async def _retry() -> dict[str, str]:
+            async with db_factory() as session:
+                response = await downloads_api.retry_download(
+                    download_id,
+                    object(),  # type: ignore[arg-type]
+                    session,
+                )
+                await session.commit()
+                return response
+
+        with patch(
+            "pullbox.composition.airdcpp.get_airdcpp_supervisor_registry",
+            return_value=registry,
+        ):
+            first = asyncio.create_task(_retry())
+            await asyncio.wait_for(mutation_started.wait(), timeout=1)
+            second = asyncio.create_task(_retry())
+            await asyncio.sleep(0.05)
+            release_mutation.set()
+            results = await asyncio.gather(first, second, return_exceptions=True)
+
+        assert api.create_file_bundle.await_count == 1
+        assert {result["status"] for result in results if isinstance(result, dict)} == {"sent"}
+        conflicts = [result for result in results if isinstance(result, HTTPException)]
+        assert len(conflicts) == 1
+        assert conflicts[0].status_code == 409
 
     @pytest.mark.asyncio
     async def test_direct_download_sources_list_only_verified_equivalent_routes(

--- a/tests/api/test_downloads_api.py
+++ b/tests/api/test_downloads_api.py
@@ -1117,6 +1117,61 @@ class TestDownloadRouteFunctions:
             assert issue.status is IssueStatus.WANTED
 
     @pytest.mark.asyncio
+    async def test_cancel_airdcpp_download_marks_pre_bundle_intent_cancelled(
+        self,
+        db_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        issue_id = await _seed_issue(db_factory, status=IssueStatus.DOWNLOADING)
+        config_id = 78
+        await _seed_client_config(
+            db_factory,
+            config_id=config_id,
+            client_type=DownloadClientType.AIRDCPP,
+        )
+        download_id = await _seed_download(
+            db_factory,
+            issue_id,
+            state=DownloadState.QUEUED,
+            client_type=DownloadClientType.AIRDCPP,
+            external_id=None,
+            download_client_config_id=config_id,
+            error_message=None,
+        )
+        async with db_factory() as session:
+            acquisition = AirDcppAcquisition(
+                download_history_id=download_id,
+                request_key="cancel-airdcpp-pre-bundle",
+                client_config_id=config_id,
+                client_identity=f"airdcpp:{config_id}",
+                tth="CUO74LMZUQMQCBR5UKTIFJPO32LVUH5VZBOL54Y",
+                size_bytes=100_000_000,
+                original_name="Batman 004 (2025).cbz",
+                client_state="mutation_pending",
+            )
+            session.add(acquisition)
+            await session.flush()
+            acquisition_id = acquisition.id
+            await session.commit()
+
+        with patch("pullbox.composition.airdcpp.get_airdcpp_supervisor_registry") as get_registry:
+            async with db_factory() as session:
+                await downloads_api.cancel_download(download_id, object(), session)  # type: ignore[arg-type]
+                await session.commit()
+
+        get_registry.assert_not_called()
+        async with db_factory() as session:
+            download = await session.get(DownloadHistory, download_id)
+            acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+            issue = await session.get(Issue, issue_id)
+            assert download is not None and acquisition is not None and issue is not None
+            assert download.state is DownloadState.FAILED
+            assert download.error_message == "Cancelled by user"
+            assert acquisition.bundle_id is None
+            assert acquisition.client_state == "cancelled"
+            assert acquisition.next_retry_at is None
+            assert issue.status is IssueStatus.WANTED
+
+    @pytest.mark.asyncio
     async def test_cancel_airdcpp_download_preserves_active_state_when_client_unavailable(
         self,
         db_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/test_airdcpp_acquisition.py
+++ b/tests/unit/test_airdcpp_acquisition.py
@@ -132,6 +132,7 @@ class _FakeApi:
         self.mutations = 0
         self.lookups = 0
         self.file_bundle_mutations = 0
+        self.removed_bundles: list[int] = []
         self.observed_mutation_state: str | None = None
         self.observed_next_retry_at: datetime | None = None
 
@@ -161,6 +162,10 @@ class _FakeApi:
         if self.file_bundle_failure is not None:
             raise self.file_bundle_failure
         return AirDcppQueueBundleAddInfo(id=92, merged=False)
+
+    async def remove_queue_bundle(self, bundle_id: int) -> None:
+        assert self.session.in_transaction() is False
+        self.removed_bundles.append(bundle_id)
 
 
 def _queue_file(*, size: int = 100_000_000, target: str | None = None) -> AirDcppQueueFile:
@@ -236,6 +241,62 @@ async def test_acquisition_persists_before_mutation_and_replays_idempotently(
         assert history.protocol is AcquisitionProtocol.DC
         assert history.state is DownloadState.SENT
         assert issue.status is IssueStatus.DOWNLOADING
+
+
+@pytest.mark.asyncio
+async def test_initial_mutation_does_not_resurrect_a_cancelled_download(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, issue_id = await _seed(db_factory)
+
+    class _CancelDuringMutationApi(_FakeApi):
+        async def download_search_result(
+            self,
+            *_args: object,
+            **_kwargs: object,
+        ) -> AirDcppQueueBundleAddInfo:
+            added = await super().download_search_result(*_args, **_kwargs)
+            async with db_factory() as cancel_session:
+                acquisition = (
+                    await cancel_session.execute(select(AirDcppAcquisition))
+                ).scalar_one()
+                history = await cancel_session.get(
+                    DownloadHistory,
+                    acquisition.download_history_id,
+                )
+                assert history is not None
+                acquisition.client_state = "cancelled"
+                acquisition.next_retry_at = None
+                history.state = DownloadState.FAILED
+                history.error_message = "Cancelled by user"
+                await cancel_session.commit()
+            return added
+
+    async with db_factory() as session:
+        api = _CancelDuringMutationApi(session)
+
+        result = await AirDcppQueueAcquisitionService().acquire(
+            session,
+            candidate=_candidate(client_id),
+            issue_id=issue_id,
+            request_key="manual-intent-cancelled",
+            search_log_id=None,
+            api_client=api,
+            queue_priority=3,
+            replace_existing_file=False,
+        )
+
+    assert result.bundle_id is None
+    assert result.state is DownloadState.FAILED
+    assert api.removed_bundles == [91]
+    async with db_factory() as session:
+        acquisition = (await session.execute(select(AirDcppAcquisition))).scalar_one()
+        history = await session.get(DownloadHistory, acquisition.download_history_id)
+        assert history is not None
+        assert acquisition.bundle_id is None
+        assert acquisition.client_state == "cancelled"
+        assert history.state is DownloadState.FAILED
+        assert history.error_message == "Cancelled by user"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_airdcpp_acquisition.py
+++ b/tests/unit/test_airdcpp_acquisition.py
@@ -132,9 +132,19 @@ class _FakeApi:
         self.mutations = 0
         self.lookups = 0
         self.file_bundle_mutations = 0
+        self.observed_mutation_state: str | None = None
+        self.observed_next_retry_at: datetime | None = None
 
     async def download_search_result(self, *_args: object, **_kwargs: object):
         assert self.session.in_transaction() is False
+        pending = (
+            await self.session.execute(
+                select(AirDcppAcquisition).where(AirDcppAcquisition.bundle_id.is_(None))
+            )
+        ).scalar_one()
+        self.observed_mutation_state = pending.client_state
+        self.observed_next_retry_at = pending.next_retry_at
+        await self.session.commit()
         self.mutations += 1
         if self.failure is not None:
             raise self.failure
@@ -212,6 +222,9 @@ async def test_acquisition_persists_before_mutation_and_replays_idempotently(
         )
 
         assert api.mutations == 1
+        assert api.observed_mutation_state == "mutation_pending"
+        assert api.observed_next_retry_at is not None
+        assert api.observed_next_retry_at > datetime.now(UTC)
         assert second.acquisition_id == first.acquisition_id
         acquisition = await session.get(AirDcppAcquisition, first.acquisition_id)
         history = await session.get(DownloadHistory, first.download_history_id)

--- a/tests/unit/test_airdcpp_acquisition.py
+++ b/tests/unit/test_airdcpp_acquisition.py
@@ -124,11 +124,13 @@ class _FakeApi:
         failure: Exception | None = None,
         file_bundle_failure: Exception | None = None,
         adopted: list[AirDcppQueueFile] | None = None,
+        merged: bool = False,
     ) -> None:
         self.session = session
         self.failure = failure
         self.file_bundle_failure = file_bundle_failure
         self.adopted = adopted or []
+        self.merged = merged
         self.mutations = 0
         self.lookups = 0
         self.file_bundle_mutations = 0
@@ -149,7 +151,7 @@ class _FakeApi:
         self.mutations += 1
         if self.failure is not None:
             raise self.failure
-        return AirDcppQueueBundleAddInfo(id=91, merged=False)
+        return AirDcppQueueBundleAddInfo(id=91, merged=self.merged)
 
     async def get_queue_files_by_tth(self, _tth: str) -> list[AirDcppQueueFile]:
         assert self.session.in_transaction() is False
@@ -243,9 +245,15 @@ async def test_acquisition_persists_before_mutation_and_replays_idempotently(
         assert issue.status is IssueStatus.DOWNLOADING
 
 
+@pytest.mark.parametrize(
+    ("merged", "removed_bundles"),
+    [(False, [91]), (True, [])],
+)
 @pytest.mark.asyncio
 async def test_initial_mutation_does_not_resurrect_a_cancelled_download(
     db_factory: async_sessionmaker[AsyncSession],
+    merged: bool,
+    removed_bundles: list[int],
 ) -> None:
     client_id, issue_id = await _seed(db_factory)
 
@@ -273,7 +281,7 @@ async def test_initial_mutation_does_not_resurrect_a_cancelled_download(
             return added
 
     async with db_factory() as session:
-        api = _CancelDuringMutationApi(session)
+        api = _CancelDuringMutationApi(session, merged=merged)
 
         result = await AirDcppQueueAcquisitionService().acquire(
             session,
@@ -288,7 +296,7 @@ async def test_initial_mutation_does_not_resurrect_a_cancelled_download(
 
     assert result.bundle_id is None
     assert result.state is DownloadState.FAILED
-    assert api.removed_bundles == [91]
+    assert api.removed_bundles == removed_bundles
     async with db_factory() as session:
         acquisition = (await session.execute(select(AirDcppAcquisition))).scalar_one()
         history = await session.get(DownloadHistory, acquisition.download_history_id)

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -151,12 +151,14 @@ class _FakeApi:
         pages: list[list[AirDcppQueueBundle]],
         *,
         files: list[AirDcppQueueFile] | None = None,
+        lookup_failure: Exception | None = None,
         retry_result: AirDcppQueueBundleAddInfo | None = None,
         retry_failure: Exception | None = None,
         create_result: AirDcppQueueBundleAddInfo | None = None,
     ) -> None:
         self.pages = pages
         self.files = files or []
+        self.lookup_failure = lookup_failure
         self.retry_result = retry_result or AirDcppQueueBundleAddInfo(id=92, merged=False)
         self.retry_failure = retry_failure
         self.create_result = create_result or AirDcppQueueBundleAddInfo(id=93, merged=False)
@@ -173,6 +175,8 @@ class _FakeApi:
 
     async def get_queue_files_by_tth(self, tth: str):
         self.tth_calls.append(tth)
+        if self.lookup_failure is not None:
+            raise self.lookup_failure
         return self.files
 
     async def search_queue_bundle(self, bundle_id: int) -> None:
@@ -633,3 +637,41 @@ async def test_pre_id_reconciliation_exhaustion_becomes_manually_retryable_failu
         assert acquisition.reconciliation_error == "queue_mutation_failed"
         assert history.state is DownloadState.FAILED
         assert history.next_retry_at is None
+
+
+@pytest.mark.asyncio
+async def test_pre_id_lookup_failure_does_not_consume_mutation_retry_budget(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.retry_count = 2
+        acquisition.max_retries = 3
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+    api = _FakeApi([[]], lookup_failure=AirDcppUnavailableError())
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert api.tth_calls == [_TTH]
+    assert api.retry_calls == []
+    assert api.create_calls == []
+    assert result.changed == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert acquisition.bundle_id is None
+        assert acquisition.client_state == "reconcile_pending"
+        assert acquisition.retry_count == 2
+        assert acquisition.reconciliation_error is None
+        assert history.state is DownloadState.RETRY_PENDING

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -167,6 +167,7 @@ class _FakeApi:
         self.alternate_calls: list[int] = []
         self.retry_calls: list[tuple[int, str, str, int | None]] = []
         self.create_calls: list[tuple[str, int, str, int | None]] = []
+        self.removed_bundles: list[int] = []
 
     async def get_queue_bundles(self, *, start: int, count: int):
         self.calls.append((start, count))
@@ -205,6 +206,9 @@ class _FakeApi:
     ) -> AirDcppQueueBundleAddInfo:
         self.create_calls.append((tth, size, target_name, priority))
         return self.create_result
+
+    async def remove_queue_bundle(self, bundle_id: int) -> None:
+        self.removed_bundles.append(bundle_id)
 
 
 class _FakeCooldown:
@@ -566,6 +570,42 @@ async def test_pre_id_reconciliation_retries_a_due_live_route_mutation(
 
 
 @pytest.mark.asyncio
+async def test_pre_id_reconciliation_does_not_race_an_initial_mutation(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.QUEUED,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.client_state = "mutation_pending"
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = None
+        await session.commit()
+    api = _FakeApi([[]])
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert api.tth_calls == [_TTH]
+    assert api.retry_calls == []
+    assert api.create_calls == []
+    assert result.changed == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert acquisition.bundle_id is None
+        assert acquisition.client_state == "mutation_pending"
+        assert acquisition.retry_count == 0
+        assert history.state is DownloadState.QUEUED
+
+
+@pytest.mark.asyncio
 async def test_pre_id_reconciliation_recreates_an_expired_route_by_exact_tth(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -675,3 +715,64 @@ async def test_pre_id_lookup_failure_does_not_consume_mutation_retry_budget(
         assert acquisition.retry_count == 2
         assert acquisition.reconciliation_error is None
         assert history.state is DownloadState.RETRY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+
+    class _CancelDuringRetryApi(_FakeApi):
+        async def download_search_result(
+            self,
+            instance_id: int,
+            result_id: str,
+            *,
+            target_name: str,
+            priority: int | None,
+        ) -> AirDcppQueueBundleAddInfo:
+            added = await super().download_search_result(
+                instance_id,
+                result_id,
+                target_name=target_name,
+                priority=priority,
+            )
+            async with db_factory() as session:
+                history = await session.get(DownloadHistory, history_id)
+                acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+                assert history is not None and acquisition is not None
+                history.state = DownloadState.FAILED
+                history.error_message = "Cancelled by user"
+                acquisition.client_state = "cancelled"
+                acquisition.next_retry_at = None
+                await session.commit()
+            return added
+
+    api = _CancelDuringRetryApi([[]])
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert api.retry_calls == [(44, "opaque-result", "Example Comic 001 (2026).cbz", None)]
+    assert api.removed_bundles == [92]
+    assert result.changed == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert history.state is DownloadState.FAILED
+        assert history.error_message == "Cancelled by user"
+        assert acquisition.bundle_id is None
+        assert acquisition.client_state == "cancelled"

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -570,6 +570,78 @@ async def test_pre_id_reconciliation_retries_a_due_live_route_mutation(
 
 
 @pytest.mark.asyncio
+async def test_pre_id_recovery_does_not_claim_a_merged_bundle_owned_by_pullbox(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        history = await session.get(DownloadHistory, history_id)
+        assert acquisition is not None and history is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        owner_history = DownloadHistory(
+            issue_id=history.issue_id,
+            download_client_config_id=client_id,
+            title=history.title,
+            download_url="airdcpp://intent/existing-owner",
+            download_client=DownloadClientType.AIRDCPP,
+            protocol=AcquisitionProtocol.DC,
+            external_id=f"airdcpp:{client_id}:bundle:92",
+            state=DownloadState.SENT,
+            file_size=100_000_000,
+            sent_at=datetime.now(UTC),
+        )
+        session.add(owner_history)
+        await session.flush()
+        owner = AirDcppAcquisition(
+            download_history_id=owner_history.id,
+            request_key="existing-owner",
+            client_config_id=client_id,
+            client_identity=f"airdcpp:{client_id}",
+            tth=_TTH,
+            size_bytes=100_000_000,
+            original_name=history.title,
+            bundle_id=92,
+            client_state="queued",
+        )
+        session.add(owner)
+        await session.flush()
+        owner_id = owner.id
+        await session.commit()
+    api = _FakeApi(
+        [[_bundle(bundle_id=92)]],
+        retry_result=AirDcppQueueBundleAddInfo(id=92, merged=True),
+    )
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert result.processed == 2
+    assert api.removed_bundles == []
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        owner = await session.get(AirDcppAcquisition, owner_id)
+        assert history is not None and acquisition is not None and owner is not None
+        assert acquisition.bundle_id is None
+        assert acquisition.client_state == "duplicate"
+        assert acquisition.reconciliation_error == "queue_bundle_already_owned"
+        assert acquisition.route_snapshot["existing_bundle_owner_acquisition_id"] == owner_id
+        assert history.external_id is None
+        assert history.state is DownloadState.FAILED
+        assert history.error_message == (
+            "AirDC++ merged this request into an existing Pullbox download."
+        )
+        assert owner.bundle_id == 92
+
+
+@pytest.mark.asyncio
 async def test_pre_id_reconciliation_does_not_race_an_initial_mutation(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -635,6 +635,55 @@ async def test_manual_retry_claim_is_not_missing_before_its_deadline(
 
 
 @pytest.mark.asyncio
+async def test_expired_manual_retry_claim_does_not_hide_a_committed_replacement(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.client_state = "retry_mutation_pending"
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+
+    class _CommitReplacementDuringSnapshotApi(_FakeApi):
+        async def get_queue_bundles(
+            self,
+            *,
+            start: int,
+            count: int,
+        ) -> list[AirDcppQueueBundle]:
+            async with db_factory() as session:
+                history = await session.get(DownloadHistory, history_id)
+                acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+                assert history is not None and acquisition is not None
+                acquisition.bundle_id = 95
+                acquisition.client_state = "source_search_pending"
+                acquisition.next_retry_at = datetime.now(UTC)
+                history.external_id = f"airdcpp:{client_id}:bundle:95"
+                await session.commit()
+            return await super().get_queue_bundles(start=start, count=count)
+
+    api = _CommitReplacementDuringSnapshotApi([[]])
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert result.changed == 0
+    assert result.missing == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert history.state is DownloadState.RETRY_PENDING
+        assert history.external_id == f"airdcpp:{client_id}:bundle:95"
+        assert acquisition.bundle_id == 95
+        assert acquisition.client_state == "source_search_pending"
+
+
+@pytest.mark.asyncio
 async def test_pre_id_reconciliation_recreates_an_expired_route_by_exact_tth(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -606,6 +606,35 @@ async def test_pre_id_reconciliation_does_not_race_an_initial_mutation(
 
 
 @pytest.mark.asyncio
+async def test_manual_retry_claim_is_not_missing_before_its_deadline(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.client_state = "retry_mutation_pending"
+        acquisition.next_retry_at = datetime.now(UTC) + timedelta(minutes=5)
+        await session.commit()
+    api = _FakeApi([[]])
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert result.changed == 0
+    assert result.missing == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert history.state is DownloadState.RETRY_PENDING
+        assert acquisition.bundle_id == 91
+        assert acquisition.client_state == "retry_mutation_pending"
+
+
+@pytest.mark.asyncio
 async def test_pre_id_reconciliation_recreates_an_expired_route_by_exact_tth(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -776,3 +805,58 @@ async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
         assert history.error_message == "Cancelled by user"
         assert acquisition.bundle_id is None
         assert acquisition.client_state == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_pre_id_recovery_failure_does_not_resurrect_a_cancelled_download(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+
+    class _CancelDuringFailedRetryApi(_FakeApi):
+        async def download_search_result(
+            self,
+            instance_id: int,
+            result_id: str,
+            *,
+            target_name: str,
+            priority: int | None,
+        ) -> AirDcppQueueBundleAddInfo:
+            self.retry_calls.append((instance_id, result_id, target_name, priority))
+            async with db_factory() as session:
+                history = await session.get(DownloadHistory, history_id)
+                acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+                assert history is not None and acquisition is not None
+                history.state = DownloadState.FAILED
+                history.error_message = "Cancelled by user"
+                acquisition.client_state = "cancelled"
+                acquisition.next_retry_at = None
+                await session.commit()
+            raise AirDcppUnavailableError()
+
+    api = _CancelDuringFailedRetryApi([[]])
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert api.retry_calls == [(44, "opaque-result", "Example Comic 001 (2026).cbz", None)]
+    assert result.changed == 0
+    async with db_factory() as session:
+        history = await session.get(DownloadHistory, history_id)
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert history is not None and acquisition is not None
+        assert history.state is DownloadState.FAILED
+        assert history.error_message == "Cancelled by user"
+        assert acquisition.client_state == "cancelled"
+        assert acquisition.retry_count == 0

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -938,6 +938,97 @@ async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
 
 
 @pytest.mark.asyncio
+async def test_stale_recovery_does_not_delete_a_bundle_adopted_by_another_acquisition(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+
+    class _AdoptDuringCancelledRetryApi(_FakeApi):
+        async def download_search_result(
+            self,
+            instance_id: int,
+            result_id: str,
+            *,
+            target_name: str,
+            priority: int | None,
+        ) -> AirDcppQueueBundleAddInfo:
+            added = await super().download_search_result(
+                instance_id,
+                result_id,
+                target_name=target_name,
+                priority=priority,
+            )
+            async with db_factory() as session:
+                history = await session.get(DownloadHistory, history_id)
+                acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+                assert history is not None and acquisition is not None
+                history.state = DownloadState.FAILED
+                history.error_message = "Cancelled by user"
+                acquisition.client_state = "cancelled"
+                acquisition.next_retry_at = None
+                owner_history = DownloadHistory(
+                    issue_id=history.issue_id,
+                    download_client_config_id=client_id,
+                    title=history.title,
+                    download_url="airdcpp://intent/adopted-owner",
+                    download_client=DownloadClientType.AIRDCPP,
+                    protocol=AcquisitionProtocol.DC,
+                    external_id=f"airdcpp:{client_id}:bundle:{added.id}",
+                    state=DownloadState.SENT,
+                    file_size=100_000_000,
+                    sent_at=datetime.now(UTC),
+                )
+                session.add(owner_history)
+                await session.flush()
+                session.add(
+                    AirDcppAcquisition(
+                        download_history_id=owner_history.id,
+                        request_key="adopted-owner",
+                        client_config_id=client_id,
+                        client_identity=f"airdcpp:{client_id}",
+                        tth=_TTH,
+                        size_bytes=100_000_000,
+                        original_name=history.title,
+                        bundle_id=added.id,
+                        client_state="queued",
+                    )
+                )
+                await session.commit()
+            return added
+
+    api = _AdoptDuringCancelledRetryApi(
+        [[]],
+        retry_result=AirDcppQueueBundleAddInfo(id=92, merged=False),
+    )
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert result.changed == 0
+    assert api.removed_bundles == []
+    async with db_factory() as session:
+        owner = await session.scalar(
+            select(AirDcppAcquisition).where(
+                AirDcppAcquisition.client_identity == f"airdcpp:{client_id}",
+                AirDcppAcquisition.bundle_id == 92,
+            )
+        )
+        assert owner is not None
+        assert owner.id != acquisition_id
+
+
+@pytest.mark.asyncio
 async def test_pre_id_recovery_failure_does_not_resurrect_a_cancelled_download(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -795,9 +795,15 @@ async def test_pre_id_lookup_failure_does_not_consume_mutation_retry_budget(
         assert history.state is DownloadState.RETRY_PENDING
 
 
+@pytest.mark.parametrize(
+    ("merged", "expected_removed_bundles"),
+    [(False, [92]), (True, [])],
+)
 @pytest.mark.asyncio
 async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
     db_factory: async_sessionmaker[AsyncSession],
+    merged: bool,
+    expected_removed_bundles: list[int],
 ) -> None:
     client_id, history_id, acquisition_id = await _seed(
         db_factory,
@@ -839,12 +845,15 @@ async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
                 await session.commit()
             return added
 
-    api = _CancelDuringRetryApi([[]])
+    api = _CancelDuringRetryApi(
+        [[]],
+        retry_result=AirDcppQueueBundleAddInfo(id=92, merged=merged),
+    )
 
     result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
 
     assert api.retry_calls == [(44, "opaque-result", "Example Comic 001 (2026).cbz", None)]
-    assert api.removed_bundles == [92]
+    assert api.removed_bundles == expected_removed_bundles
     assert result.changed == 0
     async with db_factory() as session:
         history = await session.get(DownloadHistory, history_id)


### PR DESCRIPTION
## Summary
- Publishes the reviewed AirDC++ acquisition recovery fixes merged through `develop`.
- Keeps cancellation, retries, merged queue bundles, and duplicate ownership race-safe.
- Promotes the application version from `1.2.1-dev` to `1.2.1` with curated release notes.

## Validation
- `make release-changelog-check VERSION=1.2.1`
- `git diff --check`
- Release commit hooks: Ruff, Ruff format, mypy, and fast unit tests
- Full required CI, Security, Workflow Hygiene, and Docker validation passed on PR #126 for the runtime changes

## Release
- After this PR merges, create and verify signed tag `v1.2.1` from the merge commit.
- The tag-only release workflows publish, scan, smoke-test, sign, and verify GHCR and Docker Hub images before creating the GitHub Release.
