### PR TITLE
Sync develop after v1.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-08-28
+
+Patch release hardening AirDC++ acquisition recovery so retries, cancellation,
+and merged queue bundles remain race-safe.
+
 ### Fixed
 
 - Kept transient AirDC++ queue lookup failures from consuming the bounded queue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and merged queue bundles remain race-safe.
 - Claimed missing AirDC++ bundle retries atomically, bound completion to the
   exact claim, preserved remote bundles merged with existing queue work, and
   prevented duplicate intents from taking ownership of the same bundle.
+- Rechecked AirDC++ bundle ownership immediately before stale recovery cleanup
+  so cancellation cannot delete a bundle adopted by another Pullbox download.
 
 ## [1.2.0] - 2026-08-28
 

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.2.1-dev"
+__version__ = "1.2.1"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/__init__.py
+++ b/src/pullbox/__init__.py
@@ -2,7 +2,7 @@
 
 from datetime import UTC, datetime
 
-__version__ = "1.2.1"
+__version__ = "1.2.2-dev"
 
 # Set once at process start; used by System > About for uptime calculation.
 STARTED_AT: datetime = datetime.now(UTC)

--- a/src/pullbox/services/airdcpp_reconciliation.py
+++ b/src/pullbox/services/airdcpp_reconciliation.py
@@ -203,7 +203,7 @@ class AirDcppReconciler:
         adopted: dict[int, AirDcppQueueFile] = {}
         recovered: dict[int, _RecoveredMutation] = {}
         retry_failures: dict[int, str] = {}
-        stale_recovered_bundle_ids: set[int] = set()
+        stale_recovered_bundles: set[tuple[str, int]] = set()
         pre_id = [snapshot for snapshot in snapshots if snapshot.bundle_id is None]
         now = datetime.now(UTC)
         for snapshot in pre_id[:_MAX_PRE_ID_LOOKUPS]:
@@ -351,7 +351,9 @@ class AirDcppReconciler:
                                 )
                             )
                     elif _stale_recovery_requires_cleanup(acquisition, recovered_mutation):
-                        stale_recovered_bundle_ids.add(recovered_mutation.bundle_id)
+                        stale_recovered_bundles.add(
+                            (snapshot.client_identity, recovered_mutation.bundle_id)
+                        )
                 elif snapshot.acquisition_id in retry_failures:
                     if _active_snapshot_is_current(acquisition, snapshot):
                         changed += int(
@@ -376,7 +378,23 @@ class AirDcppReconciler:
                 )
             await session.commit()
 
-        for bundle_id in stale_recovered_bundle_ids:
+        for client_identity, bundle_id in stale_recovered_bundles:
+            async with self._session_factory() as session:
+                owner_id = await session.scalar(
+                    select(AirDcppAcquisition.id)
+                    .where(
+                        AirDcppAcquisition.client_identity == client_identity,
+                        AirDcppAcquisition.bundle_id == bundle_id,
+                    )
+                    .limit(1)
+                )
+            if owner_id is not None:
+                logger.info(
+                    "airdcpp_stale_recovery_cleanup_skipped_owned_bundle",
+                    bundle_id=bundle_id,
+                    owner_acquisition_id=owner_id,
+                )
+                continue
             try:
                 await api_client.remove_queue_bundle(bundle_id)
             except AirDcppEntityNotFoundError:

--- a/tests/unit/test_airdcpp_reconciliation.py
+++ b/tests/unit/test_airdcpp_reconciliation.py
@@ -938,6 +938,97 @@ async def test_pre_id_recovery_does_not_resurrect_a_cancelled_download(
 
 
 @pytest.mark.asyncio
+async def test_stale_recovery_does_not_delete_a_bundle_adopted_by_another_acquisition(
+    db_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    client_id, history_id, acquisition_id = await _seed(
+        db_factory,
+        state=DownloadState.RETRY_PENDING,
+        bundle_id=None,
+    )
+    async with db_factory() as session:
+        acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+        assert acquisition is not None
+        acquisition.search_instance_id = 44
+        acquisition.grouped_result_id = "opaque-result"
+        acquisition.result_expires_at = datetime.now(UTC) + timedelta(minutes=1)
+        acquisition.next_retry_at = datetime.now(UTC) - timedelta(seconds=1)
+        await session.commit()
+
+    class _AdoptDuringCancelledRetryApi(_FakeApi):
+        async def download_search_result(
+            self,
+            instance_id: int,
+            result_id: str,
+            *,
+            target_name: str,
+            priority: int | None,
+        ) -> AirDcppQueueBundleAddInfo:
+            added = await super().download_search_result(
+                instance_id,
+                result_id,
+                target_name=target_name,
+                priority=priority,
+            )
+            async with db_factory() as session:
+                history = await session.get(DownloadHistory, history_id)
+                acquisition = await session.get(AirDcppAcquisition, acquisition_id)
+                assert history is not None and acquisition is not None
+                history.state = DownloadState.FAILED
+                history.error_message = "Cancelled by user"
+                acquisition.client_state = "cancelled"
+                acquisition.next_retry_at = None
+                owner_history = DownloadHistory(
+                    issue_id=history.issue_id,
+                    download_client_config_id=client_id,
+                    title=history.title,
+                    download_url="airdcpp://intent/adopted-owner",
+                    download_client=DownloadClientType.AIRDCPP,
+                    protocol=AcquisitionProtocol.DC,
+                    external_id=f"airdcpp:{client_id}:bundle:{added.id}",
+                    state=DownloadState.SENT,
+                    file_size=100_000_000,
+                    sent_at=datetime.now(UTC),
+                )
+                session.add(owner_history)
+                await session.flush()
+                session.add(
+                    AirDcppAcquisition(
+                        download_history_id=owner_history.id,
+                        request_key="adopted-owner",
+                        client_config_id=client_id,
+                        client_identity=f"airdcpp:{client_id}",
+                        tth=_TTH,
+                        size_bytes=100_000_000,
+                        original_name=history.title,
+                        bundle_id=added.id,
+                        client_state="queued",
+                    )
+                )
+                await session.commit()
+            return added
+
+    api = _AdoptDuringCancelledRetryApi(
+        [[]],
+        retry_result=AirDcppQueueBundleAddInfo(id=92, merged=False),
+    )
+
+    result = await AirDcppReconciler(db_factory).reconcile_client(client_id, api)
+
+    assert result.changed == 0
+    assert api.removed_bundles == []
+    async with db_factory() as session:
+        owner = await session.scalar(
+            select(AirDcppAcquisition).where(
+                AirDcppAcquisition.client_identity == f"airdcpp:{client_id}",
+                AirDcppAcquisition.bundle_id == 92,
+            )
+        )
+        assert owner is not None
+        assert owner.id != acquisition_id
+
+
+@pytest.mark.asyncio
 async def test_pre_id_recovery_failure_does_not_resurrect_a_cancelled_download(
     db_factory: async_sessionmaker[AsyncSession],
 ) -> None:


### PR DESCRIPTION
## Summary
- Syncs the released `v1.2.1` mainline and its final AirDC++ ownership fix back into `develop`.
- Reopens development at `1.2.2-dev`.

## Validation
- Signed `v1.2.1` release tag verified locally.
- Docker Release and GitHub Release workflows completed successfully.
- GHCR and Docker Hub manifests share the published digest and both Cosign signatures verify.
- Sync commit hooks passed Ruff, Ruff format, mypy, and fast unit tests.

## Sync Contract
- Branch is based on `origin/main`.
- The only change after `origin/main` is `src/pullbox/__init__.py` from `1.2.1` to `1.2.2-dev`.
- This PR intentionally uses the narrow post-release sync checks rather than `ci:full`.
